### PR TITLE
refactor(netcdf): updates focused on flopy parity

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/utl-ncf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-ncf.dfn
@@ -96,7 +96,7 @@ shape (ncpl)
 optional true
 reader readarray
 longname cell center latitude
-description cell center latitude. Only supported for NETCDF\_STRUCTURED export types.
+description cell center latitude. Only supported for NETCDF\_STRUCTURED export type.
 
 block griddata
 name longitude
@@ -105,4 +105,4 @@ shape (ncpl)
 optional true
 reader readarray
 longname cell center longitude
-description cell center longitude. Only supported for NETCDF\_STRUCTURED export types.
+description cell center longitude. Only supported for NETCDF\_STRUCTURED export type.

--- a/doc/mf6io/mf6ivar/dfn/utl-ncf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-ncf.dfn
@@ -10,7 +10,7 @@ shape lenbigline
 reader urword
 optional true
 longname CRS well-known text (WKT) string
-description is the coordinate reference system (CRS) well-known text (WKT) string.
+description is the coordinate reference system (CRS) well-known text (WKT) string. Ignored if latitude and longitude griddata arrays have been provided for NETCDF\_STRUCTURED export type.
 
 block options
 name deflate
@@ -96,7 +96,7 @@ shape (ncpl)
 optional true
 reader readarray
 longname cell center latitude
-description cell center latitude.
+description cell center latitude. Only supported for NETCDF\_STRUCTURED export types.
 
 block griddata
 name longitude
@@ -105,4 +105,4 @@ shape (ncpl)
 optional true
 reader readarray
 longname cell center longitude
-description cell center longitude.
+description cell center longitude. Only supported for NETCDF\_STRUCTURED export types.

--- a/src/Utilities/Export/DisNCMesh.f90
+++ b/src/Utilities/Export/DisNCMesh.f90
@@ -508,13 +508,12 @@ contains
     cell_x = NF90_FILL_DOUBLE
     cell_y = NF90_FILL_DOUBLE
     do j = 1, this%dis%nrow
-      x = this%dis%xorigin
       y = this%dis%celly(j) + this%dis%yorigin
       do i = 1, this%dis%ncol
+        x = this%dis%cellx(i) + this%dis%xorigin
         cell_x(cnt) = x
         cell_y(cnt) = y
         cnt = cnt + 1
-        x = this%dis%cellx(i) + this%dis%xorigin
       end do
     end do
 

--- a/src/Utilities/Export/DisNCMesh.f90
+++ b/src/Utilities/Export/DisNCMesh.f90
@@ -69,7 +69,7 @@ contains
 
     ! initialize base class
     call this%mesh_init(modelname, modeltype, modelfname, nc_fname, disenum, &
-                        nctype, iout)
+                        nctype, this%dis%lenuni, iout)
   end subroutine dis_export_init
 
   !> @brief netcdf export dis destroy

--- a/src/Utilities/Export/DisNCStructured.f90
+++ b/src/Utilities/Export/DisNCStructured.f90
@@ -640,10 +640,10 @@ contains
     call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'source', &
                                 this%annotation%source), this%nc_fname)
     ! export type (MODFLOW 6)
-    call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'modflow6_grid', &
+    call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'modflow_grid', &
                                 this%annotation%grid), this%nc_fname)
     ! MODFLOW 6 model type
-    call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'modflow6_model', &
+    call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'modflow_model', &
                                 this%annotation%model), this%nc_fname)
     ! generation datetime
     call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'history', &

--- a/src/Utilities/Export/DisNCStructured.f90
+++ b/src/Utilities/Export/DisNCStructured.f90
@@ -145,7 +145,7 @@ contains
         this%chunk_x = -1
         write (warnmsg, '(a)') 'Ignoring user provided NetCDF chunking &
           &parameters. Define chunk_time, chunk_x, chunk_y and chunk_z input &
-          &parameters to see an effect.'
+          &parameters to see an effect in file "'//trim(nc_fname)//'".'
         call store_warning(warnmsg)
       end if
 
@@ -156,7 +156,8 @@ contains
         this%latlon = .true.
         if (this%wkt /= '') then
           write (warnmsg, '(a)') 'Ignoring user provided NetCDF wkt parameter &
-            &as longitude and latitude arrays have been provided.'
+            &as longitude and latitude arrays have been provided. &
+            &Applies to file "'//trim(nc_fname)//'".'
           call store_warning(warnmsg)
           this%wkt = ''
           this%gridmap_name = ''
