### PR TITLE
MSVS File Update and Fixes

### DIFF
--- a/msvs/mf6.sln
+++ b/msvs/mf6.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35004.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "mf6", "mf6.vfproj", "{369C1E2E-A513-4E83-A076-923534E30304}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -12,36 +12,16 @@ Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "mf6core", "mf6core.vfproj",
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
-		Profile|Win32 = Profile|Win32
-		Profile|x64 = Profile|x64
-		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{369C1E2E-A513-4E83-A076-923534E30304}.Debug|Win32.ActiveCfg = Debug|Win32
-		{369C1E2E-A513-4E83-A076-923534E30304}.Debug|Win32.Build.0 = Debug|Win32
 		{369C1E2E-A513-4E83-A076-923534E30304}.Debug|x64.ActiveCfg = Debug|x64
 		{369C1E2E-A513-4E83-A076-923534E30304}.Debug|x64.Build.0 = Debug|x64
-		{369C1E2E-A513-4E83-A076-923534E30304}.Profile|Win32.ActiveCfg = Profile|Win32
-		{369C1E2E-A513-4E83-A076-923534E30304}.Profile|Win32.Build.0 = Profile|Win32
-		{369C1E2E-A513-4E83-A076-923534E30304}.Profile|x64.ActiveCfg = Profile|x64
-		{369C1E2E-A513-4E83-A076-923534E30304}.Profile|x64.Build.0 = Profile|x64
-		{369C1E2E-A513-4E83-A076-923534E30304}.Release|Win32.ActiveCfg = Release|Win32
-		{369C1E2E-A513-4E83-A076-923534E30304}.Release|Win32.Build.0 = Release|Win32
 		{369C1E2E-A513-4E83-A076-923534E30304}.Release|x64.ActiveCfg = Release|x64
 		{369C1E2E-A513-4E83-A076-923534E30304}.Release|x64.Build.0 = Release|x64
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Debug|Win32.ActiveCfg = Debug|Win32
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Debug|Win32.Build.0 = Debug|Win32
 		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Debug|x64.ActiveCfg = Debug|x64
 		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Debug|x64.Build.0 = Debug|x64
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Profile|Win32.ActiveCfg = Release|Win32
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Profile|Win32.Build.0 = Release|Win32
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Profile|x64.ActiveCfg = Release|x64
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Profile|x64.Build.0 = Release|x64
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Release|Win32.ActiveCfg = Release|Win32
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Release|Win32.Build.0 = Release|Win32
 		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Release|x64.ActiveCfg = Release|x64
 		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection

--- a/msvs/mf6.vfproj
+++ b/msvs/mf6.vfproj
@@ -1,72 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <VisualStudioProject ProjectCreator="Intel Fortran" Keyword="Console Application" Version="11.0" ProjectIdGuid="{369C1E2E-A513-4E83-A076-923534E30304}">
 	<Platforms>
-		<Platform Name="Win32"/>
-		<Platform Name="x64"/></Platforms>
+		<Platform Name="x64"/>
+	</Platforms>
 	<Configurations>
-		<Configuration Name="Debug|Win32" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" TargetName="$(ProjectName)d">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" HeapArrays="0" StandardWarnings="standardWarningsF08" WarnUnusedVariables="true" WarnUncalled="true" WarnInterfaces="true" OptDiagFile="optrpt" FloatingPointExceptionHandling="fpe0" Traceback="true" BoundsCheck="true" UninitializedVariablesCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
-				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Release|Win32" OutputDirectory="../../bin" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" HeapArrays="0" FloatingPointExceptionHandling="fpe0" BoundsCheck="true"/>
-				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Debug|x64" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" TargetName="$(ProjectName)d">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" HeapArrays="0" WarnUnusedVariables="true" WarnUncalled="true" WarnInterfaces="true" FloatingPointExceptionHandling="fpe0" Traceback="true" NullPointerCheck="true" BoundsCheck="true" UninitializedVariablesCheck="true" ArgTempCreatedCheck="true" StackFrameCheck="true"/>
-				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" IgnoreDefaultLibraryNames="LIBCMTD" GenerateDebugInformation="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Release|x64" OutputDirectory="../bin/" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" HeapArrays="0" OptDiagFile="optrpt" FloatingPointExceptionHandling="fpe0"/>
-				<Tool Name="VFLinkerTool" AdditionalOptions="/verbose:lib" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" IgnoreDefaultLibraryNames="LIBCMTD" GenerateDebugInformation="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Profile|Win32" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" HeapArrays="0" FloatingPointExceptionHandling="fpe0" BoundsCheck="true" RuntimeLibrary="rtMultiThreadedDLL"/>
-				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Profile|x64" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)">
-				<Tool Name="VFFortranCompilerTool" AdditionalOptions="/debug:inline-debug-info" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" DebugParameter="debugParameterAll" FloatingPointExceptionHandling="fpe0" Traceback="true" RuntimeLibrary="rtMultiThreadedDLL"/>
-				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" IgnoreDefaultLibraryNames="LIBCMTD" GenerateManifest="false" ManifestFile="$(IntDir)\$(TargetName)p$(TargetExt).intermediate.manifest" GenerateDebugInformation="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true" OutputManifestFile="$(IntDir)\$(TargetName)p$(TargetExt).embed.manifest" ResourceFile="$(IntDir)\$(TargetName)p$(TargetExt).embed.manifest.res"/></Configuration></Configurations>
+		<Configuration Name="Debug|x64" UseCompiler="ifortCompiler" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)_$(PlatformName)_$(ConfigurationName)" TargetName="$(ProjectName)d">
+			<Tool Name="VFFortranCompilerTool" AdditionalOptions="/Qdiag-disable:10448" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" HeapArrays="0" WarnUnusedVariables="true" WarnUncalled="true" WarnInterfaces="true" FloatingPointExceptionHandling="fpe0" Traceback="true" NullPointerCheck="true" BoundsCheck="true" UninitializedVariablesCheck="true" ArgTempCreatedCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
+			<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
+			<Tool Name="VFResourceCompilerTool"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
+			<Tool Name="VFCustomBuildTool"/>
+			<Tool Name="VFPreLinkEventTool"/>
+			<Tool Name="VFPreBuildEventTool"/>
+			<Tool Name="VFPostBuildEventTool"/>
+			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
+		</Configuration>
+		<Configuration Name="Release|x64" UseCompiler="ifortCompiler" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)_$(PlatformName)_$(ConfigurationName)">
+			<Tool Name="VFFortranCompilerTool" AdditionalOptions="/Qdiag-disable:10448" SuppressStartupBanner="true" HeapArrays="0" OptDiagFile="optrpt" FloatingPointExceptionHandling="fpe0"/>
+			<Tool Name="VFLinkerTool" AdditionalOptions="/verbose:lib" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
+			<Tool Name="VFResourceCompilerTool"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
+			<Tool Name="VFCustomBuildTool"/>
+			<Tool Name="VFPreLinkEventTool"/>
+			<Tool Name="VFPreBuildEventTool"/>
+			<Tool Name="VFPostBuildEventTool"/>
+			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
+		</Configuration>
+	</Configurations>
 	<Files>
 		<Filter Name="Header Files" Filter="fi;fd"/>
 		<Filter Name="Resource Files" Filter="rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe"/>
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
-		<File RelativePath="..\src\mf6.f90"/></Filter></Files>
-	<Globals/></VisualStudioProject>
+			<File RelativePath="..\src\mf6.f90"/>
+		</Filter>
+	</Files>
+	<Globals/>
+</VisualStudioProject>

--- a/msvs/mf6bmi.sln
+++ b/msvs/mf6bmi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35004.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "mf6core", "mf6core.vfproj", "{380139B4-29CE-4CF3-BD74-5AA979FD0F43}"
 EndProject
@@ -12,36 +12,16 @@ Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "mf6bmi", "mf6bmi.vfproj", "
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
-		Profile|Win32 = Profile|Win32
-		Profile|x64 = Profile|x64
-		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Debug|Win32.ActiveCfg = Debug|Win32
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Debug|Win32.Build.0 = Debug|Win32
 		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Debug|x64.ActiveCfg = Debug|x64
 		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Debug|x64.Build.0 = Debug|x64
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Profile|Win32.ActiveCfg = Release|Win32
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Profile|Win32.Build.0 = Release|Win32
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Profile|x64.ActiveCfg = Release|x64
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Profile|x64.Build.0 = Release|x64
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Release|Win32.ActiveCfg = Release|Win32
-		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Release|Win32.Build.0 = Release|Win32
 		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Release|x64.ActiveCfg = Release|x64
 		{380139B4-29CE-4CF3-BD74-5AA979FD0F43}.Release|x64.Build.0 = Release|x64
-		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Debug|Win32.ActiveCfg = Debug|Win32
-		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Debug|Win32.Build.0 = Debug|Win32
 		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Debug|x64.ActiveCfg = Debug|x64
 		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Debug|x64.Build.0 = Debug|x64
-		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Profile|Win32.ActiveCfg = Release|Win32
-		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Profile|Win32.Build.0 = Release|Win32
-		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Profile|x64.ActiveCfg = Release|x64
-		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Profile|x64.Build.0 = Release|x64
-		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Release|Win32.ActiveCfg = Release|Win32
-		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Release|Win32.Build.0 = Release|Win32
 		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Release|x64.ActiveCfg = Release|x64
 		{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection

--- a/msvs/mf6bmi.vfproj
+++ b/msvs/mf6bmi.vfproj
@@ -1,65 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <VisualStudioProject ProjectType="typeDynamicLibrary" ProjectCreator="Intel Fortran" Keyword="Dll" Version="11.0" ProjectIdGuid="{63FE82B0-6FA8-43FC-9B31-C1D6478CB4BC}">
 	<Platforms>
-		<Platform Name="Win32"/>
-		<Platform Name="x64"/></Platforms>
+		<Platform Name="x64"/>
+	</Platforms>
 	<Configurations>
-		<Configuration Name="Debug|x64" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6d" ConfigurationType="typeDynamicLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" WarnInterfaces="true" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebugDLL"/>
-				<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" SubSystem="subSystemWindows" LinkDLL="true"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Release|x64" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6" ConfigurationType="typeDynamicLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" RuntimeLibrary="rtMultiThreadedDLL"/>
-				<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" SuppressStartupBanner="true" SubSystem="subSystemWindows" LinkDLL="true"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Debug|Win32" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6d" ConfigurationType="typeDynamicLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" WarnInterfaces="true" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebugDLL"/>
-				<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" SubSystem="subSystemWindows" LinkDLL="true"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
-		<Configuration Name="Release|Win32" IntermediateDirectory="obj_temp\$(ProjectName)\$(Platform)\$(ConfigurationName)" TargetName="libmf6" ConfigurationType="typeDynamicLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" RuntimeLibrary="rtMultiThreadedDLL"/>
-				<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" SuppressStartupBanner="true" SubSystem="subSystemWindows" LinkDLL="true"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/>
-				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration></Configurations>
+		<Configuration Name="Debug|x64" UseCompiler="ifortCompiler" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)_$(Platform)_$(ConfigurationName)" TargetName="libmf6d" ConfigurationType="typeDynamicLibrary">
+			<Tool Name="VFFortranCompilerTool" AdditionalOptions="/Qdiag-disable:10448" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" HeapArrays="0" WarnInterfaces="true" FloatingPointExceptionHandling="fpe0" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebugDLL"/>
+			<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" IgnoreDefaultLibraryNames="LIBCMTD;LIBIFCOREMT" GenerateDebugInformation="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemWindows" LinkDLL="true"/>
+			<Tool Name="VFResourceCompilerTool"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
+			<Tool Name="VFCustomBuildTool"/>
+			<Tool Name="VFPreLinkEventTool"/>
+			<Tool Name="VFPreBuildEventTool"/>
+			<Tool Name="VFPostBuildEventTool"/>
+			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
+		</Configuration>
+		<Configuration Name="Release|x64" UseCompiler="ifortCompiler" OutputDirectory="../bin" IntermediateDirectory="obj_temp\$(ProjectName)_$(Platform)_$(ConfigurationName)" TargetName="libmf6" ConfigurationType="typeDynamicLibrary">
+			<Tool Name="VFFortranCompilerTool" AdditionalOptions="/Qdiag-disable:10448" SuppressStartupBanner="true" HeapArrays="0" FloatingPointExceptionHandling="fpe0" RuntimeLibrary="rtMultiThreadedDLL"/>
+			<Tool Name="VFLinkerTool" AdditionalOptions="/ignore:4049,4217" SuppressStartupBanner="true" IgnoreDefaultLibraryNames="LIBCMT;LIBIFCOREMT" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemWindows" LinkDLL="true"/>
+			<Tool Name="VFResourceCompilerTool"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
+			<Tool Name="VFCustomBuildTool"/>
+			<Tool Name="VFPreLinkEventTool"/>
+			<Tool Name="VFPreBuildEventTool"/>
+			<Tool Name="VFPostBuildEventTool"/>
+			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
+		</Configuration>
+	</Configurations>
 	<Files>
 		<Filter Name="Header Files" Filter="fi;fd;h;inc"/>
 		<Filter Name="Resource Files" Filter="rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe"/>
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
-		<File RelativePath="..\srcbmi\bmi.f90"/>
-		<File RelativePath="..\srcbmi\mf6bmi.f90"/>
-		<File RelativePath="..\srcbmi\mf6bmiError.f90"/>
-		<File RelativePath="..\srcbmi\mf6bmiGrid.f90"/>
-		<File RelativePath="..\srcbmi\mf6bmiUtil.f90"/>
-		<File RelativePath="..\srcbmi\mf6xmi.F90">
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File></Filter></Files>
-	<Globals/></VisualStudioProject>
+			<File RelativePath="..\srcbmi\bmi.f90"/>
+			<File RelativePath="..\srcbmi\mf6bmi.f90"/>
+			<File RelativePath="..\srcbmi\mf6bmiError.f90"/>
+			<File RelativePath="..\srcbmi\mf6bmiGrid.f90"/>
+			<File RelativePath="..\srcbmi\mf6bmiUtil.f90"/>
+			<File RelativePath="..\srcbmi\mf6xmi.F90">
+				<FileConfiguration Name="Release|x64">
+					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+				</FileConfiguration>
+				<FileConfiguration Name="Debug|x64">
+					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+				</FileConfiguration>
+			</File>
+		</Filter>
+	</Files>
+	<Globals/>
+</VisualStudioProject>

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -1,597 +1,644 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <VisualStudioProject ProjectType="typeStaticLibrary" ProjectCreator="Intel Fortran" Keyword="Static Library" Version="11.0" ProjectIdGuid="{380139B4-29CE-4CF3-BD74-5AA979FD0F43}">
 	<Platforms>
