### PR TITLE
refactor(dis*): flatten idomain and move to base type

### DIFF
--- a/src/Exchange/exg-gwfgwe.f90
+++ b/src/Exchange/exg-gwfgwe.f90
@@ -229,32 +229,10 @@ contains
     end if
     !
     ! -- Make sure idomains are identical
-    select type (gwfdis => gwfmodel%dis)
-    type is (DisType)
-      select type (gwedis => gwemodel%dis)
-      type is (DisType)
-        if (.not. all(gwfdis%idomain == gwedis%idomain)) then
-          write (errmsg, fmtidomerr) trim(this%name)
-          call store_error(errmsg, terminate=.TRUE.)
-        end if
-      end select
-    type is (DisvType)
-      select type (gwedis => gwemodel%dis)
-      type is (DisvType)
-        if (.not. all(gwfdis%idomain == gwedis%idomain)) then
-          write (errmsg, fmtidomerr) trim(this%name)
-          call store_error(errmsg, terminate=.TRUE.)
-        end if
-      end select
-    type is (DisuType)
-      select type (gwedis => gwemodel%dis)
-      type is (DisuType)
-        if (.not. all(gwfdis%idomain == gwedis%idomain)) then
-          write (errmsg, fmtidomerr) trim(this%name)
-          call store_error(errmsg, terminate=.TRUE.)
-        end if
-      end select
-    end select
+    if (.not. all(gwfmodel%dis%idomain == gwemodel%dis%idomain)) then
+      write (errmsg, fmtidomerr) trim(this%name)
+      call store_error(errmsg, terminate=.TRUE.)
+    end if
     !
     ! -- setup pointers to gwf variables allocated in gwf_ar
     gwemodel%fmi%gwfhead => gwfmodel%x

--- a/src/Exchange/exg-gwfgwt.f90
+++ b/src/Exchange/exg-gwfgwt.f90
@@ -232,32 +232,10 @@ contains
     end if
     !
     ! -- Make sure idomains are identical
-    select type (gwfdis => gwfmodel%dis)
-    type is (DisType)
-      select type (gwtdis => gwtmodel%dis)
-      type is (DisType)
-        if (.not. all(gwfdis%idomain == gwtdis%idomain)) then
-          write (errmsg, fmtidomerr) trim(this%name)
-          call store_error(errmsg, terminate=.TRUE.)
-        end if
-      end select
-    type is (DisvType)
-      select type (gwtdis => gwtmodel%dis)
-      type is (DisvType)
-        if (.not. all(gwfdis%idomain == gwtdis%idomain)) then
-          write (errmsg, fmtidomerr) trim(this%name)
-          call store_error(errmsg, terminate=.TRUE.)
-        end if
-      end select
-    type is (DisuType)
-      select type (gwtdis => gwtmodel%dis)
-      type is (DisuType)
-        if (.not. all(gwfdis%idomain == gwtdis%idomain)) then
-          write (errmsg, fmtidomerr) trim(this%name)
-          call store_error(errmsg, terminate=.TRUE.)
-        end if
-      end select
-    end select
+    if (.not. all(gwfmodel%dis%idomain == gwtmodel%dis%idomain)) then
+      write (errmsg, fmtidomerr) trim(this%name)
+      call store_error(errmsg, terminate=.TRUE.)
+    end if
     !
     ! -- setup pointers to gwf variables allocated in gwf_ar
     gwtmodel%fmi%gwfhead => gwfmodel%x

--- a/src/Exchange/exg-gwfprt.f90
+++ b/src/Exchange/exg-gwfprt.f90
@@ -225,32 +225,10 @@ contains
     end if
     !
     ! -- Make sure idomains are identical
