### PR TITLE
ci(benchmarks): benchmark all 3 platforms, refactor dist scripts

### DIFF
--- a/.build_rtd_docs/conf.py
+++ b/.build_rtd_docs/conf.py
@@ -7,6 +7,7 @@
 # -- Path setup --------------------------------------------------------------
 
 import os
+from pathlib import Path
 import shutil
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -42,19 +43,20 @@ update_version()
 # -- import version from doc/version.py -------------------------------------
 from version import __version__
 
-# -- copy run-time comparison markdown --------------------------------------
-print("Copy the run-time comparison table")
+# -- copy run-time comparison tables ----------------------------------------
+print("Copy run-time comparison tables")
 dstdir = "_mf6run"
-fpth = "run-time-comparison.md"
-src = os.path.join("..", "distribution", fpth)
-dst = os.path.join(dstdir, fpth)
+src = Path(os.path.join("..", "distribution", ".benchmarks")) 
+srcs = list(src.glob("run-time-comparison*"))
 # clean up an existing _mf6run directory
 if os.path.isdir(dstdir):
     shutil.rmtree(dstdir)
 # make the _mf6run directory
 os.makedirs(dstdir)
-# copy the file
-shutil.copy(src, dst)
+# copy the files
+for f in srcs:
+    dst = os.path.join(dstdir, f.name)
+    shutil.copy(f, dst)
 
 # -- build the mf6io markdown files -----------------------------------------
 print("Build the mf6io markdown files")

--- a/.build_rtd_docs/index.rst
+++ b/.build_rtd_docs/index.rst
@@ -13,5 +13,5 @@ Contents:
 
    MODFLOW 6 Source Code Documentation <https://modflow-usgs.github.io/modflow6/>
    mf6io
-   _mf6run/run-time-comparison.md
+   _mf6run/run-time-comparison*.md
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,16 +14,25 @@ on:
     paths-ignore:
       - '.github/workflows/release.yml'
 jobs:
-  rtd_build:
-    name: Build ReadTheDocs
-    runs-on: ubuntu-22.04
+  benchmark:
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -l {0}
-    env:
-      GCC_V: 12
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: ubuntu-22.04, compiler_toolchain: gcc, compiler_version: 13}
+          - {os: macos-12, compiler_toolchain: gcc, compiler_version: 13}
+          - {os: windows-2022, compiler_toolchain: gcc, compiler_version: 12}
+          - {os: ubuntu-22.04, compiler_toolchain: intel, compiler_version: 2022.2}
+          - {os: windows-2022, compiler_toolchain: intel, compiler_version: 2022.2}
+          - {os: ubuntu-22.04, compiler_toolchain: intel-classic, compiler_version: 2021.7.0}
+          - {os: macos-12, compiler_toolchain: intel-classic, compiler_version: 2021.7.0}
+          - {os: windows-2022, compiler_toolchain: intel-classic, compiler_version: 2021.7.0}
     steps:
+
       - name: Checkout modflow6
         uses: actions/checkout@v3
         with:
@@ -34,6 +43,84 @@ jobs:
         with:
           repository: MODFLOW-USGS/modflow6-examples
           path: modflow6-examples
+
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: modflow6/environment.yml
+          cache-environment: true
+          cache-downloads: true
+
+      - name: Print python package versions
+        run: pip list
+
+      - name: Setup ${{ matrix.compiler_toolchain }} ${{ matrix.compiler_version }}
+        uses: awvwgk/setup-fortran@main
+        with:
+          compiler: ${{ matrix.compiler_toolchain }}
+          version: ${{ matrix.compiler_version }}
+
+      - name: Cache modflow6 examples
+        id: cache-examples
+        uses: actions/cache@v3
+        with:
+          path: modflow6-examples/examples
+          key: modflow6-examples-${{ hashFiles('modflow6-examples/scripts/**') }}
+
+      - name: Install extra Python packages
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6-examples/etc
+        run: |
+          pip install -r requirements.pip.txt
+          pip install -r requirements.usgs.txt
+
+      - name: Update FloPy
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6/autotest
+        run: python update_flopy.py
+
+      - name: Build example models
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6-examples/etc
+        run: |
+          python ci_build_files.py
+          ls -lh ../examples/
+
+      - name: Run benchmarks
+        working-directory: modflow6/distribution
+        run: python benchmark.py
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      
+      - name: Rename/show benchmarks
+        id: rename-benchmarks
+        working-directory: modflow6/distribution/.benchmarks
+        run: |
+          orig="run-time-comparison.md"
+          name="run-time-comparison-${{ matrix.os }}-${{ matrix.compiler_toolchain }}-${{ matrix.compiler_version }}.md"
+          cat $orig
+          mv $orig $name
+          echo "name=$name" >> $GITHUB_OUTPUT
+      
+      - name: Upload benchmarks
+        uses: actions/upload-artifact@v3
+        with:
+          name: run-time-comparison
+          path: modflow6/distribution/.benchmarks/${{ steps.rename-benchmarks.outputs.name }}
+
+  rtd_build:
+    name: Benchmark & build RTD
+    needs: benchmark
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+
+      - name: Checkout modflow6
+        uses: actions/checkout@v3
+        with:
+          path: modflow6
 
       - name: Checkout usgslatex
         uses: actions/checkout@v3
@@ -68,59 +155,23 @@ jobs:
         working-directory: modflow6/autotest
         run: pytest -v build_mfio_tex.py
 
-      - name: Setup GNU Fortran ${{ env.GCC_V }}
-        uses: awvwgk/setup-fortran@main
+      - name: Download benchmarks
+        uses: actions/download-artifact@v3
         with:
-          compiler: gcc
-          version: ${{ env.GCC_V }}
-
-      - name: Cache modflow6 examples
-        id: cache-examples
-        uses: actions/cache@v3
-        with:
-          path: modflow6-examples/examples
-          key: modflow6-examples-${{ hashFiles('modflow6-examples/scripts/**') }}
-
-      - name: Install extra Python packages
-        if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6-examples/etc
-        run: |
-          pip install -r requirements.pip.txt
-          pip install -r requirements.usgs.txt
-
-      - name: Update FloPy
-        if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6/autotest
-        run: python update_flopy.py
-
-      - name: Build example models
-        if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6-examples/etc
-        run: |
-          python ci_build_files.py
-          ls -lh ../examples/
-
-      - name: Run benchmarks
-        working-directory: modflow6/distribution
-        run: python benchmark.py
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Run sphinx
-        working-directory: modflow6/.build_rtd_docs
-        run: make html
+          name: run-time-comparison
+          path: modflow6/distribution
 
       - name: Show benchmarks
         working-directory: modflow6/distribution
-        run: cat run-time-comparison.md
+        run: cat run-time-comparison-*.md
 
-      - name: Upload benchmarks
-        uses: actions/upload-artifact@v3
-        with:
-          name: run-time-comparison
-          path: modflow6/distribution/run-time-comparison.md
+      - name: Run sphinx
+        if: runner.os == 'Linux'
+        working-directory: modflow6/.build_rtd_docs
+        run: make html
 
       - name: Upload results
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v3
         with:
           name: rtd-files-for-${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -116,7 +116,8 @@ CMakeFiles/
 latex/
 html/
 xml/
-distribution/run-time-comparison.md
+distribution/run-time-comparison*.md
+distribution/.benchmarks/run-time-comparison*.md
 doc/ReleaseNotes/run-time-comparison.tex
 
 # Intel Fortran Visual Studio intermediate files

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -10,14 +10,14 @@ from pprint import pprint
 from shutil import copytree
 
 import pytest
+from build_docs import build_documentation
+from build_makefiles import (build_mf5to6_makefile, build_mf6_makefile,
+                             build_zbud6_makefile)
 from modflow_devtools.build import meson_build
 from modflow_devtools.download import download_and_unzip, get_release
 from modflow_devtools.markers import requires_exe
 from modflow_devtools.misc import get_model_paths
 
-from build_docs import build_documentation
-from build_makefiles import (build_mf5to6_makefile, build_mf6_makefile,
-                             build_zbud6_makefile)
 from utils import get_project_root_path, run_command
 
 # default paths
@@ -323,7 +323,6 @@ def build_distribution(
             bin_path=output_path / "bin",
             output_path=output_path / "doc",
             examples_repo_path=examples_repo_path,
-            # benchmarks_path=_benchmarks_path / "run-time-comparison.md",
             full=full,
             overwrite=overwrite,
         )

--- a/distribution/build_makefiles.py
+++ b/distribution/build_makefiles.py
@@ -3,12 +3,12 @@ import sys
 from os import environ
 from pathlib import Path
 
-import pymake
 import pytest
 from flaky import flaky
 from modflow_devtools.markers import requires_exe
 from modflow_devtools.misc import set_dir
 
+import pymake
 from utils import get_modified_time, get_project_root_path
 
 _project_root_path = get_project_root_path()

--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -6,7 +6,6 @@ from pprint import pprint
 
 import pytest
 
-
 # OS-specific extensions
 _system = platform.system()
 _eext = ".exe" if _system == "Windows" else ""

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -34,13 +34,13 @@ import os
 import textwrap
 from collections import OrderedDict
 from datetime import datetime
-from packaging.version import Version
 from pathlib import Path
 from typing import Optional
 
 import pytest
-from filelock import FileLock
 import yaml
+from filelock import FileLock
+from packaging.version import Version
 
 from utils import get_modified_time
 
@@ -292,11 +292,7 @@ def update_version(
     try:
         lock = FileLock(lock_path)
         previous = Version(version_file_path.read_text().strip())
-        version = (
-            version
-            if version
-            else previous
-        )
+        version = version if version else previous
 
         with lock:
             update_version_txt_and_py(version, timestamp)
@@ -320,7 +316,9 @@ _current_version = Version(version_file_path.read_text().strip())
     [
         None,
         _initial_version,
-        Version(f"{_initial_version.major}.{_initial_version.minor}.dev{_initial_version.micro}"),
+        Version(
+            f"{_initial_version.major}.{_initial_version.minor}.dev{_initial_version.micro}"
+        ),
     ],
 )
 @pytest.mark.parametrize("approved", [True, False])

--- a/distribution/utils.py
+++ b/distribution/utils.py
@@ -9,8 +9,8 @@ from os import PathLike, environ
 from pathlib import Path
 from warnings import warn
 
-from modflow_devtools.markers import requires_exe
 import pytest
+from modflow_devtools.markers import requires_exe
 
 _project_root_path = Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
- benchmark on linux, mac and windows in `docs.yml` CI workflow
- move benchmarks to separate job (previously in RTD build job)
- display all 3 platforms' results on RTD 
- only include Linux results in release notes
  - could be all 3 but consideration maybe needed on format
- benchmark on gfortran 13 on linux and mac (still 12 on windows until 13 supported by `setup-fortran` action)
  - matrix could be expanded to test gfortran, ifort, ifx
- maybe benchmarks should run nightly to avoid slowing down CI?