-		<Platform Name="Win32"/>
-		<Platform Name="x64"/></Platforms>
+		<Platform Name="x64"/>
+	</Platforms>
 	<Configurations>
-		<Configuration Name="Debug|x64" OutputDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" ConfigurationType="typeStaticLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" Preprocess="preprocessYes" WarnDeclarations="true" WarnUnusedVariables="true" WarnInterfaces="true" FloatingPointExceptionHandling="fpe0" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
-				<Tool Name="VFLibrarianTool"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/></Configuration>
-		<Configuration Name="Release|x64" OutputDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" ConfigurationType="typeStaticLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" WarnDeclarations="true" WarnUnusedVariables="true" FloatingPointExceptionHandling="fpe0"/>
-				<Tool Name="VFLibrarianTool"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/></Configuration>
-		<Configuration Name="Debug|Win32" OutputDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" ConfigurationType="typeStaticLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" WarnUnusedVariables="true" WarnUncalled="true" WarnInterfaces="true" FloatingPointExceptionHandling="fpe0" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
-				<Tool Name="VFLibrarianTool"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/></Configuration>
-		<Configuration Name="Release|Win32" OutputDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" IntermediateDirectory="obj_temp\$(ProjectName)\$(PlatformName)\$(ConfigurationName)" ConfigurationType="typeStaticLibrary">
-				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true"/>
-				<Tool Name="VFLibrarianTool"/>
-				<Tool Name="VFResourceCompilerTool"/>
-				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
-				<Tool Name="VFCustomBuildTool"/>
-				<Tool Name="VFPreLinkEventTool"/>
-				<Tool Name="VFPreBuildEventTool"/>
-				<Tool Name="VFPostBuildEventTool"/></Configuration></Configurations>
+		<Configuration Name="Debug|x64" UseCompiler="ifortCompiler" OutputDirectory="obj_temp\$(ProjectName)_$(PlatformName)_$(ConfigurationName)" IntermediateDirectory="obj_temp\$(ProjectName)_$(PlatformName)_$(ConfigurationName)" ConfigurationType="typeStaticLibrary">
+			<Tool Name="VFFortranCompilerTool" AdditionalOptions="/Qdiag-disable:10448" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" HeapArrays="0" WarnDeclarations="true" WarnUnusedVariables="true" WarnInterfaces="true" FloatingPointExceptionHandling="fpe0" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
+			<Tool Name="VFLibrarianTool"/>
+			<Tool Name="VFResourceCompilerTool"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
+			<Tool Name="VFCustomBuildTool"/>
+			<Tool Name="VFPreLinkEventTool"/>
+			<Tool Name="VFPreBuildEventTool"/>
+			<Tool Name="VFPostBuildEventTool"/>
+		</Configuration>
+		<Configuration Name="Release|x64" UseCompiler="ifortCompiler" OutputDirectory="obj_temp\$(ProjectName)_$(PlatformName)_$(ConfigurationName)" IntermediateDirectory="obj_temp\$(ProjectName)_$(PlatformName)_$(ConfigurationName)" ConfigurationType="typeStaticLibrary">
+			<Tool Name="VFFortranCompilerTool" AdditionalOptions="/Qdiag-disable:10448" SuppressStartupBanner="true" HeapArrays="0" WarnDeclarations="true" WarnUnusedVariables="true" FloatingPointExceptionHandling="fpe0"/>
+			<Tool Name="VFLibrarianTool"/>
+			<Tool Name="VFResourceCompilerTool"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
+			<Tool Name="VFCustomBuildTool"/>
+			<Tool Name="VFPreLinkEventTool"/>
+			<Tool Name="VFPreBuildEventTool"/>
+			<Tool Name="VFPostBuildEventTool"/>
+		</Configuration>
+	</Configurations>
 	<Files>
 		<Filter Name="Header Files" Filter="fi;fd"/>
 		<Filter Name="Resource Files" Filter="rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe"/>
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
-		<Filter Name="Distributed">
-		<File RelativePath="..\src\Distributed\DistributedSim.f90"/>
-		<File RelativePath="..\src\Distributed\IndexMap.f90"/>
-		<File RelativePath="..\src\Distributed\InterfaceMap.f90"/>
-		<File RelativePath="..\src\Distributed\MappedMemory.f90"/>
-		<File RelativePath="..\src\Distributed\Mapper.f90"/>
-		<File RelativePath="..\src\Distributed\MpiMessageBuilder.f90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Distributed\MpiMessageCache.f90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Distributed\MpiRouter.f90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Distributed\MpiRunControl.F90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Distributed\MpiUnitCache.f90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Distributed\MpiWorld.f90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Distributed\RouterBase.f90"/>
-		<File RelativePath="..\src\Distributed\RouterFactory.F90">
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\src\Distributed\SerialRouter.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualBase.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualDataContainer.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualDataLists.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualDataManager.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualExchange.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualGweExchange.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualGweModel.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualGwfExchange.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualGwfModel.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualGwtExchange.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualGwtModel.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualModel.f90"/>
-		<File RelativePath="..\src\Distributed\VirtualSolution.f90"/></Filter>
-		<Filter Name="Exchange">
-		<File RelativePath="..\src\Exchange\BaseExchange.f90"/>
-		<File RelativePath="..\src\Exchange\DisConnExchange.f90"/>
-		<File RelativePath="..\src\Exchange\exg-gwegwe.f90"/>
-		<File RelativePath="..\src\Exchange\exg-gwfgwe.f90"/>
-		<File RelativePath="..\src\Exchange\exg-gwfgwf.f90"/>
-		<File RelativePath="..\src\Exchange\exg-gwfgwt.f90"/>
-		<File RelativePath="..\src\Exchange\exg-gwfprt.f90"/>
-		<File RelativePath="..\src\Exchange\exg-gwtgwt.f90"/>
-		<File RelativePath="..\src\Exchange\exg-swfgwf.f90"/>
-		<File RelativePath="..\src\Exchange\GhostNode.f90"/>
-		<File RelativePath="..\src\Exchange\GwfExchangeMover.f90"/>
-		<File RelativePath="..\src\Exchange\NumericalExchange.f90"/></Filter>
-		<Filter Name="Idm">
-		<Filter Name="selector">
-		<File RelativePath="..\src\Idm\selector\IdmDfnSelector.f90"/>
-		<File RelativePath="..\src\Idm\selector\IdmExgDfnSelector.f90"/>
-		<File RelativePath="..\src\Idm\selector\IdmGweDfnSelector.f90"/>
-		<File RelativePath="..\src\Idm\selector\IdmGwfDfnSelector.f90"/>
-		<File RelativePath="..\src\Idm\selector\IdmGwtDfnSelector.f90"/>
-		<File RelativePath="..\src\Idm\selector\IdmPrtDfnSelector.f90"/>
-		<File RelativePath="..\src\Idm\selector\IdmSimDfnSelector.f90"/>
-		<File RelativePath="..\src\Idm\selector\IdmSwfDfnSelector.f90"/>
-		<File RelativePath="..\src\Idm\selector\IdmUtlDfnSelector.f90"/></Filter>
-		<File RelativePath="..\src\Idm\exg-gwegweidm.f90"/>
-		<File RelativePath="..\src\Idm\exg-gwfgweidm.f90"/>
-		<File RelativePath="..\src\Idm\exg-gwfgwfidm.f90"/>
-		<File RelativePath="..\src\Idm\exg-gwfgwtidm.f90"/>
-		<File RelativePath="..\src\Idm\exg-gwfprtidm.f90"/>
-		<File RelativePath="..\src\Idm\exg-gwtgwtidm.f90"/>
-		<File RelativePath="..\src\Idm\exg-swfgwfidm.f90"/>
-		<File RelativePath="..\src\Idm\gwe-cndidm.f90"/>
-		<File RelativePath="..\src\Idm\gwe-ctpidm.f90"/>
-		<File RelativePath="..\src\Idm\gwe-disidm.f90"/>
-		<File RelativePath="..\src\Idm\gwe-disuidm.f90"/>
-		<File RelativePath="..\src\Idm\gwe-disvidm.f90"/>
-		<File RelativePath="..\src\Idm\gwe-icidm.f90"/>
-		<File RelativePath="..\src\Idm\gwe-namidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-chdidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-disidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-disuidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-disvidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-drnidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-evtaidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-evtidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-ghbidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-icidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-namidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-npfidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-rchaidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-rchidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-rividm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-stoidm.f90"/>
-		<File RelativePath="..\src\Idm\gwf-welidm.f90"/>
-		<File RelativePath="..\src\Idm\gwt-cncidm.f90"/>
-		<File RelativePath="..\src\Idm\gwt-disidm.f90"/>
-		<File RelativePath="..\src\Idm\gwt-disuidm.f90"/>
-		<File RelativePath="..\src\Idm\gwt-disvidm.f90"/>
-		<File RelativePath="..\src\Idm\gwt-dspidm.f90"/>
-		<File RelativePath="..\src\Idm\gwt-icidm.f90"/>
-		<File RelativePath="..\src\Idm\gwt-namidm.f90"/>
-		<File RelativePath="..\src\Idm\prt-disidm.f90"/>
-		<File RelativePath="..\src\Idm\prt-disvidm.f90"/>
-		<File RelativePath="..\src\Idm\prt-mipidm.f90"/>
-		<File RelativePath="..\src\Idm\prt-namidm.f90"/>
-		<File RelativePath="..\src\Idm\sim-namidm.f90"/>
-		<File RelativePath="..\src\Idm\sim-tdisidm.f90"/>
-		<File RelativePath="..\src\Idm\swf-cdbidm.f90"/>
-		<File RelativePath="..\src\Idm\swf-chdidm.f90"/>
-		<File RelativePath="..\src\Idm\swf-cxsidm.f90"/>
-		<File RelativePath="..\src\Idm\swf-dfwidm.f90"/>
-		<File RelativePath="..\src\Idm\swf-dis2didm.f90"/>
-		<File RelativePath="..\src\Idm\swf-disv1didm.f90"/>
-		<File RelativePath="..\src\Idm\swf-disv2didm.f90"/>
-		<File RelativePath="..\src\Idm\swf-flwidm.f90"/>
-		<File RelativePath="..\src\Idm\swf-icidm.f90"/>
-		<File RelativePath="..\src\Idm\swf-namidm.f90"/>
-		<File RelativePath="..\src\Idm\swf-stoidm.f90"/>
-		<File RelativePath="..\src\Idm\swf-zdgidm.f90"/>
-		<File RelativePath="..\src\Idm\utl-hpcidm.f90"/>
-		<File RelativePath="..\src\Idm\utl-ncfidm.f90"/></Filter>
-		<Filter Name="Model">
-		<Filter Name="Connection">
-		<File RelativePath="..\src\Model\Connection\CellWithNbrs.f90"/>
-		<File RelativePath="..\src\Model\Connection\ConnectionBuilder.f90"/>
-		<File RelativePath="..\src\Model\Connection\CsrUtils.f90"/>
-		<File RelativePath="..\src\Model\Connection\DistributedVariable.f90"/>
-		<File RelativePath="..\src\Model\Connection\GridConnection.f90"/>
-		<File RelativePath="..\src\Model\Connection\GridSorting.f90"/>
-		<File RelativePath="..\src\Model\Connection\GweGweConnection.f90"/>
-		<File RelativePath="..\src\Model\Connection\GweInterfaceModel.f90"/>
-		<File RelativePath="..\src\Model\Connection\GwfGwfConnection.f90"/>
-		<File RelativePath="..\src\Model\Connection\GwfInterfaceModel.f90"/>
-		<File RelativePath="..\src\Model\Connection\GwtGwtConnection.f90"/>
-		<File RelativePath="..\src\Model\Connection\GwtInterfaceModel.f90"/>
-		<File RelativePath="..\src\Model\Connection\qsort_inline.inc"/>
-		<File RelativePath="..\src\Model\Connection\SpatialModelConnection.f90"/></Filter>
-		<Filter Name="Discretization">
-		<File RelativePath="..\src\Model\Discretization\Dis.f90"/>
-		<File RelativePath="..\src\Model\Discretization\Dis2d.f90"/>
-		<File RelativePath="..\src\Model\Discretization\Disu.f90"/>
-		<File RelativePath="..\src\Model\Discretization\Disv.f90"/>
-		<File RelativePath="..\src\Model\Discretization\Disv1d.f90"/>
-		<File RelativePath="..\src\Model\Discretization\Disv2d.f90"/></Filter>
-		<Filter Name="Geometry">
-		<File RelativePath="..\src\Model\Geometry\BaseGeometry.f90"/>
-		<File RelativePath="..\src\Model\Geometry\CircularGeometry.f90"/>
-		<File RelativePath="..\src\Model\Geometry\RectangularGeometry.f90"/></Filter>
-		<Filter Name="GroundWaterEnergy">
-		<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-cnd.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-ctp.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-esl.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-est.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-lke.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-mwe.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-sfe.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-uze.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterEnergy\gwe.f90"/></Filter>
-		<Filter Name="GroundWaterFlow">
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-api.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-buy.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-chd.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-csub.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-drn.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-evt.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-ghb.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-hfb.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-ic.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-lak.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-maw.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-mvr.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-npf.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-obs.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-oc.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-rch.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-riv.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-sfr.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-sto.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-tvk.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-tvs.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-uzf.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-vsc.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf-wel.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\gwf.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\TvBase.f90"/>
-		<Filter Name="submodules">
-		<File RelativePath="..\src\Model\GroundWaterFlow\submodules\gwf-sfr-constant.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterFlow\submodules\gwf-sfr-steady.f90"/></Filter></Filter>
-		<Filter Name="GroundWaterTransport">
-		<File RelativePath="..\src\Model\GroundWaterTransport\gwt-cnc.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterTransport\gwt-dsp.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterTransport\gwt-ist.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterTransport\gwt-lkt.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterTransport\gwt-mst.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterTransport\gwt-mwt.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterTransport\gwt-sft.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterTransport\gwt-src.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterTransport\gwt-uzt.f90"/>
-		<File RelativePath="..\src\Model\GroundWaterTransport\gwt.f90"/></Filter>
-		<Filter Name="ModelUtilities">
-		<File RelativePath="..\src\Model\ModelUtilities\BoundaryPackage.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\BoundaryPackageExt.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\Connections.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\DiscretizationBase.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\Disv1dGeom.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\DisvGeom.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\FlowModelInterface.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\GweCndOptions.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\GweInputData.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\GwfBuyInputData.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\GwfConductanceUtils.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\GwfMvrPeriodData.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\GwfNpfOptions.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\GwfStorageUtils.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\GwfVscInputData.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\GwtDspOptions.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\GwtSpc.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\ModelPackageInput.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\Mover.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\PackageMover.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\SfrCrossSectionManager.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\SfrCrossSectionUtils.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\SwfCxsUtils.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\TimeSelect.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\TimeStepSelect.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\TrackData.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\TspAdvOptions.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\UzfCellGroup.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\VectorInterpolation.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\Xt3dAlgorithm.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\Xt3dInterface.f90"/></Filter>
-		<Filter Name="ParticleTracking">
-		<File RelativePath="..\src\Model\ParticleTracking\prt-fmi.f90"/>
-		<File RelativePath="..\src\Model\ParticleTracking\prt-mip.f90"/>
-		<File RelativePath="..\src\Model\ParticleTracking\prt-oc.f90"/>
-		<File RelativePath="..\src\Model\ParticleTracking\prt-prp.f90"/>
-		<File RelativePath="..\src\Model\ParticleTracking\prt.f90"/></Filter>
-		<Filter Name="SurfaceWaterFlow">
-		<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-cdb.f90"/>
-		<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-cxs.f90"/>
-		<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-dfw.f90"/>
-		<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-flw.f90"/>
-		<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-ic.f90"/>
-		<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-obs.f90"/>
-		<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-oc.f90"/>
-		<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-sto.f90"/>
-		<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-zdg.f90"/>
-		<File RelativePath="..\src\Model\SurfaceWaterFlow\swf.f90"/></Filter>
-		<Filter Name="TransportModel">
-		<File RelativePath="..\src\Model\TransportModel\tsp-adv.f90"/>
-		<File RelativePath="..\src\Model\TransportModel\tsp-apt.f90"/>
-		<File RelativePath="..\src\Model\TransportModel\tsp-fmi.f90"/>
-		<File RelativePath="..\src\Model\TransportModel\tsp-ic.f90"/>
-		<File RelativePath="..\src\Model\TransportModel\tsp-mvt.f90"/>
-		<File RelativePath="..\src\Model\TransportModel\tsp-obs.f90"/>
-		<File RelativePath="..\src\Model\TransportModel\tsp-oc.f90"/>
-		<File RelativePath="..\src\Model\TransportModel\tsp-ssm.f90"/>
-		<File RelativePath="..\src\Model\TransportModel\tsp.f90"/></Filter>
-		<File RelativePath="..\src\Model\BaseModel.f90"/>
-		<File RelativePath="..\src\Model\ExplicitModel.f90"/>
-		<File RelativePath="..\src\Model\NumericalModel.f90"/>
-		<File RelativePath="..\src\Model\NumericalPackage.f90"/></Filter>
-		<Filter Name="Solution">
-		<Filter Name="LinearMethods">
-		<File RelativePath="..\src\Solution\LinearMethods\ImsLinear.f90"/>
-		<File RelativePath="..\src\Solution\LinearMethods\ImsLinearBase.f90"/>
-		<File RelativePath="..\src\Solution\LinearMethods\ImsLinearMisc.f90"/>
-		<File RelativePath="..\src\Solution\LinearMethods\ImsLinearSettings.f90"/>
-		<File RelativePath="..\src\Solution\LinearMethods\ImsLinearSolver.f90"/>
-		<File RelativePath="..\src\Solution\LinearMethods\ImsReordering.f90"/></Filter>
-		<Filter Name="ParticleTracker">
-		<File RelativePath="..\src\Solution\ParticleTracker\Cell.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\CellDefn.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\CellPoly.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\CellRect.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\CellRectQuad.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\CellUtil.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\Method.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodCellPassToBot.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodCellPollock.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodCellPollockQuad.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodCellPool.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodCellTernary.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodDis.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodDisv.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodPool.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodSubcellPollock.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodSubcellPool.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\MethodSubcellTernary.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\Particle.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\Subcell.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\SubcellRect.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\SubcellTri.f90"/>
-		<File RelativePath="..\src\Solution\ParticleTracker\TernarySolveTrack.f90"/></Filter>
-		<Filter Name="PETSc">
-		<File RelativePath="..\src\Solution\PETSc\PetscConvergence.F90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Solution\PETSc\PetscImsPreconditioner.F90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Solution\PETSc\PetscSolver.F90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File></Filter>
-		<File RelativePath="..\src\Solution\BaseSolution.f90"/>
-		<File RelativePath="..\src\Solution\ConvergenceSummary.f90"/>
-		<File RelativePath="..\src\Solution\ExplicitSolution.f90"/>
-		<File RelativePath="..\src\Solution\LinearSolverBase.f90"/>
-		<File RelativePath="..\src\Solution\LinearSolverFactory.F90">
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\src\Solution\NumericalSolution.f90"/>
-		<File RelativePath="..\src\Solution\ParallelSolution.f90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Solution\SolutionFactory.F90">
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\src\Solution\SolutionGroup.f90"/></Filter>
-		<Filter Name="Timing">
-		<File RelativePath="..\src\Timing\ats.f90"/>
-		<File RelativePath="..\src\Timing\tdis.f90"/></Filter>
-		<Filter Name="Utilities">
-		<Filter Name="ArrayRead">
-		<File RelativePath="..\src\Utilities\ArrayRead\ArrayReaderBase.f90"/>
-		<File RelativePath="..\src\Utilities\ArrayRead\Double1dReader.f90"/>
-		<File RelativePath="..\src\Utilities\ArrayRead\Double2dReader.f90"/>
-		<File RelativePath="..\src\Utilities\ArrayRead\Integer1dReader.f90"/>
-		<File RelativePath="..\src\Utilities\ArrayRead\Integer2dReader.f90"/>
-		<File RelativePath="..\src\Utilities\ArrayRead\LayeredArrayReader.f90"/></Filter>
-		<Filter Name="Export">
-		<File RelativePath="..\src\Utilities\Export\DisNCMesh.f90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Utilities\Export\DisvNCMesh.f90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Utilities\Export\MeshNCModel.f90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Utilities\Export\NCExportCreate.f90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Utilities\Export\ModelExport.f90"/>
-		<File RelativePath="..\src\Utilities\Export\NCModel.f90"/></Filter>
-		<Filter Name="Idm">
-		<Filter Name="mf6blockfile">
-		<File RelativePath="..\src\Utilities\Idm\mf6blockfile\AsciiInputLoadType.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\mf6blockfile\IdmMf6File.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\mf6blockfile\LoadMf6File.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\mf6blockfile\Mf6FileGridInput.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\mf6blockfile\Mf6FileListInput.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\mf6blockfile\Mf6FileStoInput.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\mf6blockfile\StructArray.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\mf6blockfile\StructVector.f90"/></Filter>
-		<File RelativePath="..\src\Utilities\Idm\BoundInputContext.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\DefinitionSelect.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\DynamicPackageParams.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\IdmLoad.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\IdmLogger.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\InputDefinition.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\InputLoadType.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\ModelPackageInputs.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\ModflowInput.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\SourceCommon.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\SourceLoad.F90">
-		<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File></Filter>
-		<Filter Name="Libraries">
-		<File RelativePath="..\src\Utilities\Libraries\blas\blas1_d.f90"/>
-		<File RelativePath="..\src\Utilities\Libraries\daglib\dag_module.f90"/>
-		<File RelativePath="..\src\Utilities\Libraries\sparskit2\ilut.f90"/>
-		<File RelativePath="..\src\Utilities\Libraries\rcm\rcm.f90"/>
-		<File RelativePath="..\src\Utilities\Libraries\sparsekit\sparsekit.f90"/></Filter>
-		<Filter Name="Matrix">
-		<File RelativePath="..\src\Utilities\Matrix\MatrixBase.f90"/>
-		<File RelativePath="..\src\Utilities\Matrix\PetscMatrix.F90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Utilities\Matrix\SparseMatrix.f90"/></Filter>
-		<Filter Name="Memory">
-		<File RelativePath="..\src\Utilities\Memory\Memory.f90"/>
-		<File RelativePath="..\src\Utilities\Memory\MemoryContainerIterator.f90"/>
-		<File RelativePath="..\src\Utilities\Memory\MemoryHelper.f90"/>
-		<File RelativePath="..\src\Utilities\Memory\MemoryManager.f90"/>
-		<File RelativePath="..\src\Utilities\Memory\MemoryManagerExt.f90"/>
-		<File RelativePath="..\src\Utilities\Memory\MemorySetHandler.f90"/>
-		<File RelativePath="..\src\Utilities\Memory\MemoryStore.f90"/></Filter>
-		<Filter Name="Observation">
-		<File RelativePath="..\src\Utilities\Observation\Obs.f90"/>
-		<File RelativePath="..\src\Utilities\Observation\ObsContainer.f90"/>
-		<File RelativePath="..\src\Utilities\Observation\Observe.f90"/>
-		<File RelativePath="..\src\Utilities\Observation\ObsOutput.f90"/>
-		<File RelativePath="..\src\Utilities\Observation\ObsOutputList.f90"/>
-		<File RelativePath="..\src\Utilities\Observation\ObsUtility.f90"/></Filter>
-		<Filter Name="OutputControl">
-		<File RelativePath="..\src\Utilities\OutputControl\OutputControl.f90"/>
-		<File RelativePath="..\src\Utilities\OutputControl\OutputControlData.f90"/>
-		<File RelativePath="..\src\Utilities\OutputControl\PrintSaveManager.f90"/></Filter>
-		<Filter Name="TimeSeries">
-		<File RelativePath="..\src\Utilities\TimeSeries\TimeArray.f90"/>
-		<File RelativePath="..\src\Utilities\TimeSeries\TimeArraySeries.f90"/>
-		<File RelativePath="..\src\Utilities\TimeSeries\TimeArraySeriesLink.f90"/>
-		<File RelativePath="..\src\Utilities\TimeSeries\TimeArraySeriesManager.f90"/>
-		<File RelativePath="..\src\Utilities\TimeSeries\TimeSeries.f90"/>
-		<File RelativePath="..\src\Utilities\TimeSeries\TimeSeriesFileList.f90"/>
-		<File RelativePath="..\src\Utilities\TimeSeries\TimeSeriesLink.f90"/>
-		<File RelativePath="..\src\Utilities\TimeSeries\TimeSeriesManager.f90"/>
-		<File RelativePath="..\src\Utilities\TimeSeries\TimeSeriesRecord.f90"/></Filter>
-		<Filter Name="Vector">
-		<File RelativePath="..\src\Utilities\Vector\PetscVector.F90">
-			<FileConfiguration Name="Debug|Win32" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true"/>
-			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
-		<File RelativePath="..\src\Utilities\Vector\SeqVector.f90"/>
-		<File RelativePath="..\src\Utilities\Vector\VectorBase.f90"/></Filter>
-		<File RelativePath="..\src\Utilities\ArrayHandlers.f90"/>
-		<File RelativePath="..\src\Utilities\ArrayReaders.f90"/>
-		<File RelativePath="..\src\Utilities\BlockParser.f90"/>
-		<File RelativePath="..\src\Utilities\Budget.f90"/>
-		<File RelativePath="..\src\Utilities\BudgetFileReader.f90"/>
-		<File RelativePath="..\src\Utilities\BudgetObject.f90"/>
-		<File RelativePath="..\src\Utilities\BudgetTerm.f90"/>
-		<File RelativePath="..\src\Utilities\CharString.f90"/>
-		<File RelativePath="..\src\Utilities\comarg.f90"/>
-		<File RelativePath="..\src\Utilities\compilerversion.F90">
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\src\Utilities\Constants.f90"/>
-		<File RelativePath="..\src\Utilities\defmacro.F90">
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\src\Utilities\DevFeature.f90"/>
-		<File RelativePath="..\src\Utilities\ErrorUtil.f90"/>
-		<File RelativePath="..\src\Utilities\GeomUtil.f90"/>
-		<File RelativePath="..\src\Utilities\HashTable.f90"/>
-		<File RelativePath="..\src\Utilities\HeadFileReader.f90"/>
-		<File RelativePath="..\src\Utilities\HGeoUtil.f90"/>
-		<File RelativePath="..\src\Utilities\InputOutput.f90"/>
-		<File RelativePath="..\src\Utilities\Iterator.f90"/>
-		<File RelativePath="..\src\Utilities\Iunit.f90"/>
-		<File RelativePath="..\src\Utilities\KeyValueList.f90"/>
-		<File RelativePath="..\src\Utilities\KeyValueListIterator.f90"/>
-		<File RelativePath="..\src\Utilities\KeyValueNode.f90"/>
-		<File RelativePath="..\src\Utilities\kind.f90"/>
-		<File RelativePath="..\src\Utilities\List.f90"/>
-		<File RelativePath="..\src\Utilities\ListIterator.f90"/>
-		<File RelativePath="..\src\Utilities\ListNode.f90"/>
-		<File RelativePath="..\src\Utilities\ListReader.f90"/>
-		<File RelativePath="..\src\Utilities\LongLineReader.f90"/>
-		<File RelativePath="..\src\Utilities\MathUtil.f90"/>
-		<File RelativePath="..\src\Utilities\Message.f90"/>
-		<File RelativePath="..\src\Utilities\OpenSpec.f90"/>
-		<File RelativePath="..\src\Utilities\PackageBudget.f90"/>
-		<File RelativePath="..\src\Utilities\PtrHashTable.f90"/>
-		<File RelativePath="..\src\Utilities\PtrHashTableIterator.f90"/>
-		<File RelativePath="..\src\Utilities\Sim.f90"/>
-		<File RelativePath="..\src\Utilities\SimStages.f90"/>
-		<File RelativePath="..\src\Utilities\SimVariables.f90"/>
-		<File RelativePath="..\src\Utilities\SmoothingFunctions.f90"/>
-		<File RelativePath="..\src\Utilities\sort.f90"/>
-		<File RelativePath="..\src\Utilities\Sparse.f90"/>
-		<File RelativePath="..\src\Utilities\STLVecInt.f90"/>
-		<File RelativePath="..\src\Utilities\StringList.f90"/>
-		<File RelativePath="..\src\Utilities\Table.f90"/>
-		<File RelativePath="..\src\Utilities\TableTerm.f90"/>
-		<File RelativePath="..\src\Utilities\Timer.f90"/>
-		<File RelativePath="..\src\Utilities\version.f90"/></Filter>
-		<File RelativePath="..\src\mf6core.f90"/>
-		<File RelativePath="..\src\mf6lists.f90"/>
-		<File RelativePath="..\src\RunControl.f90"/>
-		<File RelativePath="..\src\RunControlFactory.F90">
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\src\SimulationCreate.f90"/></Filter></Files>
-	<Globals/></VisualStudioProject>
+			<Filter Name="Distributed">
+				<File RelativePath="..\src\Distributed\DistributedSim.f90"/>
+				<File RelativePath="..\src\Distributed\IndexMap.f90"/>
+				<File RelativePath="..\src\Distributed\InterfaceMap.f90"/>
+				<File RelativePath="..\src\Distributed\MappedMemory.f90"/>
+				<File RelativePath="..\src\Distributed\Mapper.f90"/>
+				<File RelativePath="..\src\Distributed\MpiMessageBuilder.f90">
+					<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Distributed\MpiMessageCache.f90">
+					<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Distributed\MpiRouter.f90">
+					<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Distributed\MpiRunControl.F90">
+					<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Distributed\MpiUnitCache.f90">
+					<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Distributed\MpiWorld.f90">
+					<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Distributed\RouterBase.f90"/>
+				<File RelativePath="..\src\Distributed\RouterFactory.F90">
+					<FileConfiguration Name="Release|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Distributed\SerialRouter.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualBase.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualDataContainer.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualDataLists.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualDataManager.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualExchange.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualGweExchange.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualGweModel.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualGwfExchange.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualGwfModel.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualGwtExchange.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualGwtModel.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualModel.f90"/>
+				<File RelativePath="..\src\Distributed\VirtualSolution.f90"/>
+			</Filter>
+			<Filter Name="Exchange">
+				<File RelativePath="..\src\Exchange\BaseExchange.f90"/>
+				<File RelativePath="..\src\Exchange\DisConnExchange.f90"/>
+				<File RelativePath="..\src\Exchange\exg-gwegwe.f90"/>
+				<File RelativePath="..\src\Exchange\exg-gwfgwe.f90"/>
+				<File RelativePath="..\src\Exchange\exg-gwfgwf.f90"/>
+				<File RelativePath="..\src\Exchange\exg-gwfgwt.f90"/>
+				<File RelativePath="..\src\Exchange\exg-gwfprt.f90"/>
+				<File RelativePath="..\src\Exchange\exg-gwtgwt.f90"/>
+				<File RelativePath="..\src\Exchange\exg-swfgwf.f90"/>
+				<File RelativePath="..\src\Exchange\GhostNode.f90"/>
+				<File RelativePath="..\src\Exchange\GwfExchangeMover.f90"/>
+				<File RelativePath="..\src\Exchange\NumericalExchange.f90"/>
+			</Filter>
+			<Filter Name="Idm">
+				<Filter Name="selector">
+					<File RelativePath="..\src\Idm\selector\IdmDfnSelector.f90"/>
+					<File RelativePath="..\src\Idm\selector\IdmExgDfnSelector.f90"/>
+					<File RelativePath="..\src\Idm\selector\IdmGweDfnSelector.f90"/>
+					<File RelativePath="..\src\Idm\selector\IdmGwfDfnSelector.f90"/>
+					<File RelativePath="..\src\Idm\selector\IdmGwtDfnSelector.f90"/>
+					<File RelativePath="..\src\Idm\selector\IdmPrtDfnSelector.f90"/>
+					<File RelativePath="..\src\Idm\selector\IdmSimDfnSelector.f90"/>
+					<File RelativePath="..\src\Idm\selector\IdmSwfDfnSelector.f90"/>
+					<File RelativePath="..\src\Idm\selector\IdmUtlDfnSelector.f90"/>
+				</Filter>
+				<File RelativePath="..\src\Idm\exg-gwegweidm.f90"/>
+				<File RelativePath="..\src\Idm\exg-gwfgweidm.f90"/>
+				<File RelativePath="..\src\Idm\exg-gwfgwfidm.f90"/>
+				<File RelativePath="..\src\Idm\exg-gwfgwtidm.f90"/>
+				<File RelativePath="..\src\Idm\exg-gwfprtidm.f90"/>
+				<File RelativePath="..\src\Idm\exg-gwtgwtidm.f90"/>
+				<File RelativePath="..\src\Idm\exg-swfgwfidm.f90"/>
+				<File RelativePath="..\src\Idm\gwe-cndidm.f90"/>
+				<File RelativePath="..\src\Idm\gwe-ctpidm.f90"/>
+				<File RelativePath="..\src\Idm\gwe-disidm.f90"/>
+				<File RelativePath="..\src\Idm\gwe-disuidm.f90"/>
+				<File RelativePath="..\src\Idm\gwe-disvidm.f90"/>
+				<File RelativePath="..\src\Idm\gwe-icidm.f90"/>
+				<File RelativePath="..\src\Idm\gwe-namidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-chdidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-disidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-disuidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-disvidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-drnidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-evtaidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-evtidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-ghbidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-icidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-namidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-npfidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-rchaidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-rchidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-rividm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-stoidm.f90"/>
+				<File RelativePath="..\src\Idm\gwf-welidm.f90"/>
+				<File RelativePath="..\src\Idm\gwt-cncidm.f90"/>
+				<File RelativePath="..\src\Idm\gwt-disidm.f90"/>
+				<File RelativePath="..\src\Idm\gwt-disuidm.f90"/>
+				<File RelativePath="..\src\Idm\gwt-disvidm.f90"/>
+				<File RelativePath="..\src\Idm\gwt-dspidm.f90"/>
+				<File RelativePath="..\src\Idm\gwt-icidm.f90"/>
+				<File RelativePath="..\src\Idm\gwt-namidm.f90"/>
+				<File RelativePath="..\src\Idm\prt-disidm.f90"/>
+				<File RelativePath="..\src\Idm\prt-disvidm.f90"/>
+				<File RelativePath="..\src\Idm\prt-mipidm.f90"/>
+				<File RelativePath="..\src\Idm\prt-namidm.f90"/>
+				<File RelativePath="..\src\Idm\sim-namidm.f90"/>
+				<File RelativePath="..\src\Idm\sim-tdisidm.f90"/>
+				<File RelativePath="..\src\Idm\swf-cdbidm.f90"/>
+				<File RelativePath="..\src\Idm\swf-chdidm.f90"/>
+				<File RelativePath="..\src\Idm\swf-cxsidm.f90"/>
+				<File RelativePath="..\src\Idm\swf-dfwidm.f90"/>
+				<File RelativePath="..\src\Idm\swf-dis2didm.f90"/>
+				<File RelativePath="..\src\Idm\swf-disv1didm.f90"/>
+				<File RelativePath="..\src\Idm\swf-disv2didm.f90"/>
+				<File RelativePath="..\src\Idm\swf-flwidm.f90"/>
+				<File RelativePath="..\src\Idm\swf-icidm.f90"/>
+				<File RelativePath="..\src\Idm\swf-namidm.f90"/>
+				<File RelativePath="..\src\Idm\swf-stoidm.f90"/>
+				<File RelativePath="..\src\Idm\swf-zdgidm.f90"/>
+				<File RelativePath="..\src\Idm\utl-hpcidm.f90"/>
+				<File RelativePath="..\src\Idm\utl-ncfidm.f90"/>
+			</Filter>
+			<Filter Name="Model">
+				<Filter Name="Connection">
+					<File RelativePath="..\src\Model\Connection\CellWithNbrs.f90"/>
+					<File RelativePath="..\src\Model\Connection\ConnectionBuilder.f90"/>
+					<File RelativePath="..\src\Model\Connection\CsrUtils.f90"/>
+					<File RelativePath="..\src\Model\Connection\DistributedVariable.f90"/>
+					<File RelativePath="..\src\Model\Connection\GridConnection.f90"/>
+					<File RelativePath="..\src\Model\Connection\GridSorting.f90"/>
+					<File RelativePath="..\src\Model\Connection\GweGweConnection.f90"/>
+					<File RelativePath="..\src\Model\Connection\GweInterfaceModel.f90"/>
+					<File RelativePath="..\src\Model\Connection\GwfGwfConnection.f90"/>
+					<File RelativePath="..\src\Model\Connection\GwfInterfaceModel.f90"/>
+					<File RelativePath="..\src\Model\Connection\GwtGwtConnection.f90"/>
+					<File RelativePath="..\src\Model\Connection\GwtInterfaceModel.f90"/>
+					<File RelativePath="..\src\Model\Connection\qsort_inline.inc">
+						<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\src\Model\Connection\SpatialModelConnection.f90"/>
+				</Filter>
+				<Filter Name="Discretization">
+					<File RelativePath="..\src\Model\Discretization\Dis.f90"/>
+					<File RelativePath="..\src\Model\Discretization\Dis2d.f90"/>
+					<File RelativePath="..\src\Model\Discretization\Disu.f90"/>
+					<File RelativePath="..\src\Model\Discretization\Disv.f90"/>
+					<File RelativePath="..\src\Model\Discretization\Disv1d.f90"/>
+					<File RelativePath="..\src\Model\Discretization\Disv2d.f90"/>
+				</Filter>
+				<Filter Name="Geometry">
+					<File RelativePath="..\src\Model\Geometry\BaseGeometry.f90"/>
+					<File RelativePath="..\src\Model\Geometry\CircularGeometry.f90"/>
+					<File RelativePath="..\src\Model\Geometry\RectangularGeometry.f90"/>
+				</Filter>
+				<Filter Name="GroundWaterEnergy">
+					<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-cnd.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-ctp.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-esl.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-est.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-lke.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-mwe.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-sfe.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterEnergy\gwe-uze.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterEnergy\gwe.f90"/>
+				</Filter>
+				<Filter Name="GroundWaterFlow">
+					<Filter Name="submodules">
+						<File RelativePath="..\src\Model\GroundWaterFlow\submodules\gwf-sfr-constant.f90"/>
+						<File RelativePath="..\src\Model\GroundWaterFlow\submodules\gwf-sfr-steady.f90"/>
+					</Filter>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-api.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-buy.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-chd.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-csub.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-drn.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-evt.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-ghb.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-hfb.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-ic.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-lak.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-maw.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-mvr.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-npf.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-obs.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-oc.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-rch.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-riv.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-sfr.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-sto.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-tvk.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-tvs.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-uzf.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-vsc.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf-wel.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\gwf.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterFlow\TvBase.f90"/>
+				</Filter>
+				<Filter Name="GroundWaterTransport">
+					<File RelativePath="..\src\Model\GroundWaterTransport\gwt-cnc.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterTransport\gwt-dsp.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterTransport\gwt-ist.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterTransport\gwt-lkt.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterTransport\gwt-mst.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterTransport\gwt-mwt.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterTransport\gwt-sft.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterTransport\gwt-src.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterTransport\gwt-uzt.f90"/>
+					<File RelativePath="..\src\Model\GroundWaterTransport\gwt.f90"/>
+				</Filter>
+				<Filter Name="ModelUtilities">
+					<File RelativePath="..\src\Model\ModelUtilities\BoundaryPackage.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\BoundaryPackageExt.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\Connections.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\DiscretizationBase.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\Disv1dGeom.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\DisvGeom.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\FlowModelInterface.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\GweCndOptions.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\GweInputData.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\GwfBuyInputData.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\GwfConductanceUtils.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\GwfMvrPeriodData.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\GwfNpfOptions.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\GwfStorageUtils.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\GwfVscInputData.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\GwtDspOptions.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\GwtSpc.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\ModelPackageInput.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\Mover.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\PackageMover.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\SfrCrossSectionManager.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\SfrCrossSectionUtils.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\SwfCxsUtils.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\TimeSelect.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\TimeStepSelect.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\TrackData.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\TspAdvOptions.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\UzfCellGroup.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\VectorInterpolation.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\Xt3dAlgorithm.f90"/>
+					<File RelativePath="..\src\Model\ModelUtilities\Xt3dInterface.f90"/>
+				</Filter>
+				<Filter Name="ParticleTracking">
+					<File RelativePath="..\src\Model\ParticleTracking\prt-fmi.f90"/>
+					<File RelativePath="..\src\Model\ParticleTracking\prt-mip.f90"/>
+					<File RelativePath="..\src\Model\ParticleTracking\prt-oc.f90"/>
+					<File RelativePath="..\src\Model\ParticleTracking\prt-prp.f90"/>
+					<File RelativePath="..\src\Model\ParticleTracking\prt.f90"/>
+				</Filter>
+				<Filter Name="SurfaceWaterFlow">
+					<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-cdb.f90"/>
+					<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-cxs.f90"/>
+					<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-dfw.f90"/>
+					<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-flw.f90"/>
+					<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-ic.f90"/>
+					<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-obs.f90"/>
+					<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-oc.f90"/>
+					<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-sto.f90"/>
+					<File RelativePath="..\src\Model\SurfaceWaterFlow\swf-zdg.f90"/>
+					<File RelativePath="..\src\Model\SurfaceWaterFlow\swf.f90"/>
+				</Filter>
+				<Filter Name="TransportModel">
+					<File RelativePath="..\src\Model\TransportModel\tsp-adv.f90"/>
+					<File RelativePath="..\src\Model\TransportModel\tsp-apt.f90"/>
+					<File RelativePath="..\src\Model\TransportModel\tsp-fmi.f90"/>
+					<File RelativePath="..\src\Model\TransportModel\tsp-ic.f90"/>
+					<File RelativePath="..\src\Model\TransportModel\tsp-mvt.f90"/>
+					<File RelativePath="..\src\Model\TransportModel\tsp-obs.f90"/>
+					<File RelativePath="..\src\Model\TransportModel\tsp-oc.f90"/>
+					<File RelativePath="..\src\Model\TransportModel\tsp-ssm.f90"/>
+					<File RelativePath="..\src\Model\TransportModel\tsp.f90"/>
+				</Filter>
+				<File RelativePath="..\src\Model\BaseModel.f90"/>
+				<File RelativePath="..\src\Model\ExplicitModel.f90"/>
+				<File RelativePath="..\src\Model\NumericalModel.f90"/>
+				<File RelativePath="..\src\Model\NumericalPackage.f90"/>
+			</Filter>
+			<Filter Name="Solution">
+				<Filter Name="LinearMethods">
+					<File RelativePath="..\src\Solution\LinearMethods\ImsLinear.f90"/>
+					<File RelativePath="..\src\Solution\LinearMethods\ImsLinearBase.f90"/>
+					<File RelativePath="..\src\Solution\LinearMethods\ImsLinearMisc.f90"/>
+					<File RelativePath="..\src\Solution\LinearMethods\ImsLinearSettings.f90"/>
+					<File RelativePath="..\src\Solution\LinearMethods\ImsLinearSolver.f90"/>
+					<File RelativePath="..\src\Solution\LinearMethods\ImsReordering.f90"/>
+				</Filter>
+				<Filter Name="ParticleTracker">
+					<File RelativePath="..\src\Solution\ParticleTracker\Cell.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\CellDefn.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\CellPoly.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\CellRect.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\CellRectQuad.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\CellUtil.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\Method.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodCellPassToBot.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodCellPollock.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodCellPollockQuad.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodCellPool.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodCellTernary.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodDis.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodDisv.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodPool.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodSubcellPollock.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodSubcellPool.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\MethodSubcellTernary.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\Particle.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\Subcell.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\SubcellRect.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\SubcellTri.f90"/>
+					<File RelativePath="..\src\Solution\ParticleTracker\TernarySolveTrack.f90"/>
+				</Filter>
+				<Filter Name="PETSc">
+					<File RelativePath="..\src\Solution\PETSc\PetscConvergence.F90">
+						<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\src\Solution\PETSc\PetscImsPreconditioner.F90">
+						<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\src\Solution\PETSc\PetscSolver.F90">
+						<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+					</File>
+				</Filter>
+				<File RelativePath="..\src\Solution\BaseSolution.f90"/>
+				<File RelativePath="..\src\Solution\ConvergenceSummary.f90"/>
+				<File RelativePath="..\src\Solution\ExplicitSolution.f90"/>
+				<File RelativePath="..\src\Solution\LinearSolverBase.f90"/>
+				<File RelativePath="..\src\Solution\LinearSolverFactory.F90">
+					<FileConfiguration Name="Release|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Solution\NumericalSolution.f90"/>
+				<File RelativePath="..\src\Solution\ParallelSolution.f90">
+					<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Solution\SolutionFactory.F90">
+					<FileConfiguration Name="Release|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Solution\SolutionGroup.f90"/>
+			</Filter>
+			<Filter Name="Timing">
+				<File RelativePath="..\src\Timing\ats.f90"/>
+				<File RelativePath="..\src\Timing\tdis.f90"/>
+			</Filter>
+			<Filter Name="Utilities">
+				<Filter Name="ArrayRead">
+					<File RelativePath="..\src\Utilities\ArrayRead\ArrayReaderBase.f90"/>
+					<File RelativePath="..\src\Utilities\ArrayRead\Double1dReader.f90"/>
+					<File RelativePath="..\src\Utilities\ArrayRead\Double2dReader.f90"/>
+					<File RelativePath="..\src\Utilities\ArrayRead\Integer1dReader.f90"/>
+					<File RelativePath="..\src\Utilities\ArrayRead\Integer2dReader.f90"/>
+					<File RelativePath="..\src\Utilities\ArrayRead\LayeredArrayReader.f90"/>
+				</Filter>
+				<Filter Name="Export">
+					<File RelativePath="..\src\Utilities\Export\DisNCMesh.f90">
+						<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\src\Utilities\Export\DisvNCMesh.f90">
+						<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\src\Utilities\Export\MeshNCModel.f90">
+						<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\src\Utilities\Export\ModelExport.f90"/>
+					<File RelativePath="..\src\Utilities\Export\NCExportCreate.f90">
+						<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\src\Utilities\Export\NCModel.f90"/>
+				</Filter>
+				<Filter Name="Idm">
+					<Filter Name="mf6blockfile">
+						<File RelativePath="..\src\Utilities\Idm\mf6blockfile\AsciiInputLoadType.f90"/>
+						<File RelativePath="..\src\Utilities\Idm\mf6blockfile\IdmMf6File.f90"/>
+						<File RelativePath="..\src\Utilities\Idm\mf6blockfile\LoadMf6File.f90"/>
+						<File RelativePath="..\src\Utilities\Idm\mf6blockfile\Mf6FileGridInput.f90"/>
+						<File RelativePath="..\src\Utilities\Idm\mf6blockfile\Mf6FileListInput.f90"/>
+						<File RelativePath="..\src\Utilities\Idm\mf6blockfile\Mf6FileStoInput.f90"/>
+						<File RelativePath="..\src\Utilities\Idm\mf6blockfile\StructArray.f90"/>
+						<File RelativePath="..\src\Utilities\Idm\mf6blockfile\StructVector.f90"/>
+					</Filter>
+					<File RelativePath="..\src\Utilities\Idm\BoundInputContext.f90"/>
+					<File RelativePath="..\src\Utilities\Idm\DefinitionSelect.f90"/>
+					<File RelativePath="..\src\Utilities\Idm\DynamicPackageParams.f90"/>
+					<File RelativePath="..\src\Utilities\Idm\IdmLoad.f90"/>
+					<File RelativePath="..\src\Utilities\Idm\IdmLogger.f90"/>
+					<File RelativePath="..\src\Utilities\Idm\InputDefinition.f90"/>
+					<File RelativePath="..\src\Utilities\Idm\InputLoadType.f90"/>
+					<File RelativePath="..\src\Utilities\Idm\ModelPackageInputs.f90"/>
+					<File RelativePath="..\src\Utilities\Idm\ModflowInput.f90"/>
+					<File RelativePath="..\src\Utilities\Idm\SourceCommon.f90"/>
+					<File RelativePath="..\src\Utilities\Idm\SourceLoad.F90">
+						<FileConfiguration Name="Release|x64">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+					</File>
+				</Filter>
+				<Filter Name="Libraries">
+					<File RelativePath="..\src\Utilities\Libraries\blas\blas1_d.f90"/>
+					<File RelativePath="..\src\Utilities\Libraries\daglib\dag_module.f90"/>
+					<File RelativePath="..\src\Utilities\Libraries\sparskit2\ilut.f90"/>
+					<File RelativePath="..\src\Utilities\Libraries\rcm\rcm.f90"/>
+					<File RelativePath="..\src\Utilities\Libraries\sparsekit\sparsekit.f90"/>
+				</Filter>
+				<Filter Name="Matrix">
+					<File RelativePath="..\src\Utilities\Matrix\MatrixBase.f90"/>
+					<File RelativePath="..\src\Utilities\Matrix\PetscMatrix.F90">
+						<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\src\Utilities\Matrix\SparseMatrix.f90"/>
+				</Filter>
+				<Filter Name="Memory">
+					<File RelativePath="..\src\Utilities\Memory\Memory.f90"/>
+					<File RelativePath="..\src\Utilities\Memory\MemoryContainerIterator.f90"/>
+					<File RelativePath="..\src\Utilities\Memory\MemoryHelper.f90"/>
+					<File RelativePath="..\src\Utilities\Memory\MemoryManager.f90"/>
+					<File RelativePath="..\src\Utilities\Memory\MemoryManagerExt.f90"/>
+					<File RelativePath="..\src\Utilities\Memory\MemorySetHandler.f90"/>
+					<File RelativePath="..\src\Utilities\Memory\MemoryStore.f90"/>
+				</Filter>
+				<Filter Name="Observation">
+					<File RelativePath="..\src\Utilities\Observation\Obs.f90"/>
+					<File RelativePath="..\src\Utilities\Observation\ObsContainer.f90"/>
+					<File RelativePath="..\src\Utilities\Observation\Observe.f90"/>
+					<File RelativePath="..\src\Utilities\Observation\ObsOutput.f90"/>
+					<File RelativePath="..\src\Utilities\Observation\ObsOutputList.f90"/>
+					<File RelativePath="..\src\Utilities\Observation\ObsUtility.f90"/>
+				</Filter>
+				<Filter Name="OutputControl">
+					<File RelativePath="..\src\Utilities\OutputControl\OutputControl.f90"/>
+					<File RelativePath="..\src\Utilities\OutputControl\OutputControlData.f90"/>
+					<File RelativePath="..\src\Utilities\OutputControl\PrintSaveManager.f90"/>
+				</Filter>
+				<Filter Name="TimeSeries">
+					<File RelativePath="..\src\Utilities\TimeSeries\TimeArray.f90"/>
+					<File RelativePath="..\src\Utilities\TimeSeries\TimeArraySeries.f90"/>
+					<File RelativePath="..\src\Utilities\TimeSeries\TimeArraySeriesLink.f90"/>
+					<File RelativePath="..\src\Utilities\TimeSeries\TimeArraySeriesManager.f90"/>
+					<File RelativePath="..\src\Utilities\TimeSeries\TimeSeries.f90"/>
+					<File RelativePath="..\src\Utilities\TimeSeries\TimeSeriesFileList.f90"/>
+					<File RelativePath="..\src\Utilities\TimeSeries\TimeSeriesLink.f90"/>
+					<File RelativePath="..\src\Utilities\TimeSeries\TimeSeriesManager.f90"/>
+					<File RelativePath="..\src\Utilities\TimeSeries\TimeSeriesRecord.f90"/>
+				</Filter>
+				<Filter Name="Vector">
+					<File RelativePath="..\src\Utilities\Vector\PetscVector.F90">
+						<FileConfiguration Name="Release|x64" ExcludedFromBuild="true">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64" ExcludedFromBuild="true">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\src\Utilities\Vector\SeqVector.f90"/>
+					<File RelativePath="..\src\Utilities\Vector\VectorBase.f90"/>
+				</Filter>
+				<File RelativePath="..\src\Utilities\ArrayHandlers.f90"/>
+				<File RelativePath="..\src\Utilities\ArrayReaders.f90"/>
+				<File RelativePath="..\src\Utilities\BlockParser.f90"/>
+				<File RelativePath="..\src\Utilities\Budget.f90"/>
+				<File RelativePath="..\src\Utilities\BudgetFileReader.f90"/>
+				<File RelativePath="..\src\Utilities\BudgetObject.f90"/>
+				<File RelativePath="..\src\Utilities\BudgetTerm.f90"/>
+				<File RelativePath="..\src\Utilities\CharString.f90"/>
+				<File RelativePath="..\src\Utilities\comarg.f90"/>
+				<File RelativePath="..\src\Utilities\compilerversion.F90">
+					<FileConfiguration Name="Release|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Utilities\Constants.f90"/>
+				<File RelativePath="..\src\Utilities\defmacro.F90">
+					<FileConfiguration Name="Release|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\src\Utilities\DevFeature.f90"/>
+				<File RelativePath="..\src\Utilities\ErrorUtil.f90"/>
+				<File RelativePath="..\src\Utilities\GeomUtil.f90"/>
+				<File RelativePath="..\src\Utilities\HashTable.f90"/>
+				<File RelativePath="..\src\Utilities\HeadFileReader.f90"/>
+				<File RelativePath="..\src\Utilities\HGeoUtil.f90"/>
+				<File RelativePath="..\src\Utilities\InputOutput.f90"/>
+				<File RelativePath="..\src\Utilities\Iterator.f90"/>
+				<File RelativePath="..\src\Utilities\Iunit.f90"/>
+				<File RelativePath="..\src\Utilities\KeyValueList.f90"/>
+				<File RelativePath="..\src\Utilities\KeyValueListIterator.f90"/>
+				<File RelativePath="..\src\Utilities\KeyValueNode.f90"/>
+				<File RelativePath="..\src\Utilities\kind.f90"/>
+				<File RelativePath="..\src\Utilities\List.f90"/>
+				<File RelativePath="..\src\Utilities\ListIterator.f90"/>
+				<File RelativePath="..\src\Utilities\ListNode.f90"/>
+				<File RelativePath="..\src\Utilities\ListReader.f90"/>
+				<File RelativePath="..\src\Utilities\LongLineReader.f90"/>
+				<File RelativePath="..\src\Utilities\MathUtil.f90"/>
+				<File RelativePath="..\src\Utilities\Message.f90"/>
+				<File RelativePath="..\src\Utilities\OpenSpec.f90"/>
+				<File RelativePath="..\src\Utilities\PackageBudget.f90"/>
+				<File RelativePath="..\src\Utilities\PtrHashTable.f90"/>
+				<File RelativePath="..\src\Utilities\PtrHashTableIterator.f90"/>
+				<File RelativePath="..\src\Utilities\Sim.f90"/>
+				<File RelativePath="..\src\Utilities\SimStages.f90"/>
+				<File RelativePath="..\src\Utilities\SimVariables.f90"/>
+				<File RelativePath="..\src\Utilities\SmoothingFunctions.f90"/>
+				<File RelativePath="..\src\Utilities\sort.f90"/>
+				<File RelativePath="..\src\Utilities\Sparse.f90"/>
+				<File RelativePath="..\src\Utilities\STLVecInt.f90"/>
+				<File RelativePath="..\src\Utilities\StringList.f90"/>
+				<File RelativePath="..\src\Utilities\Table.f90"/>
+				<File RelativePath="..\src\Utilities\TableTerm.f90"/>
+				<File RelativePath="..\src\Utilities\Timer.f90"/>
+				<File RelativePath="..\src\Utilities\version.f90"/>
+			</Filter>
+			<File RelativePath="..\src\mf6core.f90"/>
+			<File RelativePath="..\src\mf6lists.f90"/>
+			<File RelativePath="..\src\RunControl.f90"/>
+			<File RelativePath="..\src\RunControlFactory.F90">
+				<FileConfiguration Name="Release|x64">
+					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+				</FileConfiguration>
+				<FileConfiguration Name="Debug|x64">
+					<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+				</FileConfiguration>
+			</File>
+			<File RelativePath="..\src\SimulationCreate.f90"/>
+		</Filter>
+	</Files>
+	<Globals/>
+</VisualStudioProject>

