### PR TITLE
style(geometry): apply fprettify formatting

### DIFF
--- a/src/Model/Geometry/BaseGeometry.f90
+++ b/src/Model/Geometry/BaseGeometry.f90
@@ -1,13 +1,13 @@
 module BaseGeometryModule
-  
+
   use KindModule, only: DP, I4B
-  
+
   implicit none
   private
   public BaseGeometryType
-  
+
   integer(I4B), parameter :: GEONAMELEN = 20
-  
+
   type :: BaseGeometryType
     character(len=20) :: geo_type = 'UNDEFINED'
     integer(I4B) :: id = 0
@@ -21,8 +21,8 @@ module BaseGeometryModule
     procedure :: print_attributes
   end type BaseGeometryType
 
-  contains
-  
+contains
+
   function area_sat(this)
     ! -- return
     real(DP) :: area_sat
@@ -32,8 +32,8 @@ module BaseGeometryModule
     ! -- return
     return
   end function area_sat
-  
- function perimeter_sat(this)
+
+  function perimeter_sat(this)
     ! -- return
     real(DP) :: perimeter_sat
     ! -- dummy
@@ -42,29 +42,29 @@ module BaseGeometryModule
     ! -- return
     return
   end function perimeter_sat
-  
+
   function area_wet(this, depth)
     ! -- return
     real(DP) :: area_wet
     ! -- dummy
     class(BaseGeometryType) :: this
-    real(DP), intent(in) :: depth    
+    real(DP), intent(in) :: depth
     area_wet = 0.d0
     ! -- return
     return
   end function area_wet
-  
+
   function perimeter_wet(this, depth)
     ! -- return
     real(DP) :: perimeter_wet
     ! -- dummy
     class(BaseGeometryType) :: this
-    real(DP), intent(in) :: depth    
+    real(DP), intent(in) :: depth
     perimeter_wet = 0.d0
     ! -- return
     return
   end function perimeter_wet
-  
+
   subroutine set_attribute(this, line)
     ! -- dummy
     class(BaseGeometryType) :: this
@@ -72,7 +72,7 @@ module BaseGeometryModule
     ! -- return
     return
   end subroutine set_attribute
-  
+
   subroutine print_attributes(this, iout)
 ! ******************************************************************************
 ! print_attributes -- print the attributes for this object
@@ -89,13 +89,12 @@ module BaseGeometryModule
     character(len=*), parameter :: fmtnm = "(4x,a,a)"
 ! ------------------------------------------------------------------------------
     !
-    write(iout, fmtid) 'ID = ', this%id
-    write(iout, fmtnm) 'NAME = ', trim(adjustl(this%name))
-    write(iout, fmtnm) 'GEOMETRY TYPE = ', trim(adjustl(this%geo_type))
+    write (iout, fmtid) 'ID = ', this%id
+    write (iout, fmtnm) 'NAME = ', trim(adjustl(this%name))
+    write (iout, fmtnm) 'GEOMETRY TYPE = ', trim(adjustl(this%geo_type))
     !
     ! -- return
     return
   end subroutine print_attributes
-  
-  
+
 end module BaseGeometryModule

--- a/src/Model/Geometry/CircularGeometry.f90
+++ b/src/Model/Geometry/CircularGeometry.f90
@@ -7,7 +7,7 @@ module CircularGeometryModule
 
   private
   public :: CircularGeometryType
-  
+
   type, extends(BaseGeometryType) :: CircularGeometryType
     real(DP) :: radius = DZERO
   contains
@@ -18,9 +18,9 @@ module CircularGeometryModule
     procedure :: set_attribute
     procedure :: print_attributes
   end type CircularGeometryType
-  
-  contains
-  
+
+contains
+
   function area_sat(this)
 ! ******************************************************************************
 ! area_sat -- return area as if geometry is fully saturated
@@ -37,12 +37,12 @@ module CircularGeometryModule
 ! ------------------------------------------------------------------------------
     !
     ! -- Calculate area
-    area_sat = DPI * this%radius ** DTWO
+    area_sat = DPI * this%radius**DTWO
     !
     ! -- Return
     return
   end function area_sat
-  
+
   function perimeter_sat(this)
 ! ******************************************************************************
 ! perimeter_sat -- return perimeter as if geometry is fully saturated
@@ -64,7 +64,7 @@ module CircularGeometryModule
     ! -- return
     return
   end function perimeter_sat
-  
+
   function area_wet(this, depth)
 ! ******************************************************************************
 ! area_wet -- return wetted area
@@ -82,25 +82,26 @@ module CircularGeometryModule
 ! ------------------------------------------------------------------------------
     !
     ! -- Calculate area
