### PR TITLE
refactor(prt): deconflict naming, use enum for tracking level

### DIFF
--- a/doc/mf6io/prt/prt.tex
+++ b/doc/mf6io/prt/prt.tex
@@ -115,6 +115,7 @@ The ISTATUS field indicates the status of the particle:
 \item \texttt{7}: particle terminated in an inactive cell
 \item \texttt{8}: particle terminated immediately upon release into a dry cell
 \item \texttt{9}: particle terminated in a subcell with no exit face
+\item \texttt{10}: particle terminated at stop time or end of simulation
 \end{description}
 
 The IREASON field indicates the reason the particle track record was saved:

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -528,11 +528,11 @@ contains
     end if
 
     particle%ttrack = particle%trelease
-    particle%idomain(1) = 0
+    particle%itrdomain(1) = 0
     particle%iboundary(1) = 0
-    particle%idomain(2) = ic
+    particle%itrdomain(2) = ic
     particle%iboundary(2) = 0
-    particle%idomain(3) = 0
+    particle%itrdomain(3) = 0
     particle%iboundary(3) = 0
     particle%ifrctrn = this%ifrctrn
     particle%iexmeth = this%iexmeth

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -445,7 +445,7 @@ contains
   end subroutine release
 
   subroutine initialize_particle(this, particle, ip, trelease)
-    use ParticleModule, only: TERM_UNRELEASED
+    use ParticleModule, only: TERM_UNRELEASED, LVL_MODEL, LVL_CELL, LVL_SUBCELL
     class(PrtPrpType), intent(inout) :: this !< this instance
     type(ParticleType), pointer, intent(inout) :: particle !< the particle
     integer(I4B), intent(in) :: ip !< particle index
@@ -528,12 +528,12 @@ contains
     end if
 
     particle%ttrack = particle%trelease
-    particle%itrdomain(1) = 0
-    particle%iboundary(1) = 0
-    particle%itrdomain(2) = ic
-    particle%iboundary(2) = 0
-    particle%itrdomain(3) = 0
-    particle%iboundary(3) = 0
+    particle%itrdomain(LVL_MODEL) = 0
+    particle%iboundary(LVL_MODEL) = 0
+    particle%itrdomain(LVL_CELL) = ic
+    particle%iboundary(LVL_CELL) = 0
+    particle%itrdomain(LVL_SUBCELL) = 0
+    particle%iboundary(LVL_SUBCELL) = 0
     particle%ifrctrn = this%ifrctrn
     particle%iexmeth = this%iexmeth
     particle%iextend = this%iextend

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -405,6 +405,7 @@ contains
 
   !> @brief Calculate particle mass storage
   subroutine prt_cq_sto(this)
+    use ParticleModule, only: LVL_CELL
     ! modules
     use TdisModule, only: delt
     use PrtPrpModule, only: PrtPrpType
@@ -436,7 +437,7 @@ contains
           istatus = packobj%particles%istatus(np)
           ! this may need to change if istatus flags change
           if ((istatus > 0) .and. (istatus /= 8)) then
-            n = packobj%particles%itrdomain(np, 2)
+            n = packobj%particles%itrdomain(np, LVL_CELL)
             ! Each particle currently assigned unit mass
             this%masssto(n) = this%masssto(n) + DONE
           end if

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -436,7 +436,7 @@ contains
           istatus = packobj%particles%istatus(np)
           ! this may need to change if istatus flags change
           if ((istatus > 0) .and. (istatus /= 8)) then
-            n = packobj%particles%idomain(np, 2)
+            n = packobj%particles%itrdomain(np, 2)
             ! Each particle currently assigned unit mass
             this%masssto(n) = this%masssto(n) + DONE
           end if

--- a/src/Solution/ParticleTracker/MethodCellPassToBot.f90
+++ b/src/Solution/ParticleTracker/MethodCellPassToBot.f90
@@ -43,7 +43,7 @@ contains
 
   !> @brief Pass particle vertically and instantaneously to the cell bottom
   subroutine apply_ptb(this, particle, tmax)
-    use ParticleModule, only: TERM_NO_EXITS
+    use ParticleModule, only: TERM_NO_EXITS, LVL_CELL
     ! dummy
     class(MethodCellPassToBotType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -57,7 +57,7 @@ contains
 
     ! Pass to bottom face
     particle%z = this%cell%defn%bot
-    particle%iboundary(2) = this%cell%defn%npolyverts + 2
+    particle%iboundary(LVL_CELL) = this%cell%defn%npolyverts + 2
 
     ! Terminate if in bottom layer
     select type (dis => this%fmi%dis)

--- a/src/Solution/ParticleTracker/MethodCellPollock.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollock.f90
@@ -68,7 +68,7 @@ contains
       trackctl=this%trackctl, &
       tracktimes=this%tracktimes)
     submethod => method_subcell_plck