--- a/utils/mf5to6/msvs/mf5to6.sln
+++ b/utils/mf5to6/msvs/mf5to6.sln
@@ -1,20 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35004.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "mf5to6", "mf5to6.vfproj", "{EE5F8367-9220-45ED-9B0B-5942AF51229C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EE5F8367-9220-45ED-9B0B-5942AF51229C}.Debug|x86.ActiveCfg = Debug|Win32
-		{EE5F8367-9220-45ED-9B0B-5942AF51229C}.Debug|x86.Build.0 = Debug|Win32
-		{EE5F8367-9220-45ED-9B0B-5942AF51229C}.Release|x86.ActiveCfg = Release|Win32
-		{EE5F8367-9220-45ED-9B0B-5942AF51229C}.Release|x86.Build.0 = Release|Win32
+		{EE5F8367-9220-45ED-9B0B-5942AF51229C}.Debug|x64.ActiveCfg = Debug|x64
+		{EE5F8367-9220-45ED-9B0B-5942AF51229C}.Debug|x64.Build.0 = Debug|x64
+		{EE5F8367-9220-45ED-9B0B-5942AF51229C}.Release|x64.ActiveCfg = Release|x64
+		{EE5F8367-9220-45ED-9B0B-5942AF51229C}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/utils/mf5to6/msvs/mf5to6.vfproj
+++ b/utils/mf5to6/msvs/mf5to6.vfproj
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <VisualStudioProject ProjectCreator="Intel Fortran" Keyword="Console Application" Version="11.0" ProjectIdGuid="{EE5F8367-9220-45ED-9B0B-5942AF51229C}">
 	<Platforms>
