### PR TITLE
feat(prp): support coordinate transformations

### DIFF
--- a/autotest/test_prt_coord_transform.py
+++ b/autotest/test_prt_coord_transform.py
@@ -1,0 +1,219 @@
+"""
+Tests ability to transform release point coordinates from
+global, local, or local offset coordinate representations
+to model coordinates, as well as to transform output data
+from model to global cooordinates.
+
+The grid is a 10x10 square with a single layer,
+the same flow system shown on the FloPy readme.
+
+Test cases are defined for each coordinate system option.
+These are:
+
+ - local_xy
+ - local_xy_offset
+ - dev_global_xy
+
+"""
+
+import flopy
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from flopy.utils.gridintersect import GridIntersect
+from framework import TestFramework
+from prt_test_utils import (
+    DEFAULT_EXIT_SOLVE_TOL,
+    FlopyReadmeCase,
+    get_model_name,
+)
+from shapely.geometry import Point
+
+simname = "prtcrd"
+cases = [f"{simname}mdl", f"{simname}lcl", f"{simname}ofs"]  # todo global
+nodes = list(range(100))
+
+
+def get_start_points():
+    return np.add(
+        np.transpose(np.array(np.meshgrid(range(10), range(10))).reshape(2, -1)),
+        0.5,
+    )
+
+
+def get_prp(prt):
+    gi = GridIntersect(prt.modelgrid, method="vertex", rtree=True)
+    if "mdl" in prt.name:
+        startpts = get_start_points()
+        releasepts = [
+            (i, (0, *gi.intersect(Point(rpt))[0].cellids), *rpt, 0.5)
+            for i, rpt in enumerate(startpts)
+        ]
+    elif "lcl" in prt.name:
+        releasepts = [
+            (nn, tuple([*prt.modelgrid.get_lrc([nn])[0]]), 0.5, 0.5, 0.5)
+            for nn in nodes
+        ]
+    elif "ofs" in prt.name:
+        releasepts = [
+            (nn, tuple([*prt.modelgrid.get_lrc([nn])[0]]), 0.0, 0.0, 0.0)
+            for nn in nodes
+        ]
+    elif "gbl" in prt.name:
+        # todo global
+        pass
+
+    prp_track_file = f"{prt.name}_prt.prp.trk"
+    prp_track_csv_file = f"{prt.name}_prt.prp.trk.csv"
+    return flopy.mf6.ModflowPrtprp(
+        prt,
+        pname="prp1",
+        filename=f"{prt.name}_1.prp",
+        nreleasepts=len(releasepts),
+        packagedata=releasepts,
+        perioddata={0: ["FIRST"]},
+        track_filerecord=[prp_track_file],
+        trackcsv_filerecord=[prp_track_csv_file],
+        local_xy="lcl" in prt.name,
+        local_xy_offset="ofs" in prt.name,
+        exit_solve_tolerance=DEFAULT_EXIT_SOLVE_TOL,
+        extend_tracking=True,
+    )
+
+
+def build_prt_sim(name, gwf_ws, prt_ws, mf6):
+    # create simulation
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name,
+        exe_name=mf6,
+        version="mf6",
+        sim_ws=prt_ws,
+    )
+
+    # create tdis package
+    flopy.mf6.modflow.mftdis.ModflowTdis(
+        sim,
+        pname="tdis",
+        time_units="DAYS",
+        nper=FlopyReadmeCase.nper,
+        perioddata=[
+            (
+                FlopyReadmeCase.perlen,
+                FlopyReadmeCase.nstp,
+                FlopyReadmeCase.tsmult,
+            )
+        ],
+    )
+
+    # create prt model
+    prt_name = get_model_name(name, "prt")
+    prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name, save_flows=True)
+
+    # create prt discretization
+    flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
+        prt,
+        pname="dis",
+        nlay=FlopyReadmeCase.nlay,
+        nrow=FlopyReadmeCase.nrow,
+        ncol=FlopyReadmeCase.ncol,
+    )
+
+    # create mip package
+    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=FlopyReadmeCase.porosity)
+
+    # create prp package
+    prp = get_prp(prt)
+
+    # create output control package
+    prt_budget_file = f"{prt_name}.bud"
+    prt_track_file = f"{prt_name}.trk"
+    prt_track_csv_file = f"{prt_name}.trk.csv"
+    flopy.mf6.ModflowPrtoc(
+        prt,
+        pname="oc",
+        budget_filerecord=[prt_budget_file],
+        track_filerecord=[prt_track_file],
+        trackcsv_filerecord=[prt_track_csv_file],
+        saverecord=[("BUDGET", "ALL")],
+    )
+
+    # create the flow model interface
+    gwf_name = get_model_name(name, "gwf")
+    gwf_budget_file = gwf_ws / f"{gwf_name}.bud"
+    gwf_head_file = gwf_ws / f"{gwf_name}.hds"
+    flopy.mf6.ModflowPrtfmi(
+        prt,
+        packagedata=[
+            ("GWFHEAD", gwf_head_file),
+            ("GWFBUDGET", gwf_budget_file),
+        ],
+    )
+
+    # add explicit model solution
+    ems = flopy.mf6.ModflowEms(
+        sim,
+        pname="ems",
+        filename=f"{prt_name}.ems",
+    )
+    sim.register_solution_package(ems, [prt.name])
+
+    return sim
+
+
+def build_models(idx, test):
+    gwf_ws = test.workspace / "gwf"
+    prt_ws = test.workspace / "prt"
+    gwf_sim = FlopyReadmeCase.get_gwf_sim(test.name, gwf_ws, test.targets["mf6"])
+    prt_sim = build_prt_sim(test.name, gwf_ws, prt_ws, test.targets["mf6"])
+    return gwf_sim, prt_sim
+
+
+def check_output(idx, test):
+    name = test.name
+    gwf_ws = test.workspace
+    prt_ws = test.workspace / "prt"
+    gwf_sim, prt_sim = test.sims[:2]
+    gwf = gwf_sim.get_model()
+    prt = prt_sim.get_model()
+    hds = gwf.output.head().get_data()
+    mg = gwf.modelgrid
+    pathlines = pd.read_csv(prt_ws / f"{prt.name}.trk.csv")
+    startpts = pathlines[pathlines.ireason == 0]
+    endpts = pathlines[pathlines.ireason == 3]
+
+    # check start points
+    assert np.allclose(
+        np.sort(startpts[["x", "y"]].to_numpy(), axis=0),
+        np.sort(np.array(get_start_points()), axis=0),
+    )
+
+    # setup plot
+    plot_data = False
+    if plot_data:
+        fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(10, 10))
+        for a in ax:
+            a.set_aspect("equal")
+
+        # plot pathline in map view
+        pmv = flopy.plot.PlotMapView(modelgrid=mg, ax=ax[0])
+        pmv.plot_grid()
+        pmv.plot_array(hds[0], alpha=0.1, cmap="jet")
+        pmv.plot_pathline(pathlines)
+
+        # view/save plot
+        plt.show()
+        plt.savefig(gwf_ws / f"test_{simname}.png")
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        targets=targets,
+        compare=None,
+    )
+    test.run()

