### PR TITLE
ci: remove compiler checks schedule trigger

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -1,7 +1,5 @@
 name: MODFLOW 6 compiler checks
 on:
-  schedule:
-    - cron: 0 0 1 * * # monthly
   # workflow_dispatch trigger to start release via GitHub UI or CLI, see
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:


### PR DESCRIPTION
The main purpose of `compilers.yml` is to check which compiler toolchain/version work on which OS/version. The motivation for the scheduled runs was that github runner images might change underfoot, but this does not impact local development and is only relevant if we want to change how releases are built in CI in future (e.g. adding a gfortran build, using a newer ifort or ifx). So we can just run compiler checks manually whenever needed