-		<Platform Name="Win32"/>
+		<Platform Name="x64"/>
 	</Platforms>
 	<Configurations>
-		<Configuration Name="Debug|Win32" TargetName="$(ProjectName)d">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" HeapArrays="0" WarnUnusedVariables="true" WarnUncalled="true" WarnInterfaces="true" Traceback="true" NullPointerCheck="true" BoundsCheck="true" UninitializedVariablesCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
-			<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" SubSystem="subSystemConsole"/>
+		<Configuration Name="Debug|x64" UseCompiler="ifortCompiler" OutputDirectory="$(SolutionDir)..\..\..\bin" IntermediateDirectory="obj_temp\$(ProjectName)_$(PlatformName)_$(ConfigurationName)" TargetName="$(ProjectName)d">
+			<Tool Name="VFFortranCompilerTool" AdditionalOptions="/Qdiag-disable:10448" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" HeapArrays="0" WarnUnusedVariables="true" WarnUncalled="true" WarnInterfaces="true" Traceback="true" NullPointerCheck="true" BoundsCheck="true" UninitializedVariablesCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
+			<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
 			<Tool Name="VFResourceCompilerTool"/>
-			<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
 			<Tool Name="VFCustomBuildTool"/>
 			<Tool Name="VFPreLinkEventTool"/>
 			<Tool Name="VFPreBuildEventTool"/>