--- a/autotest/test_prt_coord_transform.py
+++ b/autotest/test_prt_coord_transform.py
@@ -2,7 +2,7 @@
 Tests ability to transform release point coordinates from
 global, local, or local offset coordinate representations
 to model coordinates, as well as to transform output data
-from model to global cooordinates.
+from model to global coordinates.
 
 The grid is a 10x10 square with a single layer,
 the same flow system shown on the FloPy readme.

--- a/autotest/test_prt_fmi.py
+++ b/autotest/test_prt_fmi.py
@@ -1,7 +1,6 @@
 """
 Tests ability to run a GWF model then a PRT model
 in separate simulations via flow model interface,
-as well as
 
 The grid is a 10x10 square with a single layer,
 the same flow system shown on the FloPy readme.

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -41,7 +41,31 @@ type keyword
 reader urword
 optional true
 longname whether to use local z coordinates
-description indicates that ``zrpt'' defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user.
+description indicates that ``zrpt'' defines the local z coordinate of the release point within the cell scaled to the unit interval, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user.
+
+block options
+name local_xy
+type keyword
+reader urword
+optional true
+longname whether to use local x and y coordinates
+description indicates that ``xrpt'' and ``yrpt'' define the local x and y coordinates of the release point within the cell scaled to the unit interval, with value of 0 at the west and south faces and 1 at the east and north faces of the cell. This option may only be used with structured models.
+
+block options
+name local_xy_offset
+type keyword
+reader urword
+optional true
+longname whether to use local x and y offsets
+description indicates that ``xrpt'' and ``rpt'' define the local x and y offsets of the release point within the cell, where the local coordinate system's origin is the cell center and distances are not rescaled. This option may be used with structured or unstructured models.
+
+block options
+name dev_global_xy
+type keyword
+reader urword
+optional true
+longname whether to transform x and y coordinates
+description indicates that ``xrpt'' and ``yrpt'' define global coordinates and should be transformed to the model coordinate system if georeferencing information (origin and rotation) is available on the model grid. By default, release points are assumed to be in model coordinates. If this option is enabled, particle pathlines will also be reported in global coordinates in output files.
 
 block options
 name extend_tracking

--- a/src/Model/ModelUtilities/TrackControl.f90
+++ b/src/Model/ModelUtilities/TrackControl.f90
@@ -110,10 +110,11 @@ contains
   !! any PRP-level files with PRP index matching the particle's
   !! PRP index.
   !<
-  subroutine save(this, particle, kper, kstp, reason, level)
+  subroutine save(this, particle, dis, kper, kstp, reason, level)
     ! dummy
     class(TrackControlType), intent(inout) :: this
     type(ParticleType), pointer, intent(in) :: particle
+    class(DisBaseType), pointer, intent(in) :: dis
     integer(I4B), intent(in) :: kper
     integer(I4B), intent(in) :: kstp
     integer(I4B), intent(in) :: reason
@@ -146,7 +147,7 @@ contains
       if (file%iun > 0 .and. &
           (file%iprp == -1 .or. &
            file%iprp == particle%iprp)) &
-        call save_record(file%iun, particle, &
+        call save_record(file%iun, particle, dis, &
                          kper, kstp, reason, csv=file%csv)
     end do
   end subroutine save

--- a/src/Model/ModelUtilities/TrackFile.f90
+++ b/src/Model/ModelUtilities/TrackFile.f90
@@ -2,6 +2,7 @@ module TrackFileModule
   use KindModule, only: DP, I4B, LGP
   use ConstantsModule, only: DZERO, DPIO180
   use ParticleModule, only: ParticleType, ACTIVE
+  use BaseDisModule, only: DisBaseType
   use GeomUtilModule, only: transform
 
   implicit none
@@ -43,20 +44,38 @@ module TrackFileModule
 contains
 
   !> @brief Save a particle track record to a binary or CSV file.
-  subroutine save_record(iun, particle, kper, kstp, reason, csv)
+  subroutine save_record(iun, particle, dis, kper, kstp, reason, csv)
     ! dummy
     integer(I4B), intent(in) :: iun
     type(ParticleType), pointer, intent(in) :: particle
+    class(DisBaseType), pointer, intent(in) :: dis
     integer(I4B), intent(in) :: kper
     integer(I4B), intent(in) :: kstp
     integer(I4B), intent(in) :: reason
     logical(LGP), intent(in) :: csv
     ! local
-    real(DP) :: x, y, z
+    real(DP) :: x, y, z, xout, yout, zout
     integer(I4B) :: status
 
     ! Convert from cell-local to model coordinates if needed
     call particle%get_model_coords(x, y, z)
+
+    ! Apply model grid offset/rotation if needed
+    if (particle%icoords == 1 .and. &
+        (dis%angrot /= DZERO .or. &
+         dis%xorigin /= DZERO .or. &
+         dis%yorigin /= DZERO)) then
+      call transform(x, y, z, &
+                     xout, yout, zout, &
+                     dis%xorigin, &
+                     dis%yorigin, &
+                     DZERO, &
+                     sin(dis%angrot * DPIO180), &
+                     cos(dis%angrot * DPIO180), &
+                     invert=.true.)
+      x = xout
+      y = yout
+    end if
 
     ! Set status
     if (particle%istatus .lt. 0) then

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -2,7 +2,7 @@ module PrtPrpModule
   use KindModule, only: DP, I4B, LGP
   use ConstantsModule, only: DZERO, DEM1, DEM5, DONE, LENFTYPE, LINELENGTH, &
                              LENBOUNDNAME, LENPAKLOC, TABLEFT, TABCENTER, &
-                             MNORMAL, DSAME, DEP3, DEP9
+                             MNORMAL, DSAME, DEP3, DEP9, DPIO180
   use BndModule, only: BndType
   use ObsModule, only: DefaultObsIdProcessor
   use TableModule, only: TableType, table_cr
@@ -18,10 +18,11 @@ module PrtPrpModule
                        store_warning
   use SimVariablesModule, only: errmsg, warnmsg
   use TrackControlModule, only: TrackControlType
-  use GeomUtilModule, only: point_in_polygon, get_ijk, get_jk
+  use GeomUtilModule, only: point_in_polygon, get_ijk, get_jk, transform
   use MemoryManagerModule, only: mem_allocate, mem_deallocate, &
                                  mem_reallocate
   use ReleaseScheduleModule, only: ReleaseScheduleType, create_release_schedule
+  use BaseDisModule, only: DisBaseType
   use DisModule, only: DisType
   use DisvModule, only: DisvType
   use ErrorUtilModule, only: pstop
@@ -48,6 +49,7 @@ module PrtPrpModule
     integer(I4B), pointer :: nparticles => null() !< number of particles released
     integer(I4B), pointer :: istopweaksink => null() !< weak sink option: 0 = no stop, 1 = stop
     integer(I4B), pointer :: istopzone => null() !< optional stop zone number: 0 = no stop zone
+    integer(I4B), pointer :: icoords => null() !< coordinate system option: 0 = model, 1 = global, 2 = local (unit-normalized, only for dis grids), 3 = local offset
     integer(I4B), pointer :: idrape => null() !< drape option: 0 = do not drape, 1 = drape to topmost active cell
     integer(I4B), pointer :: idrymeth => null() !< dry tracking method: 0 = drop, 1 = stop, 2 = stay
     integer(I4B), pointer :: itrkout => null() !< binary track file
@@ -158,6 +160,7 @@ contains
     call mem_deallocate(this%stoptraveltime)
     call mem_deallocate(this%istopweaksink)
     call mem_deallocate(this%istopzone)
+    call mem_deallocate(this%icoords)
     call mem_deallocate(this%idrape)
     call mem_deallocate(this%idrymeth)
     call mem_deallocate(this%nreleasepoints)
@@ -247,6 +250,7 @@ contains
     call mem_allocate(this%stoptraveltime, 'STOPTRAVELTIME', this%memoryPath)
     call mem_allocate(this%istopweaksink, 'ISTOPWEAKSINK', this%memoryPath)
     call mem_allocate(this%istopzone, 'ISTOPZONE', this%memoryPath)
+    call mem_allocate(this%icoords, 'ICOORDS', this%memoryPath)
     call mem_allocate(this%idrape, 'IDRAPE', this%memoryPath)
     call mem_allocate(this%idrymeth, 'IDRYMETH', this%memoryPath)
     call mem_allocate(this%nreleasepoints, 'NRELEASEPOINTS', this%memoryPath)
@@ -270,6 +274,7 @@ contains
     this%stoptraveltime = huge(1d0)
     this%istopweaksink = 0
     this%istopzone = 0
+    this%icoords = 0
     this%idrape = 0
     this%idrymeth = 0
     this%nreleasepoints = 0
@@ -453,8 +458,11 @@ contains
     ! local
     integer(I4B) :: irow, icol, ilay, icpl
     integer(I4B) :: ic, icu, ic_old
-    real(DP) :: x, y, z
+    integer(I4B) :: i, j, k
+    integer(I4B) :: icoords
+    real(DP) :: x, y, z, xout, yout, zout
     real(DP) :: top, bot, hds
+    real(DP), allocatable :: polyverts(:, :)
 
     ic = this%rptnode(ip)
     icu = this%dis%get_nodeuser(ic)
@@ -500,9 +508,52 @@ contains
       end if
     end if
 
-    ! Load coordinates and transform if needed
+    ! Load x/y coordinates and transform if needed
+    icoords = 0
     x = this%rptx(ip)
     y = this%rpty(ip)
+    if (this%icoords == 1 .and. ( &
+        this%dis%angrot /= DZERO .or. &
+        this%dis%xorigin /= DZERO .or. &
+        this%dis%yorigin /= DZERO)) then
+      icoords = 1
+      ! Transform x and y from global to model coordinates
+      call transform(x, y, z, &
+                     xout, yout, zout, &
+                     this%dis%xorigin, &
+                     this%dis%yorigin, &
+                     DZERO, &
+                     sin(this%dis%angrot * DPIO180), &
+                     cos(this%dis%angrot * DPIO180))
+      x = xout
+      y = yout
+    else if (this%icoords == 2) then
+      ! Transform x and y from local to model coordinates
+      select type (dis => this%fmi%dis)
+      type is (DisType)
+        call dis%get_polyverts(ic, polyverts)
+        call get_ijk(icu, dis%nrow, dis%ncol, dis%nlay, i, j, k)
+        x = minval(polyverts(1, :)) + x * dis%delc(j)
+        y = minval(polyverts(2, :)) + y * dis%delr(i)
+      type is (DisvType)
+        errmsg = 'Error: LOCAL_XY may only be used on structured grids.'
+        call store_error(errmsg, terminate=.false.)
+        call store_error_unit(this%inunit, terminate=.true.)
+      end select
+    else if (this%icoords == 3) then
+      ! Transform x and y from local offsets to model coordinates
+      select type (dis => this%fmi%dis)
+      type is (DisType)
+        call get_ijk(icu, dis%nrow, dis%ncol, dis%nlay, i, j, k)
+        x = dis%cellx(j) + x
+        y = dis%celly(i) + y
+      type is (DisvType)
+        x = dis%cellxy(ic, 1) + x
+        y = dis%cellxy(ic, 2) + y
+      end select
+    end if
+
+    ! Load z coordinates and transform if needed
     if (this%ilocalz > 0) then
       top = this%fmi%dis%top(ic)
       bot = this%fmi%dis%bot(ic)
@@ -537,6 +588,7 @@ contains
     particle%ifrctrn = this%ifrctrn
     particle%iexmeth = this%iexmeth
     particle%iextend = this%iextend
+    particle%icoords = icoords
     particle%extol = this%extol
   end subroutine initialize_particle
 
@@ -786,6 +838,12 @@ contains
     case ('LOCAL_Z')
       this%ilocalz = 1
       found = .true.
+    case ('LOCAL_XY')
+      this%icoords = 2
+      found = .true.
+    case ('LOCAL_XY_OFFSET')
+      this%icoords = 3
+      found = .true.
     case ('EXTEND_TRACKING')
       this%iextend = 1
       found = .true.
@@ -816,6 +874,10 @@ contains
       if (.not. (this%iexmeth /= 1 .or. this%iexmeth /= 2)) &
         call store_error('DEV_EXIT_SOLVE_METHOD MUST BE &
           &1 (BRENT) OR 2 (CHANDRUPATLA)')
+      found = .true.
+    case ('DEV_GLOBAL_XY')
+      call this%parser%DevOpt()
+      this%icoords = 1
       found = .true.
     case default
       found = .false.
@@ -959,8 +1021,19 @@ contains
         y(n) = this%parser%GetDouble()
         z(n) = this%parser%GetDouble()
 
+        ! check coordinates
+        ! TODO: factor out a routine?
+        if (this%icoords == 2) then
+          if (x(n) < 0 .or. x(n) > 1) then
+            call store_error('Local x coordinate must fall in the unit interval')
+            cycle
+          else if (x(n) < 0 .or. x(n) > 1) then
+            call store_error('Local x coordinate must fall in the unit interval')
+            cycle
+          end if
+        end if
         if (this%ilocalz > 0 .and. (z(n) < 0 .or. z(n) > 1)) then
-          call store_error('Local z coordinate must fall in the interval [0, 1]')
+          call store_error('Local z coordinate must fall in the unit interval')
           cycle
         end if
 

--- a/src/Solution/ParticleTracker/Method.f90
+++ b/src/Solution/ParticleTracker/Method.f90
@@ -181,7 +181,10 @@ contains
       end if
     end if
 
-    call this%trackctl%save(particle, kper=per, kstp=stp, reason=reason)
+    ! Save the particle's state to any registered tracking output files
+    call this%trackctl%save(particle, this%fmi%dis, &
+                            kper=per, kstp=stp, &
+                            reason=reason)
   end subroutine save
 
 end module MethodModule

--- a/src/Solution/ParticleTracker/MethodCellPollock.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollock.f90
@@ -64,6 +64,7 @@ contains
       call this%load_subcell(particle, subcell)
     end select
     call method_subcell_plck%init( &
+      fmi=this%fmi, &
       cell=this%cell, &
       subcell=this%subcell, &
       trackctl=this%trackctl, &


### PR DESCRIPTION
PRT requires particle release points (except for z via `LOCAL_Z`) specified in the model coordinate system, and also reports pathlines in the model coordinate system. This PR enables input coordinate transformations with keyword options for the particle release point package.

With this change, points may be specified as

- model coordinates (default, as before)
- local cell coordinates scaled to the unit interval with `LOCAL_XY` and/or `LOCAL_Z` &mdash; only structured grids
- offsets from the cell center, no rescaling, via `LOCAL_XY_OFFSET` &mdash; structured or unstructured grids
- global coordinates via dev option `DEV_GLOBAL_XY` &mdash; transform release points to model coordinates using grid georeference information

___

Checklist of items for pull request

- [x] Added new test or modified an existing test
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [x] Removed checklist items not relevant to this pull request