@@ -168,7 +169,8 @@ contains
       if (this%wkt /= '') then
         if (this%dis%angrot /= DZERO) then
           write (warnmsg, '(a)') 'WKT parameter set with structured rotated &
-            &grid. Projected coordinates will have grid local values.'
+            &grid. Projected coordinates will have grid local values. &
+            &Applies to file "'//trim(nc_fname)//'".'
           call store_warning(warnmsg)
         end if
       end if

--- a/src/Utilities/Export/DisvNCMesh.f90
+++ b/src/Utilities/Export/DisvNCMesh.f90
@@ -67,7 +67,7 @@ contains
 
     ! initialize base class
     call this%mesh_init(modelname, modeltype, modelfname, nc_fname, disenum, &
-                        nctype, iout)
+                        nctype, this%disv%lenuni, iout)
   end subroutine disv_export_init
 
   !> @brief netcdf export disv destroy

--- a/src/Utilities/Export/MeshNCModel.f90
+++ b/src/Utilities/Export/MeshNCModel.f90
@@ -158,10 +158,10 @@ contains
     call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'source', &
                                 this%annotation%source), this%nc_fname)
     ! export type (MODFLOW 6)
-    call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'modflow6_grid', &
+    call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'modflow_grid', &
                                 this%annotation%grid), this%nc_fname)
     ! MODFLOW 6 model type
-    call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'modflow6_model', &
+    call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'modflow_model', &
                                 this%annotation%model), this%nc_fname)
     ! generation datetime
     call nf_verify(nf90_put_att(this%ncid, NF90_GLOBAL, 'history', &

--- a/src/Utilities/Export/MeshNCModel.f90
+++ b/src/Utilities/Export/MeshNCModel.f90
@@ -128,7 +128,8 @@ contains
       this%chunk_face = -1
       this%chunk_time = -1
       write (warnmsg, '(a)') 'Ignoring user provided NetCDF chunking parameter. &
-        &Define chunk_time and chunk_face input parameters to see an effect.'
+        &Define chunk_time and chunk_face input parameters to see an effect in &
+        &file "'//trim(nc_fname)//'".'
       call store_warning(warnmsg)
     end if
 

--- a/src/Utilities/Export/MeshNCModel.f90
+++ b/src/Utilities/Export/MeshNCModel.f90
@@ -96,7 +96,7 @@ contains
   !> @brief initialize
   !<
   subroutine mesh_init(this, modelname, modeltype, modelfname, nc_fname, &
-                       disenum, nctype, iout)
+                       disenum, nctype, lenuni, iout)
     use MemoryManagerExtModule, only: mem_set_value
     class(MeshModelType), intent(inout) :: this
     character(len=*), intent(in) :: modelname
@@ -105,6 +105,7 @@ contains
     character(len=*), intent(in) :: nc_fname
     integer(I4B), intent(in) :: disenum
     integer(I4B), intent(in) :: nctype
+    integer(I4B), intent(in) :: lenuni
     integer(I4B), intent(in) :: iout
     logical(LGP) :: found
 
@@ -129,6 +130,12 @@ contains
       write (warnmsg, '(a)') 'Ignoring user provided NetCDF chunking parameter. &
         &Define chunk_time and chunk_face input parameters to see an effect.'
       call store_warning(warnmsg)
+    end if
+
+    if (lenuni == 1) then
+      this%lenunits = 'ft'
+    else
+      this%lenunits = 'm'
     end if
 
     ! create the netcdf file
@@ -298,7 +305,7 @@ contains
 
       ! assign variable attributes
       call nf_verify(nf90_put_att(this%ncid, this%var_ids%dependent(k), &
-                                  'units', 'm'), this%nc_fname)
+                                  'units', this%lenunits), this%nc_fname)
       call nf_verify(nf90_put_att(this%ncid, this%var_ids%dependent(k), &
                                   'standard_name', this%annotation%stdname), &
                      this%nc_fname)
@@ -377,7 +384,7 @@ contains
 
     ! assign mesh x node variable attributes
     call nf_verify(nf90_put_att(this%ncid, this%var_ids%mesh_node_x, &
-                                'units', 'm'), this%nc_fname)
+                                'units', this%lenunits), this%nc_fname)
     call nf_verify(nf90_put_att(this%ncid, this%var_ids%mesh_node_x, &
                                 'standard_name', 'projection_x_coordinate'), &
                    this%nc_fname)