-			<Tool Name="VFPostBuildEventTool" CommandLine="copy $(OutDir)\$(TargetName)$(TargetExt) ..\..\..\bin"/>
+			<Tool Name="VFPostBuildEventTool"/>
 			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
 		</Configuration>
-		<Configuration Name="Release|Win32">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" HeapArrays="0" RuntimeLibrary="rtMultiThreadedDebug"/>
-			<Tool Name="VFLinkerTool" SuppressStartupBanner="true" GenerateDebugInformation="true" SubSystem="subSystemConsole"/>
+		<Configuration Name="Release|x64" UseCompiler="ifortCompiler" OutputDirectory="$(SolutionDir)..\..\..\bin" IntermediateDirectory="obj_temp\$(ProjectName)_$(PlatformName)_$(ConfigurationName)">
+			<Tool Name="VFFortranCompilerTool" AdditionalOptions="/Qdiag-disable:10448" SuppressStartupBanner="true" DebugInformationFormat="debugLineInfoOnly" HeapArrays="0"/>
+			<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
 			<Tool Name="VFResourceCompilerTool"/>
-			<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
 			<Tool Name="VFCustomBuildTool"/>
 			<Tool Name="VFPreLinkEventTool"/>
 			<Tool Name="VFPreBuildEventTool"/>
