### PR TITLE
fix(distribution): miscellaneous

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
     paths-ignore:
       - '**.md'
       - 'doc/**'
-      - '.github/workflows/release.yml'
   pull_request:
     branches:
       - master
@@ -16,7 +15,6 @@ on:
     paths-ignore:
       - '**.md'
       - 'doc/**'
-      - '.github/workflows/release.yml'
 jobs:
   lint:
     name: Lint (fprettify)
@@ -36,8 +34,7 @@ jobs:
           cache-env: true
 
       - name: Check Fortran source formatting
-        run: |
-          .github/common/fortran-format-check.sh
+        run: .github/common/fortran-format-check.sh
 
   build:
     name: Build (gfortran 12)
@@ -66,16 +63,13 @@ jobs:
           cache-env: true
 
       - name: Meson setup
-        run: |
-          meson setup builddir -Ddebug=false -Dwerror=true
+        run: meson setup builddir -Ddebug=false -Dwerror=true
 
       - name: Meson compile
-        run: |
-          meson compile -C builddir
+        run: meson compile -C builddir
 
       - name: Meson test
-        run: |
-          meson test --verbose --no-rebuild -C builddir
+        run: meson test --verbose --no-rebuild -C builddir
 
   test_gfortran_latest:
     name: Test (gfortran 12)
@@ -140,9 +134,7 @@ jobs:
       - name: Build example models
         if: steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc
-        run: |
-          python ci_build_files.py
-          ls -lh ../examples/
+        run: python ci_build_files.py
 
       - name: Build modflow6
         working-directory: modflow6
@@ -161,7 +153,12 @@ jobs:
 
       - name: Test programs
         working-directory: modflow6/autotest
-        run: pytest -v -n auto --durations 0
+        run: |
+          if [ "${{ github.ref_name }}" == "master" ]; then
+            pytest -v -n auto --durations 0 -m "not developmode"
+          else
+            pytest -v -n auto --durations 0
+          fi
 
       - name: Test scripts
         working-directory: modflow6/distribution
@@ -213,8 +210,7 @@ jobs:
 
       - name: Update flopy
         working-directory: modflow6/autotest
-        run: |
-          python update_flopy.py
+        run: python update_flopy.py
 
       - name: Build modflow6
         working-directory: modflow6
@@ -225,13 +221,16 @@ jobs:
       
       - name: Get executables
         working-directory: modflow6/autotest
-        run: |
-          pytest -v --durations 0 get_exes.py
+        run: pytest -v --durations 0 get_exes.py
 
       - name: Test modflow6
         working-directory: modflow6/autotest
         run: |
-          pytest -v -n auto --durations 0
+          if [ "${{ github.ref_name }}" == "master" ]; then
+            pytest -v -n auto --durations 0 -m "not developmode"
+          else
+            pytest -v -n auto --durations 0
+          fi
 
   test_ifort:
     name: Test (ifort)
@@ -293,15 +292,12 @@ jobs:
       - name: Install extra Python packages
         if: steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc
-        run: |
-          pip install -r requirements.pip.txt
+        run: pip install -r requirements.pip.txt
 
       - name: Build example models
         if: steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc
-        run: |
-          python ci_build_files.py
-          ls -lh ../examples/
+        run: python ci_build_files.py
 
       - name: Update version files
         working-directory: modflow6/distribution
@@ -326,42 +322,46 @@ jobs:
 
       - name: Update flopy
         working-directory: modflow6/autotest
-        run: |
-          python update_flopy.py
+        run: python update_flopy.py
 
       - name: Get executables
         if: runner.os != 'Windows'
         working-directory: modflow6/autotest
-        run: |
-          pytest -v --durations 0 get_exes.py
+        run: pytest -v --durations 0 get_exes.py
           
       - name: Get executables (Windows)
         if: runner.os == 'Windows'
         working-directory: modflow6/autotest
         shell: pwsh
-        run: |
-          pytest -v --durations 0 get_exes.py
+        run: pytest -v --durations 0 get_exes.py
 
       - name: Test programs
         if: runner.os != 'Windows'
         working-directory: modflow6/autotest
         run: |
