### PR TITLE
refactor(meson):  update build to Fortran 2018 standard

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
     'b_vscrt=static_from_buildtype', # Link runtime libraries statically on Windows
     'optimization=2',
     'debug=false',
-    'fortran_std=f2008',
+    'fortran_std=f2018',
 ])
 
 if get_option('optimization') == '3'

--- a/pymake/makedefaults
+++ b/pymake/makedefaults
@@ -58,11 +58,11 @@ OPTLEVEL ?= -O2
 # set the fortran flags
 ifeq ($(detected_OS), Windows)
 	ifeq ($(FC), gfortran)
-		FFLAGS ?= -static -fbacktrace -ffpe-summary=overflow -ffpe-trap=overflow,zero,invalid $(OS_macro) -Wtabs -Wline-truncation -Wunused-label -Wunused-variable -pedantic -std=f2008 -Wcharacter-truncation -cpp
+		FFLAGS ?= -static -fbacktrace -ffpe-summary=overflow -ffpe-trap=overflow,zero,invalid $(OS_macro) -Wtabs -Wline-truncation -Wunused-label -Wunused-variable -pedantic -std=f2018 -Wcharacter-truncation -cpp
 	endif
 else
 	ifeq ($(FC), gfortran)
-		FFLAGS ?= -fbacktrace -ffpe-summary=overflow -ffpe-trap=overflow,zero,invalid $(OS_macro) -Wtabs -Wline-truncation -Wunused-label -Wunused-variable -pedantic -std=f2008 -Wcharacter-truncation -cpp
+		FFLAGS ?= -fbacktrace -ffpe-summary=overflow -ffpe-trap=overflow,zero,invalid $(OS_macro) -Wtabs -Wline-truncation -Wunused-label -Wunused-variable -pedantic -std=f2018 -Wcharacter-truncation -cpp
 	endif
 	ifeq ($(FC), $(filter $(FC), ifort mpiifort))
 		FFLAGS ?= -no-heap-arrays -fpe0 -traceback -fpp

--- a/src/Solution/LinearMethods/ImsReordering.f90
+++ b/src/Solution/LinearMethods/ImsReordering.f90
@@ -300,12 +300,13 @@ contains
     ! -- local
     integer(I4B) :: tag
     integer(I4B) :: dmin
-    integer(I4B) :: vk
-    integer(I4B) :: ek
+    integer(I4B), pointer :: vk
+    integer(I4B), pointer :: ek
     integer(I4B) :: tail
     integer(I4B) :: k
 
-    equivalence(vk, ek)
+    allocate (vk)
+    ek => vk
     !
     ! initialization
     tag = 0
@@ -352,6 +353,8 @@ contains
       next(k) = -next(k)
       last(next(k)) = k
     end do
+    !
+    deallocate (vk)
     !
     return
   end subroutine ims_md
@@ -482,15 +485,16 @@ contains
     integer(I4B) :: tag
     integer(I4B) :: s
     integer(I4B) :: ls
-    integer(I4B) :: vs
-    integer(I4B) :: es
+    integer(I4B), pointer :: vs
+    integer(I4B), pointer :: es
     integer(I4B) :: b
     integer(I4B) :: lb
     integer(I4B) :: vb
     integer(I4B) :: blp
     integer(I4B) :: blpmax
 
-    equivalence(vs, es)
+    allocate (vs)
+    es => vs
     !
     ! initialize tag and list of uneliminated neighbors
     tag = mark(vk)
@@ -535,6 +539,8 @@ contains
     !
     ! terminate list of uneliminated neighbors
 5   l(tail) = 0
+    !
+    deallocate (vs)
     !
     return
   end subroutine ims_mdm
@@ -681,8 +687,8 @@ contains
     integer(I4B) :: evi
     integer(I4B) :: dvi
     integer(I4B) :: s
-    integer(I4B) :: vs
-    integer(I4B) :: es
+    integer(I4B), pointer :: vs
+    integer(I4B), pointer :: es
     integer(I4B) :: b
     integer(I4B) :: vb
     integer(I4B) :: ilp
@@ -691,7 +697,8 @@ contains
     integer(I4B) :: blpmax
     integer(I4B) :: i
 
-    equivalence(vs, es)
+    allocate (vs)
+    es => vs
     !
     ! initialize tag
     tag = mark(ek) - last(ek)
@@ -768,7 +775,9 @@ contains
       !
     end do louter !10
     !
-11  return
+11  deallocate (vs)
+    !
+    return
   end subroutine ims_mdu
 
 end module IMSReorderingModule


### PR DESCRIPTION
Update gfortran builds to use Fortran 2018 standard.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).