-			<Tool Name="VFPostBuildEventTool" CommandLine="copy $(OutDir)\$(TargetName)$(TargetExt) ..\..\..\bin"/>
+			<Tool Name="VFPostBuildEventTool"/>
 			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
 		</Configuration>
 	</Configurations>
@@ -31,187 +31,210 @@
 		<Filter Name="Header Files" Filter="fi;fd"/>
 		<Filter Name="Resource Files" Filter="rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe"/>
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
-		<Filter Name="LGR">
-		<File RelativePath="..\src\LGR\GwfLgrModule.f"/>
-		<File RelativePath="..\src\LGR\GwfLgrSubs.f"/>
-		<File RelativePath="..\src\LGR\GwfSfrSubs.f"/></Filter>
-		<Filter Name="MF2005">
-		<File RelativePath="..\src\MF2005\de47.f"/>
-		<File RelativePath="..\src\MF2005\gmg7.f"/>
-		<File RelativePath="..\src\MF2005\gwf2mnw17.f"/>
-		<File RelativePath="..\src\MF2005\gwf2mnw2i7.f"/>
-		<File RelativePath="..\src\MF2005\GwfBasModule.f90"/>
-		<File RelativePath="..\src\MF2005\GwfBasOcSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfBasSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfBcfModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfBcfSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfChdModule.f90"/>
-		<File RelativePath="..\src\MF2005\GwfChdSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfDrnModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfDrnSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfEtsModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfEtsSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfEvtModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfEvtSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfFhbModule.f90"/>
-		<File RelativePath="..\src\MF2005\GwfFhbSubs.f90"/>
-		<File RelativePath="..\src\MF2005\GwfGhbModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfGhbSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfLakModule.f90"/>
-		<File RelativePath="..\src\MF2005\GwfLakSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfLpfModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfLpfSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfMnwModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfMnwSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfRchModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfRchSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfResModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfResSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfRivModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfRivSubs.f"/>
-		<File RelativePath="..\src\MF2005\GwfSfrCheck.f"/>
-		<File RelativePath="..\src\MF2005\GwfSfrModule.f"/>
-		<File RelativePath="..\src\MF2005\GwfWelModule.f90"/>
-		<File RelativePath="..\src\MF2005\obs2bas7.f"/>
-		<File RelativePath="..\src\MF2005\obs2chd7.f"/>
-		<File RelativePath="..\src\MF2005\obs2drn7.f"/>
-		<File RelativePath="..\src\MF2005\obs2ghb7.f"/>
-		<File RelativePath="..\src\MF2005\obs2riv7.f"/>
-		<File RelativePath="..\src\MF2005\parutl7.f"/>
-		<File RelativePath="..\src\MF2005\pcg7.f"/>
-		<File RelativePath="..\src\MF2005\pcgn2.f90"/>
-		<File RelativePath="..\src\MF2005\precutls.f90"/>
-		<File RelativePath="..\src\MF2005\sip7.f"/>
-		<File RelativePath="..\src\MF2005\utl7.f"/></Filter>
-		<Filter Name="MF6">
-		<Filter Name="Utilities">
-		<Filter Name="Memory">
-		<File RelativePath="..\..\..\src\Utilities\Memory\Memory.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\Memory\MemoryContainerIterator.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\Memory\MemoryHelper.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\Memory\MemoryManager.f90"/></Filter>
-		<File RelativePath="..\..\..\src\Utilities\Memory\MemoryStore.f90"/>
-		<Filter Name="TimeSeries">
-		<File RelativePath="..\..\..\src\Utilities\TimeSeries\TimeSeries.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\TimeSeries\TimeSeriesRecord.f90"/></Filter>
-		<File RelativePath="..\..\..\src\Utilities\BlockParser.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\CharString.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\compilerversion.F90">
-			<FileConfiguration Name="Debug|Win32">
-			<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\..\..\src\Utilities\Constants.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\defmacro.F90">
-			<FileConfiguration Name="Debug|Win32">
-			<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\..\..\src\Utilities\DevFeature.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\ErrorUtil.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\GeomUtil.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\InputOutput.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\Iterator.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\KeyValueList.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\KeyValueListIterator.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\KeyValueNode.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\kind.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\List.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\ListIterator.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\ListNode.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\LongLineReader.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\MathUtil.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\Message.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\OpenSpec.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\PtrHashTable.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\PtrHashTableIterator.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\SimVariables.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\Table.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\TableTerm.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\version.f90"/></Filter></Filter>
-		<Filter Name="NWT">
-		<File RelativePath="..\src\NWT\gwf2hfb7_NWT.f"/>
-		<File RelativePath="..\src\NWT\gwf2wel7_NWT.f"/>
-		<File RelativePath="..\src\NWT\GwfHfbSubs_NWT.f90"/>
-		<File RelativePath="..\src\NWT\GwfUpwModule.f90"/>
-		<File RelativePath="..\src\NWT\GwfUpwSubs.f90"/>
-		<File RelativePath="..\src\NWT\GwfUzfModule_NWT.f"/>
-		<File RelativePath="..\src\NWT\GwfUzfSubs_NWT.f"/>
-		<File RelativePath="..\src\NWT\NWT1_gmres.f90"/>
-		<File RelativePath="..\src\NWT\NWT1_ilupc_mod.f90"/>
-		<File RelativePath="..\src\NWT\NWT1_module.f"/>
-		<File RelativePath="..\src\NWT\NWT1_solver.f"/>
-		<File RelativePath="..\src\NWT\NWT1_xmd.f"/>
-		<File RelativePath="..\src\NWT\NWT1_xmdlib.f"/></Filter>
-		<Filter Name="Preproc">
-		<File RelativePath="..\src\Preproc\ArrayHandlers.f90"/>
-		<File RelativePath="..\src\Preproc\ConstantsPHMF.f90"/>
-		<File RelativePath="..\src\Preproc\Discretization3D.f90"/>
-		<File RelativePath="..\src\Preproc\DiscretizationBasePHMF.f90"/>
-		<File RelativePath="..\src\Preproc\File.f90"/>
-		<File RelativePath="..\src\Preproc\FileList.f90"/>
-		<File RelativePath="..\src\Preproc\Global.f90"/>
-		<File RelativePath="..\src\Preproc\GlobalPHMF.f90"/>
-		<File RelativePath="..\src\Preproc\GlobalVariables.f90"/>
-		<File RelativePath="..\src\Preproc\GlobalVariablesPHMF.f90"/>
-		<File RelativePath="..\src\Preproc\ObsBlock.f90"/>
-		<File RelativePath="..\src\Preproc\ObservePHMF.f90"/>
-		<File RelativePath="..\src\Preproc\Preproc.f90"/>
-		<File RelativePath="..\src\Preproc\SimListVariables.f90"/>
-		<File RelativePath="..\src\Preproc\SimPHMF.f90"/>
-		<File RelativePath="..\src\Preproc\SimVariablesPHMF.f90"/>
-		<File RelativePath="..\src\Preproc\Utilities.f90"/></Filter>
-		<File RelativePath="..\src\ArrayReadersMF5.f90"/>
-		<File RelativePath="..\src\Auxiliary.f90"/>
-		<File RelativePath="..\src\CharacterContainer.f90"/>
-		<File RelativePath="..\src\ChdObsWriter.f90"/>
-		<File RelativePath="..\src\ChdPackageWriter.f90"/>
-		<File RelativePath="..\src\ChdType.f90"/>
-		<File RelativePath="..\src\Connection.f90"/>
-		<File RelativePath="..\src\ConverterCommon.f90"/>
-		<File RelativePath="..\src\DisWriter.f90"/>
-		<File RelativePath="..\src\DrnObsWriter.f90"/>
-		<File RelativePath="..\src\DrnPackageWriter.f90"/>
-		<File RelativePath="..\src\EvtPackageWriter.f90"/>
-		<File RelativePath="..\src\Exchange.f90"/>
-		<File RelativePath="..\src\ExchangeWriter.f90"/>
-		<File RelativePath="..\src\FhbPackageWriter.f90"/>
-		<File RelativePath="..\src\FileWriter.f90"/>
-		<File RelativePath="..\src\GhbObsWriter.f90"/>
-		<File RelativePath="..\src\GhbPackageWriter.f90"/>
-		<File RelativePath="..\src\HfbPackageWriter.f90"/>
-		<File RelativePath="..\src\IcWriter.f90"/>
-		<File RelativePath="..\src\ImsPackageWriter.f90"/>
-		<File RelativePath="..\src\Lake.f90"/>
-		<File RelativePath="..\src\LakeConnection.f90"/>
-		<File RelativePath="..\src\LakeOutlet.f90"/>
-		<File RelativePath="..\src\LakeTributary.f90"/>
-		<File RelativePath="..\src\LakPackageWriter.f90"/>
-		<File RelativePath="..\src\LineList.f90"/>
-		<File RelativePath="..\src\mach_mod.f90"/>
-		<File RelativePath="..\src\MawPackageWriter.f90"/>
-		<File RelativePath="..\src\mf5to6.f90"/>
-		<File RelativePath="..\src\Model.f90"/>
-		<File RelativePath="..\src\ModelConverter.f90"/>
-		<File RelativePath="..\src\ModelPackage.f90"/>
-		<File RelativePath="..\src\Mover.f90"/>
-		<File RelativePath="..\src\MultiLayerObsModule.f90"/>
-		<File RelativePath="..\src\MvrPackageWriter.f90"/>
-		<File RelativePath="..\src\NpfWriter.f90"/>
-		<File RelativePath="..\src\ObsWriter.f90"/>
-		<File RelativePath="..\src\OutputControlWriter.f90"/>
-		<File RelativePath="..\src\PackageWriter.f90"/>
-		<File RelativePath="..\src\ParamModule.f90"/>
-		<File RelativePath="..\src\RchPackageWriter.f90"/>
-		<File RelativePath="..\src\RivObsWriter.f90"/>
-		<File RelativePath="..\src\RivPackageWriter.f90"/>
-		<File RelativePath="..\src\SfrDiversion.f90"/>
-		<File RelativePath="..\src\SfrPackageWriter.f90"/>
-		<File RelativePath="..\src\SfrReach.f90"/>
-		<File RelativePath="..\src\SfrSegment.f90"/>
-		<File RelativePath="..\src\SimFileWriter.f90"/>
-		<File RelativePath="..\src\StoWriter.f90"/>
-		<File RelativePath="..\src\StressPeriod.f90"/>
-		<File RelativePath="..\src\TdisVariables.f90"/>
-		<File RelativePath="..\src\TdisWriter.f90"/>
-		<File RelativePath="..\src\UzfPackageWriter.f90"/>
-		<File RelativePath="..\src\WelPackageWriter.f90"/></Filter>
+			<Filter Name="LGR">
+				<File RelativePath="..\src\LGR\GwfLgrModule.f"/>
+				<File RelativePath="..\src\LGR\GwfLgrSubs.f"/>
+				<File RelativePath="..\src\LGR\GwfSfrSubs.f"/>
+			</Filter>
+			<Filter Name="MF2005">
+				<File RelativePath="..\src\MF2005\de47.f"/>
+				<File RelativePath="..\src\MF2005\gmg7.f"/>
+				<File RelativePath="..\src\MF2005\gwf2mnw17.f"/>
+				<File RelativePath="..\src\MF2005\gwf2mnw2i7.f"/>
+				<File RelativePath="..\src\MF2005\GwfBasModule.f90"/>
+				<File RelativePath="..\src\MF2005\GwfBasOcSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfBasSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfBcfModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfBcfSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfChdModule.f90"/>
+				<File RelativePath="..\src\MF2005\GwfChdSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfDrnModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfDrnSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfEtsModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfEtsSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfEvtModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfEvtSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfFhbModule.f90"/>
+				<File RelativePath="..\src\MF2005\GwfFhbSubs.f90"/>
+				<File RelativePath="..\src\MF2005\GwfGhbModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfGhbSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfLakModule.f90"/>
+				<File RelativePath="..\src\MF2005\GwfLakSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfLpfModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfLpfSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfMnwModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfMnwSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfRchModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfRchSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfResModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfResSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfRivModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfRivSubs.f"/>
+				<File RelativePath="..\src\MF2005\GwfSfrCheck.f"/>
+				<File RelativePath="..\src\MF2005\GwfSfrModule.f"/>
+				<File RelativePath="..\src\MF2005\GwfWelModule.f90"/>
+				<File RelativePath="..\src\MF2005\obs2bas7.f"/>
+				<File RelativePath="..\src\MF2005\obs2chd7.f"/>
+				<File RelativePath="..\src\MF2005\obs2drn7.f"/>
+				<File RelativePath="..\src\MF2005\obs2ghb7.f"/>
+				<File RelativePath="..\src\MF2005\obs2riv7.f"/>
+				<File RelativePath="..\src\MF2005\parutl7.f"/>
+				<File RelativePath="..\src\MF2005\pcg7.f"/>
+				<File RelativePath="..\src\MF2005\pcgn2.f90"/>
+				<File RelativePath="..\src\MF2005\precutls.f90"/>
+				<File RelativePath="..\src\MF2005\sip7.f"/>
+				<File RelativePath="..\src\MF2005\utl7.f"/>
+			</Filter>
+			<Filter Name="MF6">
+				<Filter Name="Utilities">
+					<Filter Name="Memory">
+						<File RelativePath="..\..\..\src\Utilities\Memory\Memory.f90"/>
+						<File RelativePath="..\..\..\src\Utilities\Memory\MemoryContainerIterator.f90"/>
+						<File RelativePath="..\..\..\src\Utilities\Memory\MemoryHelper.f90"/>
+						<File RelativePath="..\..\..\src\Utilities\Memory\MemoryManager.f90"/>
+					</Filter>
+					<Filter Name="TimeSeries">
+						<File RelativePath="..\..\..\src\Utilities\TimeSeries\TimeSeries.f90"/>
+						<File RelativePath="..\..\..\src\Utilities\TimeSeries\TimeSeriesRecord.f90"/>
+					</Filter>
+					<File RelativePath="..\..\..\src\Utilities\BlockParser.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\CharString.f90">
+					</File>
+					<File RelativePath="..\..\..\src\Utilities\compilerversion.F90">
+						<FileConfiguration Name="Release|x64">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\..\..\src\Utilities\Constants.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\defmacro.F90">
+						<FileConfiguration Name="Release|x64">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+						<FileConfiguration Name="Debug|x64">
+							<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+						</FileConfiguration>
+					</File>
+					<File RelativePath="..\..\..\src\Utilities\DevFeature.f90">
+					</File>
+					<File RelativePath="..\..\..\src\Utilities\ErrorUtil.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\GeomUtil.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\InputOutput.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\Iterator.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\KeyValueList.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\KeyValueListIterator.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\KeyValueNode.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\kind.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\List.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\ListIterator.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\ListNode.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\LongLineReader.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\MathUtil.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\Memory\MemoryStore.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\Message.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\OpenSpec.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\PtrHashTable.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\PtrHashTableIterator.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\SimVariables.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\Table.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\TableTerm.f90"/>
+					<File RelativePath="..\..\..\src\Utilities\version.f90"/>
+				</Filter>
+			</Filter>
+			<Filter Name="NWT">
+				<File RelativePath="..\src\NWT\gwf2hfb7_NWT.f"/>
+				<File RelativePath="..\src\NWT\gwf2wel7_NWT.f"/>
+				<File RelativePath="..\src\NWT\GwfHfbSubs_NWT.f90"/>
+				<File RelativePath="..\src\NWT\GwfUpwModule.f90"/>
+				<File RelativePath="..\src\NWT\GwfUpwSubs.f90"/>
+				<File RelativePath="..\src\NWT\GwfUzfModule_NWT.f"/>
+				<File RelativePath="..\src\NWT\GwfUzfSubs_NWT.f"/>
+				<File RelativePath="..\src\NWT\NWT1_gmres.f90"/>
+				<File RelativePath="..\src\NWT\NWT1_ilupc_mod.f90"/>
+				<File RelativePath="..\src\NWT\NWT1_module.f"/>
+				<File RelativePath="..\src\NWT\NWT1_solver.f"/>
+				<File RelativePath="..\src\NWT\NWT1_xmd.f"/>
+				<File RelativePath="..\src\NWT\NWT1_xmdlib.f"/>
+			</Filter>
+			<Filter Name="Preproc">
+				<File RelativePath="..\src\Preproc\ArrayHandlers.f90"/>
+				<File RelativePath="..\src\Preproc\ConstantsPHMF.f90"/>
+				<File RelativePath="..\src\Preproc\Discretization3D.f90"/>
+				<File RelativePath="..\src\Preproc\DiscretizationBasePHMF.f90"/>
+				<File RelativePath="..\src\Preproc\File.f90"/>
+				<File RelativePath="..\src\Preproc\FileList.f90"/>
+				<File RelativePath="..\src\Preproc\Global.f90"/>
+				<File RelativePath="..\src\Preproc\GlobalPHMF.f90"/>
+				<File RelativePath="..\src\Preproc\GlobalVariables.f90"/>
+				<File RelativePath="..\src\Preproc\GlobalVariablesPHMF.f90"/>
+				<File RelativePath="..\src\Preproc\ObsBlock.f90"/>
+				<File RelativePath="..\src\Preproc\ObservePHMF.f90"/>
+				<File RelativePath="..\src\Preproc\Preproc.f90"/>
+				<File RelativePath="..\src\Preproc\SimListVariables.f90"/>
+				<File RelativePath="..\src\Preproc\SimPHMF.f90"/>
+				<File RelativePath="..\src\Preproc\SimVariablesPHMF.f90"/>
+				<File RelativePath="..\src\Preproc\Utilities.f90"/>
+			</Filter>
+			<File RelativePath="..\src\ArrayReadersMF5.f90"/>
+			<File RelativePath="..\src\Auxiliary.f90"/>
+			<File RelativePath="..\src\CharacterContainer.f90"/>
+			<File RelativePath="..\src\ChdObsWriter.f90"/>
+			<File RelativePath="..\src\ChdPackageWriter.f90"/>
+			<File RelativePath="..\src\ChdType.f90"/>
+			<File RelativePath="..\src\Connection.f90"/>
+			<File RelativePath="..\src\ConverterCommon.f90"/>
+			<File RelativePath="..\src\DisWriter.f90">
+			</File>
+			<File RelativePath="..\src\DrnObsWriter.f90">
+			</File>
+			<File RelativePath="..\src\DrnPackageWriter.f90"/>
+			<File RelativePath="..\src\EvtPackageWriter.f90"/>
+			<File RelativePath="..\src\Exchange.f90"/>
+			<File RelativePath="..\src\ExchangeWriter.f90"/>
+			<File RelativePath="..\src\FhbPackageWriter.f90"/>
+			<File RelativePath="..\src\FileWriter.f90"/>
+			<File RelativePath="..\src\GhbObsWriter.f90"/>
+			<File RelativePath="..\src\GhbPackageWriter.f90"/>
+			<File RelativePath="..\src\HfbPackageWriter.f90"/>
+			<File RelativePath="..\src\IcWriter.f90"/>
+			<File RelativePath="..\src\ImsPackageWriter.f90"/>
+			<File RelativePath="..\src\Lake.f90"/>
+			<File RelativePath="..\src\LakeConnection.f90"/>
+			<File RelativePath="..\src\LakeOutlet.f90"/>
+			<File RelativePath="..\src\LakeTributary.f90"/>
+			<File RelativePath="..\src\LakPackageWriter.f90"/>
+			<File RelativePath="..\src\LineList.f90"/>
+			<File RelativePath="..\src\mach_mod.f90"/>
+			<File RelativePath="..\src\MawPackageWriter.f90"/>
+			<File RelativePath="..\src\mf5to6.f90"/>
+			<File RelativePath="..\src\Model.f90"/>
+			<File RelativePath="..\src\ModelConverter.f90"/>
+			<File RelativePath="..\src\ModelPackage.f90"/>
+			<File RelativePath="..\src\Mover.f90"/>
+			<File RelativePath="..\src\MultiLayerObsModule.f90"/>
+			<File RelativePath="..\src\MvrPackageWriter.f90"/>
+			<File RelativePath="..\src\NpfWriter.f90"/>
+			<File RelativePath="..\src\ObsWriter.f90"/>
+			<File RelativePath="..\src\OutputControlWriter.f90"/>
+			<File RelativePath="..\src\PackageWriter.f90"/>
+			<File RelativePath="..\src\ParamModule.f90"/>
+			<File RelativePath="..\src\RchPackageWriter.f90"/>
+			<File RelativePath="..\src\RivObsWriter.f90"/>
+			<File RelativePath="..\src\RivPackageWriter.f90"/>
+			<File RelativePath="..\src\SfrDiversion.f90"/>
+			<File RelativePath="..\src\SfrPackageWriter.f90"/>
+			<File RelativePath="..\src\SfrReach.f90"/>
+			<File RelativePath="..\src\SfrSegment.f90"/>
+			<File RelativePath="..\src\SimFileWriter.f90"/>
+			<File RelativePath="..\src\StoWriter.f90"/>
+			<File RelativePath="..\src\StressPeriod.f90"/>
+			<File RelativePath="..\src\TdisVariables.f90"/>
+			<File RelativePath="..\src\TdisWriter.f90"/>
+			<File RelativePath="..\src\UzfPackageWriter.f90"/>
+			<File RelativePath="..\src\WelPackageWriter.f90"/>
+		</Filter>
 	</Files>
 	<Globals/>
 </VisualStudioProject>