-          pytest -v -n auto --durations 0
+          if [ "${{ github.ref_name }}" == "master" ]; then
+            pytest -v -n auto --durations 0 -m "not developmode"
+          else
+            pytest -v -n auto --durations 0
+          fi
 
       - name: Test programs (Windows)
         if: runner.os == 'Windows'
         working-directory: modflow6/autotest
         shell: pwsh
         run: |
-          pytest -v -n auto --durations 0
+          if ( "${{ github.ref_name }}" -eq "master" ) {
+            pytest -v -n auto --durations 0 -m "not developmode"
+          } else {
+            pytest -v -n auto --durations 0
+          }
 
       - name: Test scripts
         if: runner.os != 'Windows'
         working-directory: modflow6/distribution
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          pytest -v --durations 0
+        run: pytest -v --durations 0
 
       - name: Test scripts (Windows)
         if: runner.os == 'Windows'
@@ -369,5 +369,4 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          pytest -v --durations 0
+        run: pytest -v --durations 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,12 +226,8 @@ jobs:
             python update_version.py -v "${ver#"v"}" --approve
           fi
           
-          # set dist name, format is 'mf<major.minor.patch>_<ostag>'
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            distname="mf${ref#"v"}"
-          else
-            distname="mf${ref#"v"}_${{ matrix.ostag }}"
-          fi
+          # set dist name, format is 'mf<major.minor.patch>' for docs (no os tag)
+          distname="mf${ref#"v"}"
           echo "DISTNAME=$distname" >> $GITHUB_ENV
 
       - name: Create directory structure
@@ -486,7 +482,9 @@ jobs:
           body='
           # MODFLOW '$ver' release
           
-          This release can be approved by merging this PR into `master`. Doing so triggers a final job, to: 
+          The release can be approved by merging this PR into `master`. Merging rather than squashing is necessary to preserve the commit history.
+          
+          When this PR is merged, a final job will be triggered to:
           1) create and tag a draft GitHub release, then upload assets (OS distributions and release notes)
           2) open a PR to update `develop` from `master`, resetting version files and setting `IDEVELOPMODE=1`
           '
@@ -593,7 +591,6 @@ jobs:
           body='
           # Reinitialize for development
 
-          Updates the `develop` branch from `master` following a successful release.
-          Increments the minor version number and resets `IDEVELOPMODE` back to `1`.
+          Updates the `develop` branch from `master` following a successful release. Increments the minor version number and resets `IDEVELOPMODE` back to `1`.
           '
           gh pr create -B "develop" -H "$reset_branch" --title "Reinitialize develop branch" --draft --body "$body"

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -325,6 +325,7 @@ def build_distribution(
         bin_path=output_path / "bin",
         overwrite=overwrite)
 
+    # full releases include examples, source code, makefiles and docs
     if not development:
         # examples
         setup_examples(
@@ -332,22 +333,20 @@ def build_distribution(
             examples_path=output_path / "examples",
             overwrite=overwrite)
 
-    # docs
-    build_documentation(
-        bin_path=output_path / "bin",
-        output_path=output_path / "doc",
-        examples_repo_path=examples_repo_path,
-        # benchmarks_path=_benchmarks_path / "run-time-comparison.md",
-        development=development,
-        overwrite=overwrite)
-
-    # full releases include source code and makefiles
-    if not development:
         # copy source code files
         copy_sources(output_path=output_path)
 
         # build and copy makefiles
         build_makefiles(output_path=output_path)
+
+        # docs
+        build_documentation(
+            bin_path=output_path / "bin",
+            output_path=output_path / "doc",
+            examples_repo_path=examples_repo_path,
+            # benchmarks_path=_benchmarks_path / "run-time-comparison.md",
+            development=development,
+            overwrite=overwrite)
 
 
 @requires_exe("pdflatex")


### PR DESCRIPTION
Fix CI issues in release workflow unearthed by 6.4.1
- tests needing develop mode need to be skipped on `master` CI to prevent [failures](https://github.com/MODFLOW-USGS/modflow6/actions/runs/3660648208)
- clarify in the draft PR autocreated for full releases that merging to `master` is needed to keep commit history (not squashing)
- don't build docs when `build_dist.py` is run with `--development` flag &mdash; docs are not included in the nightly build archive ([this PR in the nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build/pull/21) depends on this)
- in the full release docs, the dist folder name had a trailing `_` due to trying to use a matrix variable in a Linux-only job &mdash; the dist folder name should just be `mf6.X.Y` in the docs