-    if(depth <= DZERO) then
-      area_wet = DZERO      
-    elseif(depth <= this%radius) then
-      area_wet = this%radius * this%radius *                                   &
-                 acos((this%radius - depth) / this%radius) -                   &
-                 (this%radius - depth) * sqrt(this%radius * this%radius -      &
-                 (this%radius - depth) ** DTWO)
-    elseif(depth <= DTWO * this%radius) then
-      area_wet = this%radius * this%radius * (DPI - acos((depth - this%radius) &
-                 / this%radius)) - (this%radius - depth) * sqrt(this%radius *  &
-                 this%radius - (this%radius - depth) ** DTWO)
+    if (depth <= DZERO) then
+      area_wet = DZERO
+    elseif (depth <= this%radius) then
+      area_wet = this%radius * this%radius * &
+                 acos((this%radius - depth) / this%radius) - &
+                 (this%radius - depth) * &
+                 sqrt(this%radius * this%radius - (this%radius - depth)**DTWO)
+    elseif (depth <= DTWO * this%radius) then
+      area_wet = this%radius * this%radius * &
+                 (DPI - acos((depth - this%radius) / this%radius)) - &
+                 (this%radius - depth) * &
+                 sqrt(this%radius * this%radius - (this%radius - depth)**DTWO)
     else
       area_wet = DPI * this%radius * this%radius
-    endif
+    end if
     !
     ! -- Return
     return
   end function area_wet
-  
+
   function perimeter_wet(this, depth)
 ! ******************************************************************************
 ! perimeter_wet -- return wetted perimeter
@@ -118,22 +119,22 @@ module CircularGeometryModule
 ! ------------------------------------------------------------------------------
     !
     ! -- Calculate area
-    if(depth <= DZERO) then
-      perimeter_wet = DZERO      
-    elseif(depth <= this%radius) then
-      perimeter_wet = DTWO * this%radius * acos((this%radius - depth) /        &
-                      this%radius)
-    elseif(depth <= DTWO * this%radius) then
+    if (depth <= DZERO) then
+      perimeter_wet = DZERO
+    elseif (depth <= this%radius) then
+      perimeter_wet = DTWO * this%radius * acos((this%radius - depth) / &
+                                                this%radius)
+    elseif (depth <= DTWO * this%radius) then
       perimeter_wet = DTWO * this%radius * (DPI - acos((depth - this%radius) / &
-                      this%radius))
+                                                       this%radius))
     else
       perimeter_wet = DTWO * DPI * this%radius
-    endif
+    end if
     !
     ! -- return
     return
   end function perimeter_wet
-  
+
   subroutine set_attribute(this, line)
 ! ******************************************************************************
 ! set_attribute -- set a parameter for this circular object
@@ -153,23 +154,23 @@ module CircularGeometryModule
     integer(I4B) :: lloc, istart, istop, ival
     real(DP) :: rval
 ! ------------------------------------------------------------------------------
-    !    
+    !
     ! -- should change this and set id if uninitialized or store it
-    lloc=1
+    lloc = 1
     call urword(line, lloc, istart, istop, 2, ival, rval, 0, 0)
     this%id = ival
-    
+
     ! -- Parse the attribute
     call urword(line, lloc, istart, istop, 1, ival, rval, 0, 0)
-    select case(line(istart:istop))
-    case('NAME')
+    select case (line(istart:istop))
+    case ('NAME')
       call urword(line, lloc, istart, istop, 1, ival, rval, 0, 0)
       this%name = line(istart:istop)
-    case('RADIUS')
+    case ('RADIUS')
       call urword(line, lloc, istart, istop, 3, ival, rval, 0, 0)
-      this%radius = rval      
+      this%radius = rval
     case default
-      write(errmsg,'(4x,a,a)') &
+      write (errmsg, '(4x,a,a)') &
         'Unknown circular geometry attribute: ', line(istart:istop)
       call store_error(errmsg, terminate=.TRUE.)
     end select
@@ -198,12 +199,12 @@ module CircularGeometryModule
     call this%BaseGeometryType%print_attributes(iout)
     !
     ! -- Print specifics of this geometry type
-    write(iout, fmttd) 'RADIUS = ', this%radius
-    write(iout, fmttd) 'SATURATED AREA = ', this%area_sat()
-    write(iout, fmttd) 'SATURATED WETTED PERIMETER = ', this%perimeter_sat()
+    write (iout, fmttd) 'RADIUS = ', this%radius
+    write (iout, fmttd) 'SATURATED AREA = ', this%area_sat()
+    write (iout, fmttd) 'SATURATED WETTED PERIMETER = ', this%perimeter_sat()
     !
     ! -- return
     return
   end subroutine print_attributes
-  
+
 end module CircularGeometryModule

--- a/src/Model/Geometry/RectangularGeometry.f90
+++ b/src/Model/Geometry/RectangularGeometry.f90
@@ -5,10 +5,10 @@ module RectangularGeometryModule
   implicit none
   private
   public :: RectangularGeometryType
-  
+
   type, extends(BaseGeometryType) :: RectangularGeometryType
     real(DP) :: height = DZERO