--- a/utils/zonebudget/msvs/zonebudget.sln
+++ b/utils/zonebudget/msvs/zonebudget.sln
@@ -1,22 +1,25 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35004.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "zonebudget", "zonebudget.vfproj", "{E7756A4E-003C-4D3D-B618-CC2BE6D20B04}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Win32 = Debug|Win32
-		Release|Win32 = Release|Win32
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E7756A4E-003C-4D3D-B618-CC2BE6D20B04}.Debug|Win32.ActiveCfg = Debug|Win32
-		{E7756A4E-003C-4D3D-B618-CC2BE6D20B04}.Debug|Win32.Build.0 = Debug|Win32
-		{E7756A4E-003C-4D3D-B618-CC2BE6D20B04}.Release|Win32.ActiveCfg = Release|Win32
-		{E7756A4E-003C-4D3D-B618-CC2BE6D20B04}.Release|Win32.Build.0 = Release|Win32
+		{E7756A4E-003C-4D3D-B618-CC2BE6D20B04}.Debug|x64.ActiveCfg = Debug|x64
+		{E7756A4E-003C-4D3D-B618-CC2BE6D20B04}.Debug|x64.Build.0 = Debug|x64
+		{E7756A4E-003C-4D3D-B618-CC2BE6D20B04}.Release|x64.ActiveCfg = Release|x64
+		{E7756A4E-003C-4D3D-B618-CC2BE6D20B04}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {655FB439-DE46-46A6-B2CE-1A6AF722199E}
 	EndGlobalSection
 EndGlobal