-    select type (gwfdis => gwfmodel%dis)
-    type is (DisType)
-      select type (prtdis => prtmodel%dis)
-      type is (DisType)
-        if (.not. all(gwfdis%idomain == prtdis%idomain)) then
-          write (errmsg, fmtidomerr) trim(this%name)
-          call store_error(errmsg, terminate=.TRUE.)
-        end if
-      end select
-    type is (DisvType)
-      select type (prtdis => prtmodel%dis)
-      type is (DisvType)
-        if (.not. all(gwfdis%idomain == prtdis%idomain)) then
-          write (errmsg, fmtidomerr) trim(this%name)
-          call store_error(errmsg, terminate=.TRUE.)
-        end if
-      end select
-    type is (DisuType)
-      select type (prtdis => prtmodel%dis)
-      type is (DisuType)
-        if (.not. all(gwfdis%idomain == prtdis%idomain)) then
-          write (errmsg, fmtidomerr) trim(this%name)
-          call store_error(errmsg, terminate=.TRUE.)
-        end if
-      end select
-    end select
+    if (.not. all(gwfmodel%dis%idomain == prtmodel%dis%idomain)) then
+      write (errmsg, fmtidomerr) trim(this%name)
+      call store_error(errmsg, terminate=.TRUE.)
+    end if
     !
     ! -- setup pointers to gwf variables allocated in gwf_ar
     prtmodel%fmi%gwfhead => gwfmodel%x

--- a/src/Model/Discretization/Disu.f90
+++ b/src/Model/Discretization/Disu.f90
@@ -43,9 +43,7 @@ module DisuModule
     integer(I4B), pointer :: iangledegx => null() ! =1 when angle information was present in input, 0 otherwise
     integer(I4B), dimension(:), pointer, contiguous :: iavert => null() ! cell vertex pointer ia array
     integer(I4B), dimension(:), pointer, contiguous :: javert => null() ! cell vertex pointer ja array
-    integer(I4B), dimension(:), pointer, contiguous :: idomain => null() ! idomain (nodes)
     logical(LGP) :: readFromFile ! True, when DIS is read from file (almost always)
-
   contains
 
     procedure :: dis_df => disu_df

--- a/src/Model/Discretization/Disv1d.f90
+++ b/src/Model/Discretization/Disv1d.f90
@@ -23,7 +23,6 @@ module Disv1dModule
     real(DP), dimension(:), pointer, contiguous :: length => null() !< length of each reach (of size nodesuser)
     real(DP), dimension(:), pointer, contiguous :: width => null() !< reach width
     real(DP), dimension(:), pointer, contiguous :: bottom => null() !< reach bottom elevation
-    integer(I4B), dimension(:), pointer, contiguous :: idomain => null() !< idomain (of size nodesuser)
     real(DP), dimension(:, :), pointer, contiguous :: vertices => null() !< cell vertices stored as 2d array with columns of x, y
     real(DP), dimension(:, :), pointer, contiguous :: cellxy => null() !< reach midpoints stored as 2d array with columns of x, y
     real(DP), dimension(:), pointer, contiguous :: fdc => null() !< fdc stored as array

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -28,8 +28,6 @@ module Disv2dModule
     integer(I4B), dimension(:), pointer, contiguous :: iavert => null() !< cell vertex pointer ia array
     integer(I4B), dimension(:), pointer, contiguous :: javert => null() !< cell vertex pointer ja array
     real(DP), dimension(:), pointer, contiguous :: bottom => null() !< bottom elevations for each cell (nodes)
-    integer(I4B), dimension(:), pointer, contiguous :: idomain => null() !< idomain (nodes)
-
   contains
 
     procedure :: dis_df => disv2d_df

--- a/src/Model/ModelUtilities/DiscretizationBase.f90
+++ b/src/Model/ModelUtilities/DiscretizationBase.f90
@@ -53,6 +53,7 @@ module BaseDisModule
     integer(I4B), dimension(:), pointer, contiguous :: ibuff => null() !< helper int array of size nodesuser
     integer(I4B), dimension(:), pointer, contiguous :: nodereduced => null() !< (size:nodesuser)contains reduced nodenumber (size 0 if not reduced); -1 means vertical pass through, 0 is idomain = 0
     integer(I4B), dimension(:), pointer, contiguous :: nodeuser => null() !< (size:nodes) given a reduced nodenumber, provide the user nodenumber (size 0 if not reduced)
+    integer(I4B), dimension(:), pointer, contiguous :: idomain => null() !< (size:nodesuser)
   contains
     procedure :: dis_df
     procedure :: dis_ac


### PR DESCRIPTION
Store idomain as a 1D array in DisBaseType, rather than the proper grid shape in the concrete types. This deduplicates the variable and simplifes grid equivalence checks added in #2149 and planned in #2153.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Removed checklist items not relevant to this pull request