-    particle%idomain(next_level) = 1
+    particle%itrdomain(next_level) = 1
   end subroutine load_mcp
 
   !> @brief Having exited the lone subcell, pass the particle to the cell face

--- a/src/Solution/ParticleTracker/MethodCellPollock.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollock.f90
@@ -74,6 +74,7 @@ contains
   !> @brief Having exited the lone subcell, pass the particle to the cell face
   !! In this case the lone subcell is the cell.
   subroutine pass_mcp(this, particle)
+    use ParticleModule, only: LVL_CELL, LVL_SUBCELL
     ! dummy
     class(MethodCellPollockType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -81,7 +82,7 @@ contains
     integer(I4B) :: exitface
     integer(I4B) :: entryface
 
-    exitface = particle%iboundary(3)
+    exitface = particle%iboundary(LVL_SUBCELL)
     ! Map subcell exit face to cell face
     select case (exitface) ! note: exitFace uses Dave's iface convention
     case (0)
@@ -100,7 +101,7 @@ contains
       entryface = 7
     end select
     if (entryface .eq. -1) then
-      particle%iboundary(2) = 0
+      particle%iboundary(LVL_CELL) = 0
     else
       if ((entryface .ge. 1) .and. (entryface .le. 4)) then
         ! Account for local cell rotation
@@ -110,7 +111,7 @@ contains
         end select
         if (entryface .gt. 4) entryface = entryface - 4
       end if
-      particle%iboundary(2) = entryface
+      particle%iboundary(LVL_CELL) = entryface
     end if
   end subroutine pass_mcp
 

--- a/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
@@ -71,6 +71,7 @@ contains
 
   !> @brief Pass particle to next subcell if there is one, or to the cell face
   subroutine pass_mcpq(this, particle)
+    use ParticleModule, only: LVL_CELL, LVL_SUBCELL
     ! dummy
     class(MethodCellPollockQuadType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -79,8 +80,8 @@ contains
 
     select type (cell => this%cell)
     type is (CellRectQuadType)
-      exitFace = particle%iboundary(3)
-      isc = particle%itrdomain(3)
+      exitFace = particle%iboundary(LVL_SUBCELL)
+      isc = particle%itrdomain(LVL_SUBCELL)
       npolyverts = cell%defn%npolyverts
 
       ! exitFace uses MODPATH 7 iface convention here
@@ -92,13 +93,13 @@ contains
         select case (isc)
         case (1)
           ! W face, subcell 1 --> E face, subcell 4  (cell interior)
-          particle%itrdomain(3) = 4
-          particle%iboundary(3) = 2
+          particle%itrdomain(LVL_SUBCELL) = 4
+          particle%iboundary(LVL_SUBCELL) = 2
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (2)
           ! W face, subcell 2 --> E face, subcell 3 (cell interior)
-          particle%itrdomain(3) = 3
-          particle%iboundary(3) = 2
+          particle%itrdomain(LVL_SUBCELL) = 3
+          particle%iboundary(LVL_SUBCELL) = 2
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (3)
           ! W face, subcell 3 (cell face)
@@ -121,21 +122,21 @@ contains
           infaceoff = -1
         case (3)
           ! E face, subcell 3 --> W face, subcell 2 (cell interior)
-          particle%itrdomain(3) = 2
-          particle%iboundary(3) = 1
+          particle%itrdomain(LVL_SUBCELL) = 2
+          particle%iboundary(LVL_SUBCELL) = 1
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (4)
           ! E face, subcell 4 --> W face subcell 1 (cell interior)
-          particle%itrdomain(3) = 1
-          particle%iboundary(3) = 1
+          particle%itrdomain(LVL_SUBCELL) = 1
+          particle%iboundary(LVL_SUBCELL) = 1
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         end select
       case (3)
         select case (isc)
         case (1)
           ! S face, subcell 1 --> N face, subcell 2 (cell interior)
-          particle%itrdomain(3) = 2
-          particle%iboundary(3) = 4
+          particle%itrdomain(LVL_SUBCELL) = 2
+          particle%iboundary(LVL_SUBCELL) = 4
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (2)
           ! S face, subcell 2 (cell face)
@@ -147,8 +148,8 @@ contains
           infaceoff = -1
         case (4)
           ! S face, subcell 4 --> N face, subcell 3 (cell interior)
-          particle%itrdomain(3) = 3
-          particle%iboundary(3) = 4
+          particle%itrdomain(LVL_SUBCELL) = 3
+          particle%iboundary(LVL_SUBCELL) = 4
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         end select
       case (4)
@@ -159,13 +160,13 @@ contains
           infaceoff = -1
         case (2)
           ! N face, subcell 2 --> S face, subcell 1 (cell interior)
-          particle%itrdomain(3) = 1
-          particle%iboundary(3) = 3
+          particle%itrdomain(LVL_SUBCELL) = 1
+          particle%iboundary(LVL_SUBCELL) = 3
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (3)
           ! N face, subcell 3 --> S face, subcell 4 (cell interior)
-          particle%itrdomain(3) = 4
-          particle%iboundary(3) = 3
+          particle%itrdomain(LVL_SUBCELL) = 4
+          particle%iboundary(LVL_SUBCELL) = 3
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (4)
           ! N face, subcell 4 (cell face)
@@ -181,9 +182,9 @@ contains
       end select
 
       if (inface .eq. -1) then
-        particle%iboundary(2) = 0
+        particle%iboundary(LVL_CELL) = 0
       else if (inface .eq. 0) then
-        particle%iboundary(2) = 0
+        particle%iboundary(LVL_CELL) = 0
       else
         if ((inface .ge. 1) .and. (inface .le. 4)) then
           ! Account for local cell rotation
@@ -192,7 +193,7 @@ contains
           inface = cell%irectvert(inface) + infaceoff
           if (inface .lt. 1) inface = inface + npolyverts
         end if
-        particle%iboundary(2) = inface
+        particle%iboundary(LVL_CELL) = inface
       end if
     end select
   end subroutine pass_mcpq
@@ -234,6 +235,7 @@ contains
 
   !> @brief Load the rectangular subcell from the rectangular cell
   subroutine load_subcell(this, particle, subcell)
+    use ParticleModule, only: LVL_SUBCELL
     ! dummy
     class(MethodCellPollockQuadType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -251,7 +253,7 @@ contains
       factor = factor / cell%defn%porosity
       npolyverts = cell%defn%npolyverts
 
-      isc = particle%itrdomain(3)
+      isc = particle%itrdomain(LVL_SUBCELL)
       ! Subcells 1, 2, 3, and 4 are Pollock's subcells A, B, C, and D,
       ! respectively
 
@@ -277,7 +279,7 @@ contains
         end if
 
         subcell%isubcell = isc
-        particle%itrdomain(3) = isc
+        particle%itrdomain(LVL_SUBCELL) = isc
       end if
       dx = 5d-1 * dx
       dy = 5d-1 * dy

--- a/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
@@ -80,7 +80,7 @@ contains
     select type (cell => this%cell)
     type is (CellRectQuadType)
       exitFace = particle%iboundary(3)
-      isc = particle%idomain(3)
+      isc = particle%itrdomain(3)
       npolyverts = cell%defn%npolyverts
 
       ! exitFace uses MODPATH 7 iface convention here
@@ -92,12 +92,12 @@ contains
         select case (isc)
         case (1)
           ! W face, subcell 1 --> E face, subcell 4  (cell interior)
-          particle%idomain(3) = 4
+          particle%itrdomain(3) = 4
           particle%iboundary(3) = 2
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (2)
           ! W face, subcell 2 --> E face, subcell 3 (cell interior)
-          particle%idomain(3) = 3
+          particle%itrdomain(3) = 3
           particle%iboundary(3) = 2
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (3)
@@ -121,12 +121,12 @@ contains
           infaceoff = -1
         case (3)
           ! E face, subcell 3 --> W face, subcell 2 (cell interior)
-          particle%idomain(3) = 2
+          particle%itrdomain(3) = 2
           particle%iboundary(3) = 1
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (4)
           ! E face, subcell 4 --> W face subcell 1 (cell interior)
-          particle%idomain(3) = 1
+          particle%itrdomain(3) = 1
           particle%iboundary(3) = 1
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         end select
@@ -134,7 +134,7 @@ contains
         select case (isc)
         case (1)
           ! S face, subcell 1 --> N face, subcell 2 (cell interior)
-          particle%idomain(3) = 2
+          particle%itrdomain(3) = 2
           particle%iboundary(3) = 4
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (2)
@@ -147,7 +147,7 @@ contains
           infaceoff = -1
         case (4)
           ! S face, subcell 4 --> N face, subcell 3 (cell interior)
-          particle%idomain(3) = 3
+          particle%itrdomain(3) = 3
           particle%iboundary(3) = 4
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         end select
@@ -159,12 +159,12 @@ contains
           infaceoff = -1
         case (2)
           ! N face, subcell 2 --> S face, subcell 1 (cell interior)
-          particle%idomain(3) = 1
+          particle%itrdomain(3) = 1
           particle%iboundary(3) = 3
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (3)
           ! N face, subcell 3 --> S face, subcell 4 (cell interior)
-          particle%idomain(3) = 4
+          particle%itrdomain(3) = 4
           particle%iboundary(3) = 3
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (4)
@@ -251,7 +251,7 @@ contains
       factor = factor / cell%defn%porosity
       npolyverts = cell%defn%npolyverts
 
-      isc = particle%idomain(3)
+      isc = particle%itrdomain(3)
       ! Subcells 1, 2, 3, and 4 are Pollock's subcells A, B, C, and D,
       ! respectively
 
@@ -277,7 +277,7 @@ contains
         end if
 
         subcell%isubcell = isc
-        particle%idomain(3) = isc
+        particle%itrdomain(3) = isc
       end if
       dx = 5d-1 * dx
       dy = 5d-1 * dy

--- a/src/Solution/ParticleTracker/MethodCellTernary.f90
+++ b/src/Solution/ParticleTracker/MethodCellTernary.f90
@@ -108,7 +108,7 @@ contains
     integer(I4B) :: inface
 
     exitFace = particle%iboundary(3)
-    isc = particle%idomain(3)
+    isc = particle%itrdomain(3)
 
     select case (exitFace)
     case (0)
@@ -122,14 +122,14 @@ contains
       ! Subcell face --> next subcell in "cycle" (cell interior)
       isc = isc + 1
       if (isc .gt. this%nverts) isc = 1
-      particle%idomain(3) = isc
+      particle%itrdomain(3) = isc
       particle%iboundary(3) = 3
       inface = 0
     case (3)
       ! Subcell face --> preceding subcell in "cycle" (cell interior)
       isc = isc - 1
       if (isc .lt. 1) isc = this%nverts
-      particle%idomain(3) = isc
+      particle%itrdomain(3) = isc
       particle%iboundary(3) = 2
       inface = 0
     case (4)
@@ -280,7 +280,7 @@ contains
     type is (CellPolyType)
       ic = cell%defn%icell
       subcell%icell = ic
-      isc = particle%idomain(3)
+      isc = particle%itrdomain(3)
       if (isc .le. 0) then
         xi = particle%x
         yi = particle%y
@@ -315,7 +315,7 @@ contains
 
           call pstop(1)
         else
-          particle%idomain(3) = isc
+          particle%itrdomain(3) = isc
         end if
       end if
       subcell%isubcell = isc

--- a/src/Solution/ParticleTracker/MethodCellTernary.f90
+++ b/src/Solution/ParticleTracker/MethodCellTernary.f90
@@ -99,6 +99,7 @@ contains
 
   !> @brief Pass particle to next subcell if there is one, or to the cell face
   subroutine pass_mct(this, particle)
+    use ParticleModule, only: LVL_CELL, LVL_SUBCELL
     ! dummy
     class(MethodCellTernaryType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -107,8 +108,8 @@ contains
     integer(I4B) :: exitFace
     integer(I4B) :: inface
 
-    exitFace = particle%iboundary(3)
-    isc = particle%itrdomain(3)
+    exitFace = particle%iboundary(LVL_SUBCELL)
+    isc = particle%itrdomain(LVL_SUBCELL)
 
     select case (exitFace)
     case (0)
@@ -122,15 +123,15 @@ contains
       ! Subcell face --> next subcell in "cycle" (cell interior)
       isc = isc + 1
       if (isc .gt. this%nverts) isc = 1
-      particle%itrdomain(3) = isc
-      particle%iboundary(3) = 3
+      particle%itrdomain(LVL_SUBCELL) = isc
+      particle%iboundary(LVL_SUBCELL) = 3
       inface = 0
     case (3)
       ! Subcell face --> preceding subcell in "cycle" (cell interior)
       isc = isc - 1
       if (isc .lt. 1) isc = this%nverts
-      particle%itrdomain(3) = isc
-      particle%iboundary(3) = 2
+      particle%itrdomain(LVL_SUBCELL) = isc
+      particle%iboundary(LVL_SUBCELL) = 2
       inface = 0
     case (4)
       ! Subcell bottom (cell bottom)
@@ -141,11 +142,11 @@ contains
     end select
 
     if (inface .eq. -1) then
-      particle%iboundary(2) = 0
+      particle%iboundary(LVL_CELL) = 0
     else if (inface .eq. 0) then
-      particle%iboundary(2) = 0
+      particle%iboundary(LVL_CELL) = 0
     else
-      particle%iboundary(2) = inface
+      particle%iboundary(LVL_CELL) = inface
     end if
   end subroutine pass_mct
 
@@ -248,6 +249,7 @@ contains
 
   !> @brief Loads a triangular subcell from the polygonal cell
   subroutine load_subcell(this, particle, subcell)
+    use ParticleModule, only: LVL_SUBCELL
     ! dummy
     class(MethodCellTernaryType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -280,7 +282,7 @@ contains
     type is (CellPolyType)
       ic = cell%defn%icell
       subcell%icell = ic
-      isc = particle%itrdomain(3)
+      isc = particle%itrdomain(LVL_SUBCELL)
       if (isc .le. 0) then
         xi = particle%x
         yi = particle%y
@@ -315,7 +317,7 @@ contains
 
           call pstop(1)
         else
-          particle%itrdomain(3) = isc
+          particle%itrdomain(LVL_SUBCELL) = isc
         end if
       end if
       subcell%isubcell = isc

--- a/src/Solution/ParticleTracker/MethodDis.f90
+++ b/src/Solution/ParticleTracker/MethodDis.f90
@@ -144,7 +144,7 @@ contains
 
     select type (cell => this%cell)
     type is (CellRectType)
-      ic = particle%idomain(next_level)
+      ic = particle%itrdomain(next_level)
       call this%load_celldefn(ic, cell%defn)
       call this%load_cell(ic, cell)
       if (this%fmi%ibdgwfsat0(ic) == 0) then
@@ -210,18 +210,18 @@ contains
       ! in the previous cell.
       if (ic == particle%icp .and. inface == 7 .and. ilay < particle%ilay) then
         particle%advancing = .false.
-        particle%idomain(2) = particle%icp
+        particle%itrdomain(2) = particle%icp
         particle%istatus = TERM_BOUNDARY
         particle%izone = particle%izp
         call this%save(particle, reason=3)
         return
       else
-        particle%icp = particle%idomain(2)
+        particle%icp = particle%itrdomain(2)
         particle%izp = particle%izone
       end if
 
       ! update node numbers and layer
-      particle%idomain(2) = ic
+      particle%itrdomain(2) = ic
       particle%icu = icu
       particle%ilay = ilay
 

--- a/src/Solution/ParticleTracker/MethodDis.f90
+++ b/src/Solution/ParticleTracker/MethodDis.f90
@@ -168,7 +168,7 @@ contains
   !> @brief Load cell properties into the particle, including
   ! the z coordinate, entry face, and node and layer numbers.
   subroutine load_particle(this, cell, particle)
-    use ParticleModule, only: TERM_BOUNDARY
+    use ParticleModule, only: TERM_BOUNDARY, LVL_CELL
     ! dummy
     class(MethodDisType), intent(inout) :: this
     type(CellRectType), pointer, intent(inout) :: cell
@@ -194,7 +194,7 @@ contains
     select type (dis => this%fmi%dis)
     type is (DisType)
       ! compute reduced/user node numbers and layer
-      inface = particle%iboundary(2)
+      inface = particle%iboundary(LVL_CELL)
       inbr = cell%defn%facenbr(inface)
       idiag = this%fmi%dis%con%ia(cell%defn%icell)
       ipos = idiag + inbr
@@ -210,18 +210,18 @@ contains
       ! in the previous cell.
       if (ic == particle%icp .and. inface == 7 .and. ilay < particle%ilay) then
         particle%advancing = .false.
-        particle%itrdomain(2) = particle%icp
+        particle%itrdomain(LVL_CELL) = particle%icp
         particle%istatus = TERM_BOUNDARY
         particle%izone = particle%izp
         call this%save(particle, reason=3)
         return
       else
-        particle%icp = particle%itrdomain(2)
+        particle%icp = particle%itrdomain(LVL_CELL)
         particle%izp = particle%izone
       end if
 
       ! update node numbers and layer
-      particle%itrdomain(2) = ic
+      particle%itrdomain(LVL_CELL) = ic
       particle%icu = icu
       particle%ilay = ilay
 
@@ -239,7 +239,7 @@ contains
       else if (inface .eq. 7) then
         inface = 6
       end if
-      particle%iboundary(2) = inface
+      particle%iboundary(LVL_CELL) = inface
 
       ! map z between cells
       z = particle%z
@@ -259,6 +259,7 @@ contains
   !> @brief Update cell-cell flows of particle mass.
   !! Every particle is currently assigned unit mass.
   subroutine update_flowja(this, cell, particle)
+    use ParticleModule, only: LVL_CELL
     ! dummy
     class(MethodDisType), intent(inout) :: this
     type(CellRectType), pointer, intent(inout) :: cell
@@ -269,7 +270,7 @@ contains
     integer(I4B) :: inface
     integer(I4B) :: ipos
 
-    inface = particle%iboundary(2)
+    inface = particle%iboundary(LVL_CELL)
     inbr = cell%defn%facenbr(inface)
     idiag = this%fmi%dis%con%ia(cell%defn%icell)
     ipos = idiag + inbr
@@ -284,7 +285,7 @@ contains
 
   !> @brief Pass a particle to the next cell, if there is one
   subroutine pass_dis(this, particle)
-    use ParticleModule, only: TERM_BOUNDARY
+    use ParticleModule, only: TERM_BOUNDARY, LVL_CELL
     ! dummy
     class(MethodDisType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -297,7 +298,7 @@ contains
       ! If the entry face has no neighbors it's a
       ! boundary face, so terminate the particle.
       ! todo AMP: reconsider when multiple models supported
-      if (cell%defn%facenbr(particle%iboundary(2)) .eq. 0) then
+      if (cell%defn%facenbr(particle%iboundary(LVL_CELL)) .eq. 0) then
         particle%istatus = TERM_BOUNDARY
         particle%advancing = .false.
         call this%save(particle, reason=3)

--- a/src/Solution/ParticleTracker/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/MethodDisv.f90
@@ -85,7 +85,7 @@ contains
 
     select type (cell => this%cell)
     type is (CellPolyType)
-      ic = particle%idomain(next_level)
+      ic = particle%itrdomain(next_level)
       call this%load_cell_defn(ic, cell%defn)
       if (this%fmi%ibdgwfsat0(ic) == 0) then
         ! Cell is active but dry, so select and initialize pass-to-bottom
@@ -174,17 +174,17 @@ contains
       ! in the previous cell.
       if (ic == particle%icp .and. inface == 7 .and. ilay < particle%ilay) then
         particle%advancing = .false.
-        particle%idomain(2) = particle%icp
+        particle%itrdomain(2) = particle%icp
         particle%istatus = TERM_BOUNDARY
         particle%izone = particle%izp
         call this%save(particle, reason=3)
         return
       else
-        particle%icp = particle%idomain(2)
+        particle%icp = particle%itrdomain(2)
         particle%izp = particle%izone
       end if
 
-      particle%idomain(2) = ic
+      particle%itrdomain(2) = ic
       particle%icu = icu
       particle%ilay = ilay
 
@@ -192,7 +192,7 @@ contains
       call this%map_neighbor(cell%defn, inface, z)
 
       particle%iboundary(2) = inface
-      particle%idomain(3:) = 0
+      particle%itrdomain(3:) = 0
       particle%iboundary(3:) = 0
       particle%z = z
     end select

--- a/src/Solution/ParticleTracker/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/MethodDisv.f90
@@ -141,7 +141,7 @@ contains
   subroutine load_particle(this, cell, particle)
     ! modules
     use DisvModule, only: DisvType
-    use ParticleModule, only: TERM_BOUNDARY
+    use ParticleModule, only: TERM_BOUNDARY, LVL_CELL, LVL_SUBCELL
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     type(CellPolyType), pointer, intent(inout) :: cell
@@ -159,7 +159,7 @@ contains
 
     select type (dis => this%fmi%dis)
     type is (DisvType)
-      inface = particle%iboundary(2)
+      inface = particle%iboundary(LVL_CELL)
       idiag = dis%con%ia(cell%defn%icell)
       inbr = cell%defn%facenbr(inface)
       ipos = idiag + inbr
@@ -174,32 +174,33 @@ contains
       ! in the previous cell.
       if (ic == particle%icp .and. inface == 7 .and. ilay < particle%ilay) then
         particle%advancing = .false.
-        particle%itrdomain(2) = particle%icp
+        particle%itrdomain(LVL_CELL) = particle%icp
         particle%istatus = TERM_BOUNDARY
         particle%izone = particle%izp
         call this%save(particle, reason=3)
         return
       else
-        particle%icp = particle%itrdomain(2)
+        particle%icp = particle%itrdomain(LVL_CELL)
         particle%izp = particle%izone
       end if
 
-      particle%itrdomain(2) = ic
+      particle%itrdomain(LVL_CELL) = ic
       particle%icu = icu
       particle%ilay = ilay
 
       z = particle%z
       call this%map_neighbor(cell%defn, inface, z)
 
-      particle%iboundary(2) = inface
-      particle%itrdomain(3:) = 0
-      particle%iboundary(3:) = 0
+      particle%iboundary(LVL_CELL) = inface
+      particle%itrdomain(LVL_SUBCELL:) = 0
+      particle%iboundary(LVL_SUBCELL:) = 0
       particle%z = z
     end select
 
   end subroutine
 
   subroutine update_flowja(this, cell, particle)
+    use ParticleModule, only: LVL_CELL
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     type(CellPolyType), pointer, intent(inout) :: cell
@@ -210,7 +211,7 @@ contains
     integer(I4B) :: ipos
 
     idiag = this%fmi%dis%con%ia(cell%defn%icell)
-    inbr = cell%defn%facenbr(particle%iboundary(2))
+    inbr = cell%defn%facenbr(particle%iboundary(LVL_CELL))
     ipos = idiag + inbr
 
     ! leaving old cell
@@ -224,7 +225,7 @@ contains
 
   !> @brief Pass a particle to the next cell, if there is one
   subroutine pass_disv(this, particle)
-    use ParticleModule, only: TERM_BOUNDARY
+    use ParticleModule, only: TERM_BOUNDARY, LVL_CELL
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -237,7 +238,7 @@ contains
       ! If the entry face has no neighbors it's a
       ! boundary face, so terminate the particle.
       ! todo AMP: reconsider when multiple models supported
-      if (cell%defn%facenbr(particle%iboundary(2)) .eq. 0) then
+      if (cell%defn%facenbr(particle%iboundary(LVL_CELL)) .eq. 0) then
         particle%istatus = TERM_BOUNDARY
         particle%advancing = .false.
         call this%save(particle, reason=3)

--- a/src/Solution/ParticleTracker/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/MethodSubcellPollock.f90
@@ -84,7 +84,7 @@ contains
   !! this context and for any modifications or errors.
   !<
   subroutine track_subcell(this, subcell, particle, tmax)
-    use ParticleModule, only: ACTIVE, TERM_NO_EXITS_SUB
+    use ParticleModule, only: ACTIVE, TERM_NO_EXITS_SUB, LVL_SUBCELL
     ! dummy
     class(MethodSubcellPollockType), intent(inout) :: this
     class(SubcellRectType), intent(in) :: subcell
@@ -260,7 +260,7 @@ contains
     particle%y = y * subcell%dy
     particle%z = z * subcell%dz
     particle%ttrack = t
-    particle%iboundary(3) = exitFace
+    particle%iboundary(LVL_SUBCELL) = exitFace
 
     ! Save particle track record
     if (reason >= 0) call this%save(particle, reason=reason)

--- a/src/Solution/ParticleTracker/MethodSubcellTernary.f90
+++ b/src/Solution/ParticleTracker/MethodSubcellTernary.f90
@@ -63,7 +63,7 @@ contains
 
   !> @brief Track a particle across a triangular subcell.
   subroutine track_subcell(this, subcell, particle, tmax)
-    use ParticleModule, only: ACTIVE, TERM_NO_EXITS_SUB
+    use ParticleModule, only: ACTIVE, TERM_NO_EXITS_SUB, LVL_SUBCELL
     ! dummy
     class(MethodSubcellTernaryType), intent(inout) :: this
     class(SubcellTriType), intent(in) :: subcell
@@ -202,7 +202,7 @@ contains
     vziodz = vzi / dz
 
     ! If possible, track the particle across the subcell.
-    itrifaceenter = particle%iboundary(3) - 1
+    itrifaceenter = particle%iboundary(LVL_SUBCELL) - 1
     if (itrifaceenter == -1) itrifaceenter = 999
     call traverse_triangle(isolv, tol, &
                            dtexitxy, alpexit, betexit, &
@@ -292,7 +292,7 @@ contains
     particle%y = y
     particle%z = z
     particle%ttrack = t
-    particle%iboundary(3) = exitFace
+    particle%iboundary(LVL_SUBCELL) = exitFace
 
     call this%save(particle, reason=reason)
   end subroutine track_subcell

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -14,6 +14,12 @@ module ParticleModule
   !! more methods as appropriate for finer-grained levels.
   integer, parameter :: MAX_LEVEL = 4
 
+  !> @brief Particle tracking level.
+  !!
+  !! Identifies the domain over which a tracking method is responsible for
+  !! moving a particle. Tracking methods at lower levels (coarser-grained)
+  !! defer to higher-level (finer-grained) methods within their subdomains.
+  !<
   enum, bind(C)
     enumerator :: LVL_MODEL = 1
     enumerator :: LVL_CELL = 2

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -14,6 +14,12 @@ module ParticleModule
   !! more methods as appropriate for finer-grained levels.
   integer, parameter :: MAX_LEVEL = 4
 
+  enum, bind(C)
+    enumerator :: LVL_MODEL = 1
+    enumerator :: LVL_CELL = 2
+    enumerator :: LVL_SUBCELL = 3
+  end enum
+
   !> @brief Particle status enumeration.
   !!
   !! Particles begin in status 1 (active) at release time. Status may only
@@ -88,7 +94,7 @@ module ParticleModule
     integer(I4B), public :: istopzone !< stop zone number
     integer(I4B), public :: idrymeth !< dry tracking method
     ! state
-    integer(I4B), allocatable, public :: idomain(:) !< tracking domain hierarchy ! TODO: rename to itdomain? idomain
+    integer(I4B), allocatable, public :: itrdomain(:) !< tracking domain
     integer(I4B), allocatable, public :: iboundary(:) !< tracking domain boundaries
     integer(I4B), public :: icp !< previous cell number (reduced)
     integer(I4B), public :: icu !< user cell number
@@ -132,7 +138,7 @@ module ParticleModule
     integer(I4B), dimension(:), pointer, public, contiguous :: istopzone !< stop zone number
     integer(I4B), dimension(:), pointer, public, contiguous :: idrymeth !< stop in dry cells
     ! state
-    integer(I4B), dimension(:, :), pointer, public, contiguous :: idomain !< array of indices for domains in the tracking domain hierarchy
+    integer(I4B), dimension(:, :), pointer, public, contiguous :: itrdomain !< array of indices for domains in the tracking domain hierarchy
     integer(I4B), dimension(:, :), pointer, public, contiguous :: iboundary !< array of indices for tracking domain boundaries
     integer(I4B), dimension(:), pointer, public, contiguous :: icu !< cell number (user)
     integer(I4B), dimension(:), pointer, public, contiguous :: ilay !< layer
@@ -163,7 +169,7 @@ contains
   subroutine create_particle(particle)
     type(ParticleType), pointer :: particle !< particle
     allocate (particle)
-    allocate (particle%idomain(MAX_LEVEL))
+    allocate (particle%itrdomain(MAX_LEVEL))
     allocate (particle%iboundary(MAX_LEVEL))
   end subroutine create_particle
 
@@ -196,7 +202,7 @@ contains
     call mem_allocate(store%iexmeth, np, 'PLIEXMETH', mempath)
     call mem_allocate(store%extol, np, 'PLEXTOL', mempath)
     call mem_allocate(store%extend, np, 'PLIEXTEND', mempath)
-    call mem_allocate(store%idomain, np, MAX_LEVEL, 'PLIDOMAIN', mempath)
+    call mem_allocate(store%itrdomain, np, MAX_LEVEL, 'PLITRDOMAIN', mempath)
     call mem_allocate(store%iboundary, np, MAX_LEVEL, 'PLIBOUNDARY', mempath)
   end subroutine create_particle_store
 
@@ -227,7 +233,7 @@ contains
     call mem_deallocate(this%iexmeth, 'PLIEXMETH', mempath)
     call mem_deallocate(this%extol, 'PLEXTOL', mempath)
     call mem_deallocate(this%extend, 'PLIEXTEND', mempath)
-    call mem_deallocate(this%idomain, 'PLIDOMAIN', mempath)
+    call mem_deallocate(this%itrdomain, 'PLITRDOMAIN', mempath)
     call mem_deallocate(this%iboundary, 'PLIBOUNDARY', mempath)
   end subroutine destroy
 
@@ -261,7 +267,7 @@ contains
     call mem_reallocate(this%iexmeth, np, 'PLIEXMETH', mempath)
     call mem_reallocate(this%extol, np, 'PLEXTOL', mempath)
     call mem_reallocate(this%extend, np, 'PLIEXTEND', mempath)
-    call mem_reallocate(this%idomain, np, MAX_LEVEL, 'PLIDOMAIN', mempath)
+    call mem_reallocate(this%itrdomain, np, MAX_LEVEL, 'PLITRDOMAIN', mempath)
     call mem_reallocate(this%iboundary, np, MAX_LEVEL, 'PLIBOUNDARY', mempath)
   end subroutine resize
 
@@ -299,9 +305,9 @@ contains
     particle%tstop = this%tstop(ip)
     particle%ttrack = this%ttrack(ip)
     particle%advancing = .true.
-    particle%idomain(1:MAX_LEVEL) = &
-      this%idomain(ip, 1:MAX_LEVEL)
-    particle%idomain(1) = imdl
+    particle%itrdomain(1:MAX_LEVEL) = &
+      this%itrdomain(ip, 1:MAX_LEVEL)
+    particle%itrdomain(1) = imdl
     particle%iboundary(1:MAX_LEVEL) = &
       this%iboundary(ip, 1:MAX_LEVEL)
     particle%ifrctrn = this%ifrctrn(ip)
@@ -334,10 +340,10 @@ contains
     this%trelease(ip) = particle%trelease
     this%tstop(ip) = particle%tstop
     this%ttrack(ip) = particle%ttrack
-    this%idomain( &
+    this%itrdomain( &
       ip, &
       1:MAX_LEVEL) = &
-      particle%idomain(1:MAX_LEVEL)
+      particle%itrdomain(1:MAX_LEVEL)
     this%iboundary( &
       ip, &
       1:MAX_LEVEL) = &


### PR DESCRIPTION
`Particle[Store]Type%idomain` has nothing to do with discretization IDOMAIN, name it `itrdomain` for "tracking domain" to clarify what we mean. Also use an enum for method tracking level.