--- a/utils/zonebudget/msvs/zonebudget.vfproj
+++ b/utils/zonebudget/msvs/zonebudget.vfproj
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <VisualStudioProject ProjectCreator="Intel Fortran" Keyword="Console Application" Version="11.0" ProjectIdGuid="{E7756A4E-003C-4D3D-B618-CC2BE6D20B04}">
 	<Platforms>
-		<Platform Name="Win32"/>
+		<Platform Name="x64"/>
 	</Platforms>
 	<Configurations>
-		<Configuration Name="Debug|Win32">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" WarnDeclarations="true" WarnUnusedVariables="true" WarnTruncateSource="true" WarnUnalignedData="false" WarnUncalled="true" WarnInterfaces="true" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebugDLL"/>
-			<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" SubSystem="subSystemConsole"/>
+		<Configuration Name="Debug|x64" UseCompiler="ifortCompiler" OutputDirectory="$(SolutionDir)..\..\..\bin" IntermediateDirectory="obj_temp\$(ProjectName)_$(PlatformName)_$(ConfigurationName)" TargetName="zbud6d">
+			<Tool Name="VFFortranCompilerTool" AdditionalOptions="/Qdiag-disable:10448" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" HeapArrays="0" WarnDeclarations="true" WarnUnusedVariables="true" WarnTruncateSource="true" WarnUnalignedData="false" WarnUncalled="true" WarnInterfaces="true" Traceback="true" BoundsCheck="true" StackFrameCheck="true" RuntimeLibrary="rtMultiThreadedDebug"/>
+			<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateDebugInformation="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
 			<Tool Name="VFResourceCompilerTool"/>
-			<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
 			<Tool Name="VFCustomBuildTool"/>
 			<Tool Name="VFPreLinkEventTool"/>
 			<Tool Name="VFPreBuildEventTool"/>
 			<Tool Name="VFPostBuildEventTool"/>
 			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
 		</Configuration>
-		<Configuration Name="Release|Win32">
-			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" RuntimeLibrary="rtMultiThreadedDLL"/>
-			<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" SubSystem="subSystemConsole"/>
+		<Configuration Name="Release|x64" UseCompiler="ifortCompiler" OutputDirectory="$(SolutionDir)..\..\..\bin" IntermediateDirectory="obj_temp\$(ProjectName)_$(PlatformName)_$(ConfigurationName)" TargetName="zbud6">
+			<Tool Name="VFFortranCompilerTool" AdditionalOptions="/Qdiag-disable:10448" SuppressStartupBanner="true" HeapArrays="0"/>
+			<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" ProgramDatabaseFile="$(IntDir)\$(TargetName).pdb" SubSystem="subSystemConsole"/>
 			<Tool Name="VFResourceCompilerTool"/>
-			<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
+			<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
 			<Tool Name="VFCustomBuildTool"/>
 			<Tool Name="VFPreLinkEventTool"/>
 			<Tool Name="VFPreBuildEventTool"/>
@@ -31,37 +31,50 @@
 		<Filter Name="Header Files" Filter="fi;fd;h;inc"/>
 		<Filter Name="Resource Files" Filter="rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe"/>
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
-		<Filter Name="mf6util">
-		<File RelativePath="..\..\..\src\Utilities\ArrayHandlers.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\ArrayReaders.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\BlockParser.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\Budget.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\CharString.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\compilerversion.F90">
-			<FileConfiguration Name="Debug|Win32">
-			<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\..\..\src\Utilities\Constants.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\defmacro.F90">
-			<FileConfiguration Name="Debug|Win32">
-			<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\..\..\src\Utilities\DevFeature.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\ErrorUtil.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\GeomUtil.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\InputOutput.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\kind.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\LongLineReader.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\MathUtil.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\Message.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\OpenSpec.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\Sim.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\SimVariables.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\sort.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\version.f90"/></Filter>
-		<File RelativePath="..\src\budgetdata.f90"/>
-		<File RelativePath="..\src\grb.f90"/>
-		<File RelativePath="..\src\zbud6.f90"/>
-		<File RelativePath="..\src\zone.f90"/>
-		<File RelativePath="..\src\zoneoutput.f90"/></Filter>
+			<Filter Name="mf6util">
+				<File RelativePath="..\..\..\src\Utilities\ArrayHandlers.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\ArrayReaders.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\BlockParser.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\Budget.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\CharString.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\compilerversion.F90">
+					<FileConfiguration Name="Release|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\..\..\src\Utilities\Constants.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\defmacro.F90">
+					<FileConfiguration Name="Release|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64">
+						<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/>
+					</FileConfiguration>
+				</File>
+				<File RelativePath="..\..\..\src\Utilities\DevFeature.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\ErrorUtil.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\GeomUtil.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\InputOutput.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\kind.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\LongLineReader.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\MathUtil.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\Message.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\OpenSpec.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\Sim.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\SimVariables.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\sort.f90"/>
+				<File RelativePath="..\..\..\src\Utilities\version.f90"/>
+			</Filter>
+			<File RelativePath="..\src\budgetdata.f90"/>
+			<File RelativePath="..\src\grb.f90"/>
+			<File RelativePath="..\src\zbud6.f90">
+			</File>
+			<File RelativePath="..\src\zone.f90"/>
+			<File RelativePath="..\src\zoneoutput.f90"/>
+		</Filter>
 	</Files>
 	<Globals/>
 </VisualStudioProject>


### PR DESCRIPTION
This PR contains two commits. One that updates the visual studio solution and project files associated with the mf6.exe and mf6.dll and the other updates the same files for zonebudget and MF5to6. They all still use **ifort** as the fortran compiler. 

This will not invoke any tests, but I ran `pixi run autotest` on my local machine. All tests pass except for the following:
```
FAILED test_gwf_libmf6_evt01.py::test_mf6model[0-libgwf_evt01] - UnboundLocalError: local variable 'buff' referenced before assignment
FAILED test_gwf_libmf6_ghb01.py::test_mf6model[0-libgwf_ghb01] - UnboundLocalError: local variable 'buff' referenced before assignment
FAILED test_gwf_libmf6_ifmod01.py::test_mf6model[0-libgwf_ifmod01] - UnboundLocalError: local variable 'buff' referenced before assignment
FAILED test_gwf_libmf6_ifmod02.py::test_mf6model[0-libgwf_ifmod02] - UnboundLocalError: local variable 'buff' referenced before assignment
FAILED test_gwf_libmf6_ifmod03.py::test_mf6model[0-libgwf_ifmod03] - UnboundLocalError: local variable 'buff' referenced before assignment
FAILED test_gwf_libmf6_rch01.py::test_mf6model[0-libgwf_rch01] - UnboundLocalError: local variable 'buff' referenced before assignment
FAILED test_gwf_libmf6_rch02.py::test_mf6model[0-libgwf_rch02] - UnboundLocalError: local variable 'buff' referenced before assignment
FAILED test_gwf_libmf6_riv01.py::test_mf6model[0-libgwf_riv01] - UnboundLocalError: local variable 'buff' referenced before assignment
FAILED test_gwf_libmf6_riv02.py::test_mf6model[0-libgwf_riv02] - UnboundLocalError: local variable 'buff' referenced before assignment
FAILED test_gwf_libmf6_sto01.py::test_mf6model[0-libgwf_sto01] - UnboundLocalError: local variable 'buff' referenced before assignment
FAILED test_gwf_tdis.py::test_tdis_tsmult[1.0] - FileNotFoundError: Could not find module 'C:\Data\dev\mf6-dev\modflow6\bin\libmf6.dll' (or one of its dependencies). Try using the full path with constructor syntax.
FAILED test_gwf_tdis.py::test_tdis_tsmult[1.2] - FileNotFoundError: Could not find module 'C:\Data\dev\mf6-dev\modflow6\bin\libmf6.dll' (or one of its dependencies). Try using the full path with constructor syntax.
ERROR test_gwf_libmf6_rch02.py::test_mf6model[0-libgwf_rch02] - shutil.Error: [('C:\\Users\\seboyce\\AppData\\Local\\Temp...
```

I am unsure as to the cause of the libmf6.dll errors as the file is placed in the bin directory. It could also be that these tests have not been run with VS made dll targets in a while (or some quark of Windows). I will keep looking into it, but the original version of the dll project files would not compile at all for me initially.

The bulk of the changes are described in the git commit log. The major changes are that win32 is removed and all projects are setup to compile x64. The sln/vfproj files are updated to VS2022 format, which is backward compatible with VS2019.

The major fix is that mfbmi needed several modification to successfully compile with the current version of ifort in oneAPI (2021.12). In particular, mf6bmi required ignoring the LIBCMT, LIBCMTD, and LIBIFCOREMT (not originally there) and mf6 no longer required ignoring LIBCMT.

The project for  Zonebudget now produces "zbud6.exe" as its output rather than "zonebudget.exe"

The Zonebudget and MF5to6 now produce their executables in the bin folder,
rather then using a post-build "copy" event.

Added /Qdiag-disable:10448 to suppress warning about ifort being deprecated.

The intermediate directory was changed from  
`$(ProjectName)/$(Platform)/$(ConfigurationName)`  
to  
`$(ProjectName)_$(Platform)_$(ConfigurationName)`  
to simply the structure from having multiply directories that contain nothing but a single directory.