-    real(DP) :: width  = DZERO
+    real(DP) :: width = DZERO
   contains
     procedure :: area_sat
     procedure :: perimeter_sat
@@ -17,9 +17,9 @@ module RectangularGeometryModule
     procedure :: set_attribute
     procedure :: print_attributes
   end type RectangularGeometryType
-  
-  contains
-  
+
+contains
+
   function area_sat(this)
 ! ******************************************************************************
 ! area_sat -- return saturated area
@@ -41,7 +41,7 @@ module RectangularGeometryModule
     ! -- Return
     return
   end function area_sat
-  
+
   function perimeter_sat(this)
 ! ******************************************************************************
 ! perimeter_sat -- return saturated perimeter
@@ -63,7 +63,7 @@ module RectangularGeometryModule
     ! -- return
     return
   end function perimeter_sat
-  
+
   function area_wet(this, depth)
 ! ******************************************************************************
 ! area_wet -- return wetted area
@@ -81,18 +81,18 @@ module RectangularGeometryModule
 ! ------------------------------------------------------------------------------
     !
     ! -- Calculate area
-    if(depth <= DZERO) then
-      area_wet = DZERO      
-    elseif(depth <= this%height) then
+    if (depth <= DZERO) then
+      area_wet = DZERO
+    elseif (depth <= this%height) then
       area_wet = depth * this%width
     else
       area_wet = this%width * this%height
-    endif
+    end if
     !
     ! -- Return
     return
   end function area_wet
-  
+
   function perimeter_wet(this, depth)
 ! ******************************************************************************
 ! perimeter_wet -- return wetted perimeter
@@ -110,18 +110,18 @@ module RectangularGeometryModule
 ! ------------------------------------------------------------------------------
     !
     ! -- Calculate area
-    if(depth <= DZERO) then
-      perimeter_wet = DZERO      
-    elseif(depth <= this%height) then
+    if (depth <= DZERO) then
+      perimeter_wet = DZERO
+    elseif (depth <= this%height) then
       perimeter_wet = DTWO * (depth + this%width)
     else
       perimeter_wet = DTWO * (this%height + this%width)
-    endif
+    end if
     !
     ! -- return
     return
   end function perimeter_wet
-  
+
   subroutine set_attribute(this, line)
 ! ******************************************************************************
 ! set_attribute -- set a parameter for this rectangular object
@@ -141,26 +141,26 @@ module RectangularGeometryModule
     integer(I4B) :: lloc, istart, istop, ival
     real(DP) :: rval
 ! ------------------------------------------------------------------------------
-    !    
+    !
     ! -- should change this and set id if uninitialized or store it
-    lloc=1
+    lloc = 1
     call urword(line, lloc, istart, istop, 2, ival, rval, 0, 0)
     this%id = ival
-    
+
     ! -- Parse the attribute
     call urword(line, lloc, istart, istop, 1, ival, rval, 0, 0)
-    select case(line(istart:istop))
-    case('NAME')
+    select case (line(istart:istop))
+    case ('NAME')
       call urword(line, lloc, istart, istop, 1, ival, rval, 0, 0)
       this%name = line(istart:istop)
-    case('HEIGHT')
+    case ('HEIGHT')
       call urword(line, lloc, istart, istop, 3, ival, rval, 0, 0)
-      this%height = rval      
-    case('WIDTH')
+      this%height = rval
+    case ('WIDTH')
       call urword(line, lloc, istart, istop, 3, ival, rval, 0, 0)
-      this%width = rval      
+      this%width = rval
     case default
-      write(errmsg,'(4x,a,a)') &
+      write (errmsg, '(4x,a,a)') &
         'Unknown rectangular geometry attribute: ', line(istart:istop)
       call store_error(errmsg, terminate=.TRUE.)
     end select
@@ -189,13 +189,13 @@ module RectangularGeometryModule
     call this%BaseGeometryType%print_attributes(iout)
     !
     ! -- Print specifics of this geometry type
-    write(iout, fmttd) 'HEIGHT = ', this%height
-    write(iout, fmttd) 'WIDTH = ', this%width
-    write(iout, fmttd) 'SATURATED AREA = ', this%area_sat()
-    write(iout, fmttd) 'SATURATED WETTED PERIMETER = ', this%perimeter_sat()
+    write (iout, fmttd) 'HEIGHT = ', this%height
+    write (iout, fmttd) 'WIDTH = ', this%width
+    write (iout, fmttd) 'SATURATED AREA = ', this%area_sat()
+    write (iout, fmttd) 'SATURATED WETTED PERIMETER = ', this%perimeter_sat()
     !
     ! -- return
     return
   end subroutine print_attributes
-  
+
 end module RectangularGeometryModule


### PR DESCRIPTION
* working toward consistent code formatting

Note:  the formatting tool does not offer a way to configure whitespace surrounding the exponent operator.  The default is no whitespace as in CircularGeometry.f90.