@@ -398,7 +405,7 @@ contains
 
     ! assign mesh y variable attributes
     call nf_verify(nf90_put_att(this%ncid, this%var_ids%mesh_node_y, &
-                                'units', 'm'), this%nc_fname)
+                                'units', this%lenunits), this%nc_fname)
     call nf_verify(nf90_put_att(this%ncid, this%var_ids%mesh_node_y, &
                                 'standard_name', 'projection_y_coordinate'), &
                    this%nc_fname)
@@ -419,7 +426,7 @@ contains
 
     ! assign mesh x face variable attributes
     call nf_verify(nf90_put_att(this%ncid, this%var_ids%mesh_face_x, &
-                                'units', 'm'), this%nc_fname)
+                                'units', this%lenunits), this%nc_fname)
     call nf_verify(nf90_put_att(this%ncid, this%var_ids%mesh_face_x, &
                                 'standard_name', 'projection_x_coordinate'), &
                    this%nc_fname)
@@ -448,7 +455,7 @@ contains
 
     ! assign mesh y face variable attributes
     call nf_verify(nf90_put_att(this%ncid, this%var_ids%mesh_face_y, &
-                                'units', 'm'), this%nc_fname)
+                                'units', this%lenunits), this%nc_fname)
     call nf_verify(nf90_put_att(this%ncid, this%var_ids%mesh_face_y, &
                                 'standard_name', 'projection_y_coordinate'), &
                    this%nc_fname)

--- a/src/Utilities/Export/NCModel.f90
+++ b/src/Utilities/Export/NCModel.f90
@@ -77,6 +77,7 @@ module NCModelExportModule
     character(len=LENBIGLINE) :: wkt !< wkt user string
     character(len=LINELENGTH) :: datetime !< export file creation time
     character(len=LINELENGTH) :: xname !< dependent variable name
+    character(len=LINELENGTH) :: lenunits !< unidata udunits length units
     type(NCExportAnnotation) :: annotation !< export file annotation
     real(DP), dimension(:), pointer, contiguous :: x !< dependent variable pointer
     integer(I4B) :: disenum !< type of discretization
@@ -296,6 +297,7 @@ contains
     this%wkt = ''
     this%datetime = ''
     this%xname = ''
+    this%lenunits = ''
     this%disenum = disenum
     this%ncid = 0
     this%stepcnt = 0

--- a/src/Utilities/Idm/netcdf/NCContextBuild.f90
+++ b/src/Utilities/Idm/netcdf/NCContextBuild.f90
@@ -116,7 +116,7 @@ contains
     end if
   end subroutine add_package_var
 
-  !> @brief verify global attribute modflow6_grid is present and return value
+  !> @brief verify global attribute modflow_grid is present and return value
   !<
   function verify_global_attr(modeltype, modelname, input_name, nc_fname, ncid) &
     result(grid)
@@ -132,7 +132,7 @@ contains
     grid = ''
 
     ! verify expected mf6_modeltype file attribute
-    if (nf90_get_att(ncid, NF90_GLOBAL, "modflow6_grid", &
+    if (nf90_get_att(ncid, NF90_GLOBAL, "modflow_grid", &
                      grid) == NF90_NOERR) then
       ! set grid to upper case
       call upcase(grid)

--- a/src/Utilities/Idm/netcdf/NCContextBuild.f90
+++ b/src/Utilities/Idm/netcdf/NCContextBuild.f90
@@ -137,7 +137,7 @@ contains
       ! set grid to upper case
       call upcase(grid)
     else
-      errmsg = 'NetCDF input file global attribute "grid" not found.'
+      errmsg = 'NetCDF input file global attribute "modflow_grid" not found.'
       call store_error(errmsg)
       call store_error_filename(nc_fname)
     end if


### PR DESCRIPTION
Adjustment to model NetCDF input file creation that align with [FloPy #2417](https://github.com/modflowpy/flopy/pull/2417):
  - Fix DIS mesh_face_x array, which was off by an index
  - Rotate mesh x and y coordinates when angle of rotation has been specified
  - Structured export projected coordinates are never rotated.  Only translate if angrot is 0.0, otherwise leave in grid local coordinates.
  - Structured exports support either latitude / longitude geographic coordinates or a projection variable for grid mapping via the wkt string but not both.  Latitude and longitude coordinates can be rotated.
  - change global attributes "modflow6_grid" and "modflow6_model" to "modflow_grid" and "modflow_model", as these identifiers might be more generally applied
  - After FloPy PR is merged, a follow up PR will update autotests to use new functionality

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).