### PR TITLE
feat: make binary grid file name configurable

### DIFF
--- a/autotest/test_gwf_disu.py
+++ b/autotest/test_gwf_disu.py
@@ -6,7 +6,7 @@ one of the cells inactive and test to make sure connectivity
 in binary grid file is correct.
 """
 
-import os
+from pathlib import Path
 
 import flopy
 import numpy as np
@@ -15,6 +15,7 @@ from flopy.utils.gridutil import get_disu_kwargs
 from framework import TestFramework
 
 cases = ["disu01a", "disu01b"]
+grb_filename = "disu.grb"
 
 
 def build_models(idx, test):
@@ -43,7 +44,7 @@ def build_models(idx, test):
     tdis = flopy.mf6.ModflowTdis(sim)
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
     ims = flopy.mf6.ModflowIms(sim, print_option="SUMMARY")
-    disu = flopy.mf6.ModflowGwfdisu(gwf, **disukwargs)
+    disu = flopy.mf6.ModflowGwfdisu(gwf, grb_filerecord=grb_filename, **disukwargs)
     ic = flopy.mf6.ModflowGwfic(gwf, strt=0.0)
     npf = flopy.mf6.ModflowGwfnpf(gwf)
     spd = {0: [[(0,), 1.0], [(nrow * ncol - 1), 0.0]]}
@@ -52,9 +53,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    name = test.name
-
-    fname = os.path.join(test.workspace, name + ".disu.grb")
+    fname = Path(test.workspace) / grb_filename
     grbobj = flopy.mf6.utils.MfGrdFile(fname)
     nodes = grbobj._datadict["NODES"]
     ia = grbobj._datadict["IA"]

--- a/autotest/test_gwf_disv.py
+++ b/autotest/test_gwf_disv.py
@@ -7,7 +7,7 @@ one of the cells inactive and test to make sure connectivity
 in binary grid file is correct.
 """
 
-import os
+from pathlib import Path
 
 import flopy
 import numpy as np
@@ -16,6 +16,7 @@ from flopy.utils.gridutil import get_disv_kwargs
 from framework import TestFramework
 
 cases = ["disv01a", "disv01b"]
+grb_filename = "disv.grb"
 
 
 def build_models(idx, test):
@@ -46,7 +47,7 @@ def build_models(idx, test):
     tdis = flopy.mf6.ModflowTdis(sim)
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
     ims = flopy.mf6.ModflowIms(sim, print_option="SUMMARY")
-    disv = flopy.mf6.ModflowGwfdisv(gwf, **disvkwargs)
+    disv = flopy.mf6.ModflowGwfdisv(gwf, grb_filerecord=grb_filename, **disvkwargs)
     ic = flopy.mf6.ModflowGwfic(gwf, strt=0.0)
     npf = flopy.mf6.ModflowGwfnpf(gwf)
     spd = {0: [[(0, 0), 1.0], [(0, nrow * ncol - 1), 0.0]]}
@@ -55,9 +56,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    name = test.name
-
-    fname = os.path.join(test.workspace, name + ".disv.grb")
+    fname = Path(test.workspace) / grb_filename
     grbobj = flopy.mf6.utils.MfGrdFile(fname)
     ncpl = grbobj._datadict["NCPL"]
     ia = grbobj._datadict["IA"]

--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -8,7 +8,7 @@
 \begin{itemize}
 	\item Support for adjusting time step lengths using the adaptive time stepping (ATS) capability was added to the GWT Advection (ADV) Package of the Groundwater Transport (GWT) Model in release 6.6.0.  The same functionality that was added to GWT is now available with the Groundwater Energy Transport (GWE) Model.  A description of how this functionality works and how to activate it can be found in the release notes for version 6.6.0 (Appendix A) and in the MODFLOW 6 input-output guide.
 	\item The binary grid file written by MODFLOW 6 for DISU models did not include the IDOMAIN array.  The binary grid file now includes IDOMAIN for all discretization types, including DISU.
-	\item The binary grid file's name may now be specified in all discretization packages with option GRB6 FILEOUT followed by a file path.
+	\item The binary grid file's name may now be specified in all discretization packages with option GRB6 FILEOUT followed by a file path. If this option is not provided, the binary grid file will be named as before, identical to the discretization file name plus a ``.grb'' extension. Note that renaming the binary grid file may break downstream integrations which expect the default name.
 %	\item xxx
 \end{itemize}
 

--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -8,6 +8,7 @@
 \begin{itemize}
 	\item Support for adjusting time step lengths using the adaptive time stepping (ATS) capability was added to the GWT Advection (ADV) Package of the Groundwater Transport (GWT) Model in release 6.6.0.  The same functionality that was added to GWT is now available with the Groundwater Energy Transport (GWE) Model.  A description of how this functionality works and how to activate it can be found in the release notes for version 6.6.0 (Appendix A) and in the MODFLOW 6 input-output guide.
 	\item The binary grid file written by MODFLOW 6 for DISU models did not include the IDOMAIN array.  The binary grid file now includes IDOMAIN for all discretization types, including DISU.
+	\item The binary grid file's name may now be specified in all discretization packages with option GRB6 FILEOUT followed by a file path.
 %	\item xxx
 \end{itemize}
 

--- a/doc/mf6io/framework/binaryoutput.tex
+++ b/doc/mf6io/framework/binaryoutput.tex
@@ -6,7 +6,7 @@ The file formats for the binary files are described in the following sections. T
 
 \newpage
 \subsection{Binary Grid File}
-\mf~writes a binary grid file that can be used for post processing model results.  The file structure was designed to be self-documenting so that it can evolve if necessary.  The file name is assigned automatically by the program by adding ``.grb'' to the end of the discretization input file name.  The structure of the binary grid file depends on the type of discretization package that is used.  The following subsections summarize the binary grid file for the different grid types.  The red text is not written to the binary grid file, but is shown here to explain the file content.  The binary grid file is written for the GWF Model, but is not written for the GWT Model.
+\mf~writes a binary grid file that can be used for post processing model results.  The file structure was designed to be self-documenting so that it can evolve if necessary.  By default, the file name is assigned automatically by the program by adding ``.grb'' to the end of the discretization input file name.  Alternatively, the binary grid file name may be specified in the relevant discretization input file.  The structure of the binary grid file depends on the type of discretization package that is used.  The following subsections summarize the binary grid file for the different grid types.  The red text is not written to the binary grid file, but is shown here to explain the file content.  The binary grid file is written for the GWF Model, but is not written for the GWT Model.
 
 \newpage
 \subsubsection{DIS Grids}

--- a/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
@@ -55,7 +55,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
@@ -56,7 +56,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
@@ -18,6 +18,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/gwe-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-disu.dfn
@@ -55,7 +55,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwe-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-disu.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
@@ -56,7 +56,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
@@ -18,6 +18,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
@@ -56,7 +56,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
@@ -18,6 +18,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
@@ -55,7 +55,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
@@ -56,7 +56,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
@@ -18,6 +18,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
@@ -56,7 +56,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
@@ -18,6 +18,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
@@ -55,7 +55,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
@@ -56,7 +56,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
@@ -18,6 +18,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/olf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-dis2d.dfn
@@ -55,7 +55,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/olf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-dis2d.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/olf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-disv1d.dfn
@@ -55,7 +55,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/olf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-disv1d.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/olf-disv2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-disv2d.dfn
@@ -55,7 +55,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/olf-disv2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-disv2d.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
@@ -55,7 +55,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
@@ -44,7 +44,7 @@ reader urword
 tagged true
 optional false
 longname file keyword
-description keyword to specify that an output filename is expected next.
+description keyword to specify that an output filename is expected next. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 
 block options
 name grb6_filename

--- a/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/swf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-dis2d.dfn
@@ -55,7 +55,7 @@ reader urword
 optional false
 tagged false
 longname file name of GRB information
-description defines a binary grid output file.
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/swf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-dis2d.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/swf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-disv1d.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/swf-disv2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-disv2d.dfn
@@ -17,6 +17,48 @@ longname do not write binary grid file
 description keyword to deactivate writing of the binary grid file.
 
 block options
+name grb_filerecord
+type record grb6 fileout grb6_filename
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name grb6
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname grb keyword
+description keyword to specify that record corresponds to a binary grid file.
+extended true
+
+block options
+name fileout
+type keyword
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name grb6_filename
+type string
+preserve_case true
+in_record true
+reader urword
+optional false
+tagged false
+longname file name of GRB information
+description defines a binary grid output file. If this option is not provided, the output file will have the same name as the discretization input file, plus extension ``.grb''.
+extended true
+
+block options
 name xorigin
 type double precision
 reader urword

--- a/pixi.lock
+++ b/pixi.lock
@@ -75,7 +75,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-10.3.0-h76408a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-10.4.0-h76408a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -97,7 +97,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-h4585015_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-hf3231e4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.2.0-hf3231e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-31_h59b9bed_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
@@ -127,7 +127,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.19.5-gpl_hc21c24c_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.19.6-gpl_hc18d805_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
@@ -224,7 +224,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.10-py39h8cd3c5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py39h8cd3c5a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.9.7-py39hb014886_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.9.9-py39hdcd3392_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.13.1-py39haf93ffa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.7-py39hca88cd1_0.conda
@@ -348,7 +348,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.43-hd0cad38_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-10.3.0-hb5e3f52_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-10.4.0-hb5e3f52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -370,7 +370,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.7.7-h6223a6c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.1.1-h0430067_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.2.0-h0430067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-31_h1a9f1db_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.1.0-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.1.0-h86ecc28_2.conda
@@ -400,7 +400,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libheif-1.19.5-gpl_h9ad4cf6_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libheif-1.19.6-gpl_hf91bf23_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-hc99b53d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libkml-1.3.0-h62bc5a7_1021.conda
@@ -497,7 +497,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.10-py39h060674a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.8-py39h060674a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.9.7-py39h4e1b988_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.9.9-py39ha8281a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.13.1-py39hb921187_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/shapely-2.0.7-py39h1e95d85_0.conda
@@ -613,7 +613,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gtk3-3.24.43-h82a860e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gts-0.7.6-h53e17e3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-10.3.0-h86b413f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-10.4.0-h86b413f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hicolor-icon-theme-0.17-h694c41f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -634,7 +634,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.7-h1a33361_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.23.1-h27064b9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.1.1-h6214335_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.2.0-h6214335_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-31_h7f60823_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
@@ -654,7 +654,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.82.2-h5c976ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.19.5-gpl_hc62a4a2_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.19.6-gpl_h95ec88c_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4b5e92a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.23.1-h27064b9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
@@ -736,7 +736,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py39h80efdc8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py39h296a897_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.9.7-py39hfecde11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.9.9-py39hfa46fd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.13.1-py39h038d4f4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.7-py39hb15469b_0.conda
@@ -830,7 +830,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.43-he7bb075_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-10.3.0-hb72c1af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-10.4.0-hb72c1af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -851,7 +851,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h3b16cec_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.23.1-h493aca8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.1.1-hf9d1e0e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.2.0-hf9d1e0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-31_h10e41b3_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
@@ -871,7 +871,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-hdff4504_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.19.5-gpl_h297b2c4_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.19.6-gpl_h79e6334_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-hfe07756_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.23.1-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
@@ -953,7 +953,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.10-py39hf3bc14e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py39h57695bc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.9.7-py39h5f12542_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.9.9-py39h72850e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.13.1-py39h3d5391c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.7-py39hd9a2305_0.conda
@@ -986,7 +986,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.19.0-py39h02fc5c5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_1.conda
       win-64:
-      - conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.2.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
@@ -1044,7 +1044,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphviz-12.2.1-hf40819d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-10.3.0-h9e37d49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-10.4.0-h9e37d49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
@@ -1063,7 +1063,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.7-h979ed78_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h551e529_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.2.0-h551e529_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-31_h641d27c_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
@@ -1080,7 +1080,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.2-h095903c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.19.5-gpl_hc631cee_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.19.6-gpl_h2684147_100.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-h135ad9c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
@@ -1163,7 +1163,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.10-py39ha55e580_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py39ha55e580_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.9.7-py39he05c28a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.9.9-py39hc4be082_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.13.1-py39h1a10956_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.7-py39ha482d1c_0.conda
@@ -1186,9 +1186,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py39ha55e580_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h5fd82a7_24.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-h6356254_24.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hfef2bbc_24.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hbf610ac_24.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34438-hfd919c2_24.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34438-h7142326_24.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
@@ -1292,7 +1292,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-10.3.0-h76408a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-10.4.0-h76408a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -1319,7 +1319,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.7-h4585015_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-hf3231e4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.2.0-hf3231e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-31_h59b9bed_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
@@ -1349,7 +1349,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.19.5-gpl_hc21c24c_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.19.6-gpl_hc18d805_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
@@ -1460,7 +1460,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.10-py39h8cd3c5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py39h8cd3c5a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.9.7-py39hb014886_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.9.9-py39hdcd3392_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.13.1-py39haf93ffa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.7-py39hca88cd1_0.conda
@@ -1535,7 +1535,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/92/30b4e54c4d7c48c06db61595cffbbf4f19588ea177896f9b78f0fbe021fd/mistune-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/9a/cd673b2f773a12c992f41309ef81b99da1690426bd2f96957a7ade0d3ed7/nbconvert-7.16.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/6a/8a/5dc4c8794053572a89f5c44437ef4e870f88903a6b6734500af1286f9018/nbsphinx-0.9.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/2d/8c8e635bcc6757573d311bb3c5445426382f280da32b8cd6d82d501ef4a4/nbsphinx-0.9.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/8f/cd4bb6849fef05dafc02e38b3c9b9e985d266c3ca7cb485c3160ddeb96f2/nbsphinx_link-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
@@ -1622,7 +1622,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.43-hd0cad38_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-10.3.0-hb5e3f52_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-10.4.0-hb5e3f52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -1649,7 +1649,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarchive-3.7.7-h6223a6c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.1.1-h0430067_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.2.0-h0430067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-31_h1a9f1db_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.1.0-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.1.0-h86ecc28_2.conda
@@ -1679,7 +1679,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libheif-1.19.5-gpl_h9ad4cf6_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libheif-1.19.6-gpl_hf91bf23_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-hc99b53d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libkml-1.3.0-h62bc5a7_1021.conda
@@ -1790,7 +1790,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.10-py39h060674a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.8-py39h060674a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.9.7-py39h4e1b988_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.9.9-py39ha8281a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.13.1-py39hb921187_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/shapely-2.0.7-py39h1e95d85_0.conda
@@ -1865,7 +1865,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/92/30b4e54c4d7c48c06db61595cffbbf4f19588ea177896f9b78f0fbe021fd/mistune-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/9a/cd673b2f773a12c992f41309ef81b99da1690426bd2f96957a7ade0d3ed7/nbconvert-7.16.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/6a/8a/5dc4c8794053572a89f5c44437ef4e870f88903a6b6734500af1286f9018/nbsphinx-0.9.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/2d/8c8e635bcc6757573d311bb3c5445426382f280da32b8cd6d82d501ef4a4/nbsphinx-0.9.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/8f/cd4bb6849fef05dafc02e38b3c9b9e985d266c3ca7cb485c3160ddeb96f2/nbsphinx_link-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
@@ -1945,7 +1945,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gtk3-3.24.43-h82a860e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gts-0.7.6-h53e17e3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-10.3.0-h86b413f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-10.4.0-h86b413f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hicolor-icon-theme-0.17-h694c41f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -1971,7 +1971,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.7-h1a33361_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.23.1-h27064b9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.1.1-h6214335_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.2.0-h6214335_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-31_h7f60823_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
@@ -1991,7 +1991,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.82.2-h5c976ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.19.5-gpl_hc62a4a2_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.19.6-gpl_h95ec88c_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4b5e92a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.23.1-h27064b9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
@@ -2087,7 +2087,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.10-py39h80efdc8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py39h296a897_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.9.7-py39hfecde11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.9.9-py39hfa46fd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.13.1-py39h038d4f4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.7-py39hb15469b_0.conda
@@ -2140,7 +2140,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/92/30b4e54c4d7c48c06db61595cffbbf4f19588ea177896f9b78f0fbe021fd/mistune-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/9a/cd673b2f773a12c992f41309ef81b99da1690426bd2f96957a7ade0d3ed7/nbconvert-7.16.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/6a/8a/5dc4c8794053572a89f5c44437ef4e870f88903a6b6734500af1286f9018/nbsphinx-0.9.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/2d/8c8e635bcc6757573d311bb3c5445426382f280da32b8cd6d82d501ef4a4/nbsphinx-0.9.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/8f/cd4bb6849fef05dafc02e38b3c9b9e985d266c3ca7cb485c3160ddeb96f2/nbsphinx_link-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
@@ -2220,7 +2220,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.43-he7bb075_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-10.3.0-hb72c1af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-10.4.0-hb72c1af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -2246,7 +2246,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h3b16cec_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.23.1-h493aca8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.1.1-hf9d1e0e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.2.0-hf9d1e0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-31_h10e41b3_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hd74edd7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hd74edd7_2.conda
@@ -2266,7 +2266,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-hdff4504_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.19.5-gpl_h297b2c4_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.19.6-gpl_h79e6334_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-hfe07756_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.23.1-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
@@ -2362,7 +2362,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.10-py39hf3bc14e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py39h57695bc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.9.7-py39h5f12542_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.9.9-py39h72850e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.13.1-py39h3d5391c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.7-py39hd9a2305_0.conda
@@ -2415,7 +2415,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/92/30b4e54c4d7c48c06db61595cffbbf4f19588ea177896f9b78f0fbe021fd/mistune-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/9a/cd673b2f773a12c992f41309ef81b99da1690426bd2f96957a7ade0d3ed7/nbconvert-7.16.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/6a/8a/5dc4c8794053572a89f5c44437ef4e870f88903a6b6734500af1286f9018/nbsphinx-0.9.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/2d/8c8e635bcc6757573d311bb3c5445426382f280da32b8cd6d82d501ef4a4/nbsphinx-0.9.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/8f/cd4bb6849fef05dafc02e38b3c9b9e985d266c3ca7cb485c3160ddeb96f2/nbsphinx_link-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
@@ -2425,7 +2425,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       win-64:
-      - conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.2.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.16-pyhd8ed1ab_0.conda
@@ -2491,7 +2491,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphviz-12.2.1-hf40819d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-10.3.0-h9e37d49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-10.4.0-h9e37d49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
@@ -2515,7 +2515,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.7-h979ed78_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h551e529_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.2.0-h551e529_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-31_h641d27c_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_2.conda
@@ -2532,7 +2532,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.2-h095903c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-14.2.0-h1383e82_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.19.5-gpl_hc631cee_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.19.6-gpl_h2684147_100.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-h135ad9c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
@@ -2627,7 +2627,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.10-py39ha55e580_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py39ha55e580_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.9.7-py39he05c28a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.9.9-py39hc4be082_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.13.1-py39h1a10956_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.8.2-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.7-py39ha482d1c_0.conda
@@ -2661,9 +2661,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py39ha55e580_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h5fd82a7_24.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-h6356254_24.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hfef2bbc_24.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hbf610ac_24.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34438-hfd919c2_24.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34438-h7142326_24.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
@@ -2692,7 +2692,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/92/30b4e54c4d7c48c06db61595cffbbf4f19588ea177896f9b78f0fbe021fd/mistune-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/9a/cd673b2f773a12c992f41309ef81b99da1690426bd2f96957a7ade0d3ed7/nbconvert-7.16.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/6a/8a/5dc4c8794053572a89f5c44437ef4e870f88903a6b6734500af1286f9018/nbsphinx-0.9.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/2d/8c8e635bcc6757573d311bb3c5445426382f280da32b8cd6d82d501ef4a4/nbsphinx-0.9.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/8f/cd4bb6849fef05dafc02e38b3c9b9e985d266c3ca7cb485c3160ddeb96f2/nbsphinx_link-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
@@ -2702,14 +2702,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
 packages:
-- conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_3.conda
-  sha256: bde034edf2cf6fab6b1f138ca764a4589a3048ad98f2cc1f0a13cf2d3917e3ea
-  md5: 9ec22567e9f6a987746d692cc394aa3a
+- conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.2.0-h57928b3_0.conda
+  sha256: 1bcf902a05a2ff40d72507534c5c59a7713c7270bab10f959c096ec735ad2b3e
+  md5: 1e91a9f2cff8269db0aca397da64592b
   arch: x86_64
   platform: win
   purls: []
-  size: 10763
-  timestamp: 1740443476422
+  size: 9611
+  timestamp: 1741022646434
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
@@ -3067,7 +3067,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/attrs?source=compressed-mapping
+  - pkg:pypi/attrs?source=hash-mapping
   size: 56370
   timestamp: 1737819298139
 - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
@@ -3079,7 +3079,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/babel?source=compressed-mapping
+  - pkg:pypi/babel?source=hash-mapping
   size: 6938256
   timestamp: 1738490268466
 - pypi: https://files.pythonhosted.org/packages/f9/49/6abb616eb3cbab6a7cca303dc02fdf3836de2e0b834bf966a7f5271a34d8/beautifulsoup4-4.13.3-py3-none-any.whl
@@ -3840,7 +3840,7 @@ packages:
   - python >=3.9
   license: ISC
   purls:
-  - pkg:pypi/certifi?source=compressed-mapping
+  - pkg:pypi/certifi?source=hash-mapping
   size: 162721
   timestamp: 1739515973129
 - conda: https://conda.anaconda.org/conda-forge/noarch/cffconvert-2.0.0-pyhd8ed1ab_1.conda
@@ -4373,7 +4373,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/decorator?source=compressed-mapping
+  - pkg:pypi/decorator?source=hash-mapping
   size: 14129
   timestamp: 1740385067843
 - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
@@ -5909,9 +5909,9 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 53888
   timestamp: 1738578623567
-- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-10.3.0-h76408a6_0.conda
-  sha256: fbccddfbbfaf139102e5513a2a053010338809348ade18bbf16cb6b92a53d294
-  md5: 0a06f278e5d9242057673b1358a75e8f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-10.4.0-h76408a6_0.conda
+  sha256: 3b4ccabf170e1bf98c593f724cc4defe286d64cb19288751a50c63809ca32d5f
+  md5: 81f137b4153cf111ff8e3188b6fb8e73
   depends:
   - __glibc >=2.17,<3.0.a0
   - cairo >=1.18.2,<2.0a0
@@ -5928,11 +5928,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 1671633
-  timestamp: 1740154398990
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-10.3.0-hb5e3f52_0.conda
-  sha256: 687fbb17d8303b956ff917247e41ad8c864ed029b2349c0409cc905e11d9257d
-  md5: 4575cba227f2e4b5d0f23c9adc390f83
+  size: 1694183
+  timestamp: 1741016164622
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-10.4.0-hb5e3f52_0.conda
+  sha256: 0b7223aef98ba34c7c6f937b394cdf25048ac752908ab0f5cb96673002a330e3
+  md5: f28b4d75b1ee821c768311613d3dd225
   depends:
   - cairo >=1.18.2,<2.0a0
   - freetype >=2.12.1,<3.0a0
@@ -5948,11 +5948,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 1727792
-  timestamp: 1740157913844
-- conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-10.3.0-h86b413f_0.conda
-  sha256: 6ffe7706958f82236514aabfab8ef6a6da75ecde943b47b4c8d0cad81d07a930
-  md5: f40e9311d84271d2edcd2408da7c66bb
+  size: 1709988
+  timestamp: 1741019766031
+- conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-10.4.0-h86b413f_0.conda
+  sha256: 87e47de769f93f756e61e40555796382fb1dc3cb754e2e068958a949b3df33f7
+  md5: 05493515d0b4467f8229f1e154ec80c3
   depends:
   - __osx >=10.13
   - cairo >=1.18.2,<2.0a0
@@ -5968,11 +5968,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 1444618
-  timestamp: 1740154780239
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-10.3.0-hb72c1af_0.conda
-  sha256: eb9cc0c8e61a9ce1236fdfa5d426ae31ffd9fd1d6b154e2e7318694eaed6c24e
-  md5: d77e5f42ec2a35950710f57868885683
+  size: 1442847
+  timestamp: 1741016606354
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-10.4.0-hb72c1af_0.conda
+  sha256: 5c0ba63cdc0ccda3309923deff839528cf870daf4ae0173ab07e275698236321
+  md5: c13f50a1000cc3adadb2d93c76dcedab
   depends:
   - __osx >=11.0
   - cairo >=1.18.2,<2.0a0
@@ -5988,11 +5988,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 1378165
-  timestamp: 1740155007314
-- conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-10.3.0-h9e37d49_0.conda
-  sha256: 92875824cf11fcc1329096e690b22dd5f0367549ec3c13586b0e95ebe4c975f9
-  md5: 03ffe97bee5abc7ec5f68fc2ec440c80
+  size: 1380378
+  timestamp: 1741016758098
+- conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-10.4.0-h9e37d49_0.conda
+  sha256: 4e8a5219328697247b682b161e02577613b50d20237d4b3e575713d811036895
+  md5: 63185f1b04a3f5ebd728cf1bec2dbedc
   depends:
   - cairo >=1.18.2,<2.0a0
   - freetype >=2.12.1,<3.0a0
@@ -6009,8 +6009,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 1111498
-  timestamp: 1740155836705
+  size: 1112646
+  timestamp: 1741017842033
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
   sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
   md5: bbf6f174dcd3254e19a2f5d2295ce808
@@ -6169,7 +6169,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/importlib-metadata?source=compressed-mapping
+  - pkg:pypi/importlib-metadata?source=hash-mapping
   size: 29141
   timestamp: 1737420302391
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.5.2-pyhd8ed1ab_0.conda
@@ -6971,9 +6971,9 @@ packages:
   purls: []
   size: 41679
   timestamp: 1739039255705
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-hf3231e4_3.conda
-  sha256: fdc5519fd91ebfe713561792365a1e86e0e9a1579b32f7df5d4136e97e01e30f
-  md5: 57983929fd533126e9bd71754f0d25f5
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.2.0-hf3231e4_0.conda
+  sha256: e5b9ab354be66b725a4acdd7a023598558fdace2fbc415ec41b528d02a1fa74b
+  md5: a9329ba10be85b54f0c6bf76788ed4b1
   depends:
   - __glibc >=2.17,<3.0.a0
   - aom >=3.9.1,<3.10.0a0
@@ -6986,11 +6986,11 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 117659
-  timestamp: 1740443336123
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.1.1-h0430067_3.conda
-  sha256: f414adc92127560abe135d7ae56d15d734732186fd0ceea408ab7be6415abb6d
-  md5: f7ecf6b6fbea3f1f6f4efe97b7e4ce4e
+  size: 138426
+  timestamp: 1741022597412
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libavif16-1.2.0-h0430067_0.conda
+  sha256: fbdfbb9d1cba1d756f5a03593fbf7af4584822342fd4e721fbf073642216b2c7
+  md5: dfb8f369984a33530e4a8958b662b5f6
   depends:
   - aom >=3.9.1,<3.10.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
@@ -7002,11 +7002,11 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 117519
-  timestamp: 1740443361559
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.1.1-h6214335_3.conda
-  sha256: 0680563ad7117f6b05fafc537bfeb9f137c60da5973894d541330b7e73b3c7ef
-  md5: 8e48778b324f4fe54c14132f2cb800b3
+  size: 136385
+  timestamp: 1741022586390
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.2.0-h6214335_0.conda
+  sha256: 473455ad6b9b39c66fd2fdf6f6c3ca8400b9f939a54bfe0b4b7afcf3beaa89d4
+  md5: 12123a42fa6a93fd3697860db6d0b02d
   depends:
   - __osx >=10.13
   - aom >=3.9.1,<3.10.0a0
@@ -7018,11 +7018,11 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 110471
-  timestamp: 1740443521761
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.1.1-hf9d1e0e_3.conda
-  sha256: 35f411fb4a9c7dfcf47affed864066ccdaa45969d05403f80134a41cdf7159b6
-  md5: 8d1a6e4e698ca66e953622764733803a
+  size: 122775
+  timestamp: 1741022643799
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.2.0-hf9d1e0e_0.conda
+  sha256: afe3677b64411ce79af6c42612c1a4a7ea2b537db301674261486544c0bf327e
+  md5: 64c52c1ca687cadb656e00282c9e5a66
   depends:
   - __osx >=11.0
   - aom >=3.9.1,<3.10.0a0
@@ -7034,13 +7034,13 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 98685
-  timestamp: 1740443620556
-- conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h551e529_3.conda
-  sha256: ca22da25a84e98a4c7f2b07a34ed9057f150c1283170b60eecb43ad96dc36a6f
-  md5: 9d96163312a0af56297df8d5cde37266
+  size: 110534
+  timestamp: 1741022698879
+- conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.2.0-h551e529_0.conda
+  sha256: 261ddb63fb6453c0489dc76b09a59c5cfe74dba606380bd70be3af46ac7f8b81
+  md5: 42871741dc3f46229e54052f90579908
   depends:
-  - _libavif_api >=1.1.1,<1.1.2.0a0
+  - _libavif_api >=1.2.0,<1.2.1.0a0
   - aom >=3.9.1,<3.10.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
   - rav1e >=0.6.6,<1.0a0
@@ -7053,8 +7053,8 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 99350
-  timestamp: 1740443809903
+  size: 114222
+  timestamp: 1741022971933
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-31_h59b9bed_openblas.conda
   build_number: 31
   sha256: 9839fc4ac0cbb0aa3b9eea520adfb57311838959222654804e58f6f2d1771db5
@@ -8830,9 +8830,9 @@ packages:
   purls: []
   size: 524548
   timestamp: 1740240660967
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.19.5-gpl_hc21c24c_100.conda
-  sha256: d814dd9203d5ba2f38b4682f53ac02ddd17578324d715a101d29c057610c6545
-  md5: 3b57852666eaacc13414ac811dde3f8a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libheif-1.19.6-gpl_hc18d805_100.conda
+  sha256: 3620c7f6f687e8a1d2f8ed6bae9af07c1e58dc77ed04d73c6573b390106e7b99
+  md5: 1a48b689554f7a1b049f34d8baf82464
   depends:
   - __glibc >=2.17,<3.0.a0
   - aom >=3.9.1,<3.10.0a0
@@ -8847,11 +8847,11 @@ packages:
   license: LGPL-3.0-or-later
   license_family: LGPL
   purls: []
-  size: 588609
-  timestamp: 1735260140647
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libheif-1.19.5-gpl_h9ad4cf6_100.conda
-  sha256: 2d85dcda3e39db17b3a909ee681624aab6d709690ac3909047e537be5decaa12
-  md5: a71d758e44f5286bd9abc156a86846ae
+  size: 595344
+  timestamp: 1741013987090
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libheif-1.19.6-gpl_hf91bf23_100.conda
+  sha256: bef4a8c493a793c071f3ca7a2d837077aab24e55a9c9634f1075cbc2920f98cb
+  md5: 675d8406e7c47e8539b306e68ecd6b54
   depends:
   - aom >=3.9.1,<3.10.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
@@ -8865,11 +8865,11 @@ packages:
   license: LGPL-3.0-or-later
   license_family: LGPL
   purls: []
-  size: 585864
-  timestamp: 1735260275639
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.19.5-gpl_hc62a4a2_100.conda
-  sha256: 2c37ca00e28623ddb1e86e443f6aacc2c5c4f78353a33714475c20160a40aa53
-  md5: 8fe3273539e2f4d0b8dc3d9aa960f2bf
+  size: 594198
+  timestamp: 1741014032901
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libheif-1.19.6-gpl_h95ec88c_100.conda
+  sha256: 3cf482e95ea7d85ee74d8aeb107136581a35ed86c657d938f95f3e0fce048fea
+  md5: fd4ba282d9b04252c67af824b31996f6
   depends:
   - __osx >=10.13
   - aom >=3.9.1,<3.10.0a0
@@ -8883,11 +8883,11 @@ packages:
   license: LGPL-3.0-or-later
   license_family: LGPL
   purls: []
-  size: 475342
-  timestamp: 1735260287225
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.19.5-gpl_h297b2c4_100.conda
-  sha256: f340e8e51519bcf885da9dd12602f19f76f3206347701accb28034dd0112b1a1
-  md5: 5e457131dd237050dbfe6b141592f3ea
+  size: 485968
+  timestamp: 1741014333304
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.19.6-gpl_h79e6334_100.conda
+  sha256: 491db4e61d52386d1d6c0d463d7fe5d7973aa49ff51b3c3a36b6a6f9b3a3f6f7
+  md5: 9511948f5a8e4bc7dca87dbfbbb2b9cc
   depends:
   - __osx >=11.0
   - aom >=3.9.1,<3.10.0a0
@@ -8901,11 +8901,11 @@ packages:
   license: LGPL-3.0-or-later
   license_family: LGPL
   purls: []
-  size: 429678
-  timestamp: 1735260330340
-- conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.19.5-gpl_hc631cee_100.conda
-  sha256: c0ee7fbbf78e66388146348ba78a206eeadf59602d9ca10ecaf64e019cd70cd3
-  md5: 8c77ee62663e5e4bbb60b86ba54fdbeb
+  size: 442225
+  timestamp: 1741014159707
+- conda: https://conda.anaconda.org/conda-forge/win-64/libheif-1.19.6-gpl_h2684147_100.conda
+  sha256: cacb27eaff857ecbb4ff377cb1cc750514da8146caef690ee76c6132f19eb826
+  md5: 8898af040b48cbbb8f029fd48c6f528d
   depends:
   - aom >=3.9.1,<3.10.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
@@ -8920,8 +8920,8 @@ packages:
   license: LGPL-3.0-or-later
   license_family: LGPL
   purls: []
-  size: 388187
-  timestamp: 1735260582529
+  size: 391719
+  timestamp: 1741014594194
 - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
   sha256: 850e255997f538d5fb6ed651321141155a33bb781d43d326fc4ff62114dd2842
   md5: b87a0ac5ab6495d8225db5dc72dd21cd
@@ -11609,17 +11609,17 @@ packages:
   - pkg:pypi/nbformat?source=hash-mapping
   size: 100945
   timestamp: 1733402844974
-- pypi: https://files.pythonhosted.org/packages/6a/8a/5dc4c8794053572a89f5c44437ef4e870f88903a6b6734500af1286f9018/nbsphinx-0.9.6-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/49/2d/8c8e635bcc6757573d311bb3c5445426382f280da32b8cd6d82d501ef4a4/nbsphinx-0.9.7-py3-none-any.whl
   name: nbsphinx
-  version: 0.9.6
-  sha256: 336b0b557945a7678ec7449b16449f854bc852a435bb53b8a72e6b5dc740d992
+  version: 0.9.7
+  sha256: 7292c3767fea29e405c60743eee5393682a83982ab202ff98f5eb2db02629da8
   requires_dist:
   - docutils>=0.18.1
   - jinja2
   - nbconvert>=5.3,!=5.4
   - traitlets>=5
   - nbformat
-  - sphinx>=1.8
+  - sphinx>=1.8,<8.2
   requires_python: '>=3.6'
 - pypi: https://files.pythonhosted.org/packages/6e/8f/cd4bb6849fef05dafc02e38b3c9b9e985d266c3ca7cb485c3160ddeb96f2/nbsphinx_link-1.3.1-py3-none-any.whl
   name: nbsphinx-link
@@ -12472,7 +12472,7 @@ packages:
   - python >=3.9
   license: ISC
   purls:
-  - pkg:pypi/pexpect?source=compressed-mapping
+  - pkg:pypi/pexpect?source=hash-mapping
   size: 53561
   timestamp: 1733302019362
 - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
@@ -13177,6 +13177,7 @@ packages:
   arch: x86_64
   platform: linux
   license: LGPL-3.0-only
+  license_family: LGPL
   purls:
   - pkg:pypi/pyside6?source=hash-mapping
   - pkg:pypi/shiboken6?source=hash-mapping
@@ -13201,6 +13202,7 @@ packages:
   arch: aarch64
   platform: linux
   license: LGPL-3.0-only
+  license_family: LGPL
   purls:
   - pkg:pypi/pyside6?source=hash-mapping
   - pkg:pypi/shiboken6?source=hash-mapping
@@ -13223,6 +13225,7 @@ packages:
   arch: x86_64
   platform: win
   license: LGPL-3.0-only
+  license_family: LGPL
   purls:
   - pkg:pypi/pyside6?source=hash-mapping
   - pkg:pypi/shiboken6?source=hash-mapping
@@ -13267,6 +13270,7 @@ packages:
   constrains:
   - pytest-faulthandler >=2
   license: MIT
+  license_family: MIT
   purls:
   - pkg:pypi/pytest?source=hash-mapping
   size: 259816
@@ -14461,9 +14465,9 @@ packages:
   - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
   size: 111257
   timestamp: 1728725012226
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.9.7-py39hb014886_0.conda
-  sha256: 0345c21334f107efa4bf270244706c466e26c758a92479defab703da4cccc83a
-  md5: 6458295551dbad2ce529f3cf81cc4252
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.9.9-py39hdcd3392_0.conda
+  sha256: 1bb52478203ac320a3412c570ef4f7d5fd6e511167e455d8516ab1849c35ccc9
+  md5: 540180729e8d42670a768294d0cece45
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -14478,11 +14482,11 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=hash-mapping
-  size: 8571346
-  timestamp: 1740103806515
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.9.7-py39h4e1b988_0.conda
-  sha256: f2461ed886b87a752fe04ed14332826c0241d766f22693af0a1ca5a7d19490b7
-  md5: 30022bedd9cf6c6282912dc0c8091079
+  size: 8831065
+  timestamp: 1741052297827
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruff-0.9.9-py39ha8281a4_0.conda
+  sha256: 26b78170f67e6b16f0439567b96b79a38b0ce55774dd9ebec14d524f1e1b8c49
+  md5: fde1ec8feb60defecd5de4996e7040af
   depends:
   - libgcc >=13
   - libstdcxx >=13
@@ -14497,11 +14501,11 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=hash-mapping
-  size: 8396937
-  timestamp: 1740103900461
-- conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.9.7-py39hfecde11_0.conda
-  sha256: a842eda7cfa94b4c0d1d1d8f40a9c05609deb365fac4f0b1321c32bf562afcd8
-  md5: bd877799f64ee924c938bd72f776d5ab
+  size: 8512035
+  timestamp: 1741052580596
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.9.9-py39hfa46fd8_0.conda
+  sha256: 1db07bcbe9d7a5c5cf39d71065462d224695b9a93673df95e50082d4850fd692
+  md5: 260771442112ecc00a1f694080be47b8
   depends:
   - __osx >=10.13
   - libcxx >=18
@@ -14515,11 +14519,11 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=hash-mapping
-  size: 7914159
-  timestamp: 1740103936680
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.9.7-py39h5f12542_0.conda
-  sha256: 5751b886bcf0d9c76126930df3dc8c8addcca436f64cf2bbc0ceaa08fab505fd
-  md5: 107110dd09aae1e13ec54efe067170b4
+  size: 8150316
+  timestamp: 1741052678336
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.9.9-py39h72850e9_0.conda
+  sha256: a9d16a363dffff28ff36306812aee77ce9e352351ea8dd6b170bcead785cda05
+  md5: b4fa626acd01e947a808e119a1495c5c
   depends:
   - __osx >=11.0
   - libcxx >=18
@@ -14534,11 +14538,11 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=hash-mapping
-  size: 7492054
-  timestamp: 1740104314235
-- conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.9.7-py39he05c28a_0.conda
-  sha256: 9155c4674a5325ae9857171ac1bcafc4350640a35f1451f0c882a68f863b1008
-  md5: e17475c74532baa3b8a1f1ba73106e3c
+  size: 7758811
+  timestamp: 1741052646173
+- conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.9.9-py39hc4be082_0.conda
+  sha256: 6a039e6eb6e4c658aede4e8ee38140589dd28ba0af1bf66006376c60c38a1e88
+  md5: e243facf5ce2bac7312d83e4c2bff10c
   depends:
   - python >=3.9,<3.10.0a0
   - python_abi 3.9.* *_cp39
@@ -14551,8 +14555,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=hash-mapping
-  size: 7604756
-  timestamp: 1740104126981
+  size: 7927409
+  timestamp: 1741053611706
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.13.1-py39haf93ffa_0.conda
   sha256: 55becd997688a9a499aa553e9e61eb28038ca068929c23f0a973ab9a01ac9eac
   md5: 492a2cd65862d16a4aaf535ae9ccb761
@@ -14679,7 +14683,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/setuptools?source=compressed-mapping
+  - pkg:pypi/setuptools?source=hash-mapping
   size: 777736
   timestamp: 1740654030775
 - pypi: https://files.pythonhosted.org/packages/10/7c/5a9799042320242c383c4485a2771a37d49e8ce2312ca647653d2fd1a7a4/setuptools_scm-8.2.0-py3-none-any.whl
@@ -15671,11 +15675,11 @@ packages:
   - pkg:pypi/urllib3?source=hash-mapping
   size: 100102
   timestamp: 1734859520452
-- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h5fd82a7_24.conda
-  sha256: 7ce178cf139ccea5079f9c353b3d8415d1d49b0a2f774662c355d3f89163d7b4
-  md5: 00cf3a61562bd53bd5ea99e6888793d0
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hbf610ac_24.conda
+  sha256: 8ef83b62f9f0b885882d0dd41cbe47c2308f7ac0537fd508a5bbe6d3953a176e
+  md5: 9098c5cfb418fc0b0204bf2efc1e9afa
   depends:
-  - vc14_runtime >=14.40.33810
+  - vc14_runtime >=14.42.34438
   arch: x86_64
   platform: win
   track_features:
@@ -15683,34 +15687,34 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17693
-  timestamp: 1737627189024
-- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-h6356254_24.conda
-  sha256: abda97b8728cf6e3c37df8f1178adde7219bed38b96e392cb3be66336386d32e
-  md5: 2441e010ee255e6a38bf16705a756e94
+  size: 17469
+  timestamp: 1741043406253
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34438-hfd919c2_24.conda
+  sha256: fb36814355ac12dcb4a55b75b5ef0d49ec219ad9df30d7955f2ace88bd6919c4
+  md5: 5fceb7d965d59955888d9a9732719aa8
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.42.34433.* *_24
+  - vs2015_runtime 14.42.34438.* *_24
   arch: x86_64
   platform: win
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
   purls: []
-  size: 753531
-  timestamp: 1737627061911
-- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hfef2bbc_24.conda
-  sha256: 09102e0bd283af65772c052d85028410b0c31989b3cd96c260485d28e270836e
-  md5: 117fcc5b86c48f3b322b0722258c7259
+  size: 751362
+  timestamp: 1741043402335
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34438-h7142326_24.conda
+  sha256: a7104d3d605d191c8ee8d85d4175df3630d61830583494a5d1e62cd9f1260420
+  md5: 1dd2e838eb13190ae1f1e2760c036fdc
   depends:
-  - vc14_runtime >=14.42.34433
+  - vc14_runtime >=14.42.34438
   arch: x86_64
   platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17669
-  timestamp: 1737627066773
+  size: 17474
+  timestamp: 1741043406612
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
   sha256: 0884b2023a32d2620192cf2e2fc6784b8d1e31cf9f137e49e00802d4daf7d1c1
   md5: 0a732427643ae5e0486a727927791da1

--- a/src/Idm/chf-disv1didm.f90
+++ b/src/Idm/chf-disv1didm.f90
@@ -14,6 +14,10 @@ module ChfDisv1DInputModule
   type ChfDisv1dParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -72,6 +76,78 @@ module ChfDisv1DInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    chfdisv1d_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'CHF', & ! component
+    'DISV1D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    chfdisv1d_grb6 = InputParamDefinitionType &
+    ( &
+    'CHF', & ! component
+    'DISV1D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    chfdisv1d_fileout = InputParamDefinitionType &
+    ( &
+    'CHF', & ! component
+    'DISV1D', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    chfdisv1d_grb6_filename = InputParamDefinitionType &
+    ( &
+    'CHF', & ! component
+    'DISV1D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -369,6 +445,10 @@ module ChfDisv1DInputModule
     [ &
     chfdisv1d_length_units, &
     chfdisv1d_nogrb, &
+    chfdisv1d_grb_filerecord, &
+    chfdisv1d_grb6, &
+    chfdisv1d_fileout, &
+    chfdisv1d_grb6_filename, &
     chfdisv1d_xorigin, &
     chfdisv1d_yorigin, &
     chfdisv1d_angrot, &

--- a/src/Idm/gwe-disidm.f90
+++ b/src/Idm/gwe-disidm.f90
@@ -14,6 +14,10 @@ module GweDisInputModule
   type GweDisParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -73,6 +77,78 @@ module GweDisInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedis_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedis_grb6 = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedis_fileout = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedis_grb6_filename = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -388,6 +464,10 @@ module GweDisInputModule
     [ &
     gwedis_length_units, &
     gwedis_nogrb, &
+    gwedis_grb_filerecord, &
+    gwedis_grb6, &
+    gwedis_fileout, &
+    gwedis_grb6_filename, &
     gwedis_xorigin, &
     gwedis_yorigin, &
     gwedis_angrot, &

--- a/src/Idm/gwe-disuidm.f90
+++ b/src/Idm/gwe-disuidm.f90
@@ -14,6 +14,10 @@ module GweDisuInputModule
   type GweDisuParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -82,6 +86,78 @@ module GweDisuInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedisu_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedisu_grb6 = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedisu_fileout = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedisu_grb6_filename = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -559,6 +635,10 @@ module GweDisuInputModule
     [ &
     gwedisu_length_units, &
     gwedisu_nogrb, &
+    gwedisu_grb_filerecord, &
+    gwedisu_grb6, &
+    gwedisu_fileout, &
+    gwedisu_grb6_filename, &
     gwedisu_xorigin, &
     gwedisu_yorigin, &
     gwedisu_angrot, &

--- a/src/Idm/gwe-disvidm.f90
+++ b/src/Idm/gwe-disvidm.f90
@@ -14,6 +14,10 @@ module GweDisvInputModule
   type GweDisvParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -79,6 +83,78 @@ module GweDisvInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedisv_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedisv_grb6 = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedisv_fileout = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwedisv_grb6_filename = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -502,6 +578,10 @@ module GweDisvInputModule
     [ &
     gwedisv_length_units, &
     gwedisv_nogrb, &
+    gwedisv_grb_filerecord, &
+    gwedisv_grb6, &
+    gwedisv_fileout, &
+    gwedisv_grb6_filename, &
     gwedisv_xorigin, &
     gwedisv_yorigin, &
     gwedisv_angrot, &

--- a/src/Idm/gwf-disidm.f90
+++ b/src/Idm/gwf-disidm.f90
@@ -14,6 +14,10 @@ module GwfDisInputModule
   type GwfDisParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -73,6 +77,78 @@ module GwfDisInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdis_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdis_grb6 = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdis_fileout = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdis_grb6_filename = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -388,6 +464,10 @@ module GwfDisInputModule
     [ &
     gwfdis_length_units, &
     gwfdis_nogrb, &
+    gwfdis_grb_filerecord, &
+    gwfdis_grb6, &
+    gwfdis_fileout, &
+    gwfdis_grb6_filename, &
     gwfdis_xorigin, &
     gwfdis_yorigin, &
     gwfdis_angrot, &

--- a/src/Idm/gwf-disuidm.f90
+++ b/src/Idm/gwf-disuidm.f90
@@ -14,6 +14,10 @@ module GwfDisuInputModule
   type GwfDisuParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -82,6 +86,78 @@ module GwfDisuInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdisu_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdisu_grb6 = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdisu_fileout = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdisu_grb6_filename = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -559,6 +635,10 @@ module GwfDisuInputModule
     [ &
     gwfdisu_length_units, &
     gwfdisu_nogrb, &
+    gwfdisu_grb_filerecord, &
+    gwfdisu_grb6, &
+    gwfdisu_fileout, &
+    gwfdisu_grb6_filename, &
     gwfdisu_xorigin, &
     gwfdisu_yorigin, &
     gwfdisu_angrot, &

--- a/src/Idm/gwf-disvidm.f90
+++ b/src/Idm/gwf-disvidm.f90
@@ -14,6 +14,10 @@ module GwfDisvInputModule
   type GwfDisvParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -79,6 +83,78 @@ module GwfDisvInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdisv_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdisv_grb6 = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdisv_fileout = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdisv_grb6_filename = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -502,6 +578,10 @@ module GwfDisvInputModule
     [ &
     gwfdisv_length_units, &
     gwfdisv_nogrb, &
+    gwfdisv_grb_filerecord, &
+    gwfdisv_grb6, &
+    gwfdisv_fileout, &
+    gwfdisv_grb6_filename, &
     gwfdisv_xorigin, &
     gwfdisv_yorigin, &
     gwfdisv_angrot, &

--- a/src/Idm/gwt-disidm.f90
+++ b/src/Idm/gwt-disidm.f90
@@ -14,6 +14,10 @@ module GwtDisInputModule
   type GwtDisParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -73,6 +77,78 @@ module GwtDisInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdis_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdis_grb6 = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdis_fileout = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdis_grb6_filename = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -388,6 +464,10 @@ module GwtDisInputModule
     [ &
     gwtdis_length_units, &
     gwtdis_nogrb, &
+    gwtdis_grb_filerecord, &
+    gwtdis_grb6, &
+    gwtdis_fileout, &
+    gwtdis_grb6_filename, &
     gwtdis_xorigin, &
     gwtdis_yorigin, &
     gwtdis_angrot, &

--- a/src/Idm/gwt-disuidm.f90
+++ b/src/Idm/gwt-disuidm.f90
@@ -14,6 +14,10 @@ module GwtDisuInputModule
   type GwtDisuParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -82,6 +86,78 @@ module GwtDisuInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdisu_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdisu_grb6 = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdisu_fileout = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdisu_grb6_filename = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DISU', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -559,6 +635,10 @@ module GwtDisuInputModule
     [ &
     gwtdisu_length_units, &
     gwtdisu_nogrb, &
+    gwtdisu_grb_filerecord, &
+    gwtdisu_grb6, &
+    gwtdisu_fileout, &
+    gwtdisu_grb6_filename, &
     gwtdisu_xorigin, &
     gwtdisu_yorigin, &
     gwtdisu_angrot, &

--- a/src/Idm/gwt-disvidm.f90
+++ b/src/Idm/gwt-disvidm.f90
@@ -14,6 +14,10 @@ module GwtDisvInputModule
   type GwtDisvParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -79,6 +83,78 @@ module GwtDisvInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdisv_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdisv_grb6 = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdisv_fileout = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtdisv_grb6_filename = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -502,6 +578,10 @@ module GwtDisvInputModule
     [ &
     gwtdisv_length_units, &
     gwtdisv_nogrb, &
+    gwtdisv_grb_filerecord, &
+    gwtdisv_grb6, &
+    gwtdisv_fileout, &
+    gwtdisv_grb6_filename, &
     gwtdisv_xorigin, &
     gwtdisv_yorigin, &
     gwtdisv_angrot, &

--- a/src/Idm/olf-dis2didm.f90
+++ b/src/Idm/olf-dis2didm.f90
@@ -14,6 +14,10 @@ module OlfDis2DInputModule
   type OlfDis2dParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -66,6 +70,78 @@ module OlfDis2DInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    olfdis2d_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'OLF', & ! component
+    'DIS2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    olfdis2d_grb6 = InputParamDefinitionType &
+    ( &
+    'OLF', & ! component
+    'DIS2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    olfdis2d_fileout = InputParamDefinitionType &
+    ( &
+    'OLF', & ! component
+    'DIS2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    olfdis2d_grb6_filename = InputParamDefinitionType &
+    ( &
+    'OLF', & ! component
+    'DIS2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -255,6 +331,10 @@ module OlfDis2DInputModule
     [ &
     olfdis2d_length_units, &
     olfdis2d_nogrb, &
+    olfdis2d_grb_filerecord, &
+    olfdis2d_grb6, &
+    olfdis2d_fileout, &
+    olfdis2d_grb6_filename, &
     olfdis2d_xorigin, &
     olfdis2d_yorigin, &
     olfdis2d_angrot, &

--- a/src/Idm/olf-disv2didm.f90
+++ b/src/Idm/olf-disv2didm.f90
@@ -14,6 +14,10 @@ module OlfDisv2DInputModule
   type OlfDisv2dParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -72,6 +76,78 @@ module OlfDisv2DInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    olfdisv2d_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'OLF', & ! component
+    'DISV2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    olfdisv2d_grb6 = InputParamDefinitionType &
+    ( &
+    'OLF', & ! component
+    'DISV2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    olfdisv2d_fileout = InputParamDefinitionType &
+    ( &
+    'OLF', & ! component
+    'DISV2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    olfdisv2d_grb6_filename = InputParamDefinitionType &
+    ( &
+    'OLF', & ! component
+    'DISV2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -369,6 +445,10 @@ module OlfDisv2DInputModule
     [ &
     olfdisv2d_length_units, &
     olfdisv2d_nogrb, &
+    olfdisv2d_grb_filerecord, &
+    olfdisv2d_grb6, &
+    olfdisv2d_fileout, &
+    olfdisv2d_grb6_filename, &
     olfdisv2d_xorigin, &
     olfdisv2d_yorigin, &
     olfdisv2d_angrot, &

--- a/src/Idm/prt-disidm.f90
+++ b/src/Idm/prt-disidm.f90
@@ -14,6 +14,10 @@ module PrtDisInputModule
   type PrtDisParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -73,6 +77,78 @@ module PrtDisInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtdis_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtdis_grb6 = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtdis_fileout = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtdis_grb6_filename = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'DIS', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -388,6 +464,10 @@ module PrtDisInputModule
     [ &
     prtdis_length_units, &
     prtdis_nogrb, &
+    prtdis_grb_filerecord, &
+    prtdis_grb6, &
+    prtdis_fileout, &
+    prtdis_grb6_filename, &
     prtdis_xorigin, &
     prtdis_yorigin, &
     prtdis_angrot, &

--- a/src/Idm/prt-disvidm.f90
+++ b/src/Idm/prt-disvidm.f90
@@ -14,6 +14,10 @@ module PrtDisvInputModule
   type PrtDisvParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -79,6 +83,78 @@ module PrtDisvInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtdisv_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtdisv_grb6 = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtdisv_fileout = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtdisv_grb6_filename = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'DISV', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -502,6 +578,10 @@ module PrtDisvInputModule
     [ &
     prtdisv_length_units, &
     prtdisv_nogrb, &
+    prtdisv_grb_filerecord, &
+    prtdisv_grb6, &
+    prtdisv_fileout, &
+    prtdisv_grb6_filename, &
     prtdisv_xorigin, &
     prtdisv_yorigin, &
     prtdisv_angrot, &

--- a/src/Idm/swf-dis2didm.f90
+++ b/src/Idm/swf-dis2didm.f90
@@ -14,6 +14,10 @@ module SwfDis2DInputModule
   type SwfDis2dParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -66,6 +70,78 @@ module SwfDis2DInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdis2d_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DIS2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdis2d_grb6 = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DIS2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdis2d_fileout = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DIS2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdis2d_grb6_filename = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DIS2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -255,6 +331,10 @@ module SwfDis2DInputModule
     [ &
     swfdis2d_length_units, &
     swfdis2d_nogrb, &
+    swfdis2d_grb_filerecord, &
+    swfdis2d_grb6, &
+    swfdis2d_fileout, &
+    swfdis2d_grb6_filename, &
     swfdis2d_xorigin, &
     swfdis2d_yorigin, &
     swfdis2d_angrot, &

--- a/src/Idm/swf-disv1didm.f90
+++ b/src/Idm/swf-disv1didm.f90
@@ -14,6 +14,10 @@ module SwfDisv1DInputModule
   type SwfDisv1dParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -72,6 +76,78 @@ module SwfDisv1DInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdisv1d_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DISV1D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdisv1d_grb6 = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DISV1D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdisv1d_fileout = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DISV1D', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdisv1d_grb6_filename = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DISV1D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -369,6 +445,10 @@ module SwfDisv1DInputModule
     [ &
     swfdisv1d_length_units, &
     swfdisv1d_nogrb, &
+    swfdisv1d_grb_filerecord, &
+    swfdisv1d_grb6, &
+    swfdisv1d_fileout, &
+    swfdisv1d_grb6_filename, &
     swfdisv1d_xorigin, &
     swfdisv1d_yorigin, &
     swfdisv1d_angrot, &

--- a/src/Idm/swf-disv2didm.f90
+++ b/src/Idm/swf-disv2didm.f90
@@ -14,6 +14,10 @@ module SwfDisv2DInputModule
   type SwfDisv2dParamFoundType
     logical :: length_units = .false.
     logical :: nogrb = .false.
+    logical :: grb_filerecord = .false.
+    logical :: grb6 = .false.
+    logical :: fileout = .false.
+    logical :: grb6_filename = .false.
     logical :: xorigin = .false.
     logical :: yorigin = .false.
     logical :: angrot = .false.
@@ -72,6 +76,78 @@ module SwfDisv2DInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdisv2d_grb_filerecord = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DISV2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB_FILERECORD', & ! tag name
+    'GRB_FILERECORD', & ! fortran variable
+    'RECORD GRB6 FILEOUT GRB6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdisv2d_grb6 = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DISV2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6', & ! tag name
+    'GRB6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'grb keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdisv2d_fileout = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DISV2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    swfdisv2d_grb6_filename = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DISV2D', & ! subcomponent
+    'OPTIONS', & ! block
+    'GRB6_FILENAME', & ! tag name
+    'GRB6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of GRB information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -369,6 +445,10 @@ module SwfDisv2DInputModule
     [ &
     swfdisv2d_length_units, &
     swfdisv2d_nogrb, &
+    swfdisv2d_grb_filerecord, &
+    swfdisv2d_grb6, &
+    swfdisv2d_fileout, &
+    swfdisv2d_grb6_filename, &
     swfdisv2d_xorigin, &
     swfdisv2d_yorigin, &
     swfdisv2d_angrot, &

--- a/src/Model/Discretization/Dis.f90
+++ b/src/Model/Discretization/Dis.f90
@@ -565,7 +565,7 @@ contains
     ncpl = this%nrow * this%ncol
     !
     ! -- Open the file
-    fname = trim(this%input_fname)//'.grb'
+    fname = trim(this%output_fname)
     iunit = getunit()
     write (this%iout, fmtgrdsave) iunit, trim(adjustl(fname))
     call openfile(iunit, this%iout, trim(adjustl(fname)), 'DATA(BINARY)', &

--- a/src/Model/Discretization/Dis2d.f90
+++ b/src/Model/Discretization/Dis2d.f90
@@ -499,7 +499,7 @@ contains
     ntxt = 14
     !
     ! -- Open the file
-    fname = trim(this%input_fname)//'.grb'
+    fname = trim(this%output_fname)
     iunit = getunit()
     write (this%iout, fmtgrdsave) iunit, trim(adjustl(fname))
     call openfile(iunit, this%iout, trim(adjustl(fname)), 'DATA(BINARY)', &

--- a/src/Model/Discretization/Disu.f90
+++ b/src/Model/Discretization/Disu.f90
@@ -927,7 +927,7 @@ contains
     if (this%nvert > 0) ntxt = ntxt + 5
     !
     ! -- Open the file
-    fname = trim(this%input_fname)//'.grb'
+    fname = trim(this%output_fname)
     iunit = getunit()
     write (this%iout, fmtgrdsave) iunit, trim(adjustl(fname))
     call openfile(iunit, this%iout, trim(adjustl(fname)), 'DATA(BINARY)', &

--- a/src/Model/Discretization/Disv.f90
+++ b/src/Model/Discretization/Disv.f90
@@ -727,7 +727,7 @@ contains
     ntxt = 20
     !
     ! -- Open the file
-    fname = trim(this%input_fname)//'.grb'
+    fname = trim(this%output_fname)
     iunit = getunit()
     write (this%iout, fmtgrdsave) iunit, trim(adjustl(fname))
     call openfile(iunit, this%iout, trim(adjustl(fname)), 'DATA(BINARY)', &

--- a/src/Model/Discretization/Disv1d.f90
+++ b/src/Model/Discretization/Disv1d.f90
@@ -872,7 +872,7 @@ contains
     if (this%nvert > 0) ntxt = ntxt + 5
     !
     ! -- Open the file
-    fname = trim(this%input_fname)//'.grb'
+    fname = trim(this%output_fname)
     iunit = getunit()
     write (this%iout, fmtgrdsave) iunit, trim(adjustl(fname))
     call openfile(iunit, this%iout, trim(adjustl(fname)), 'DATA(BINARY)', &

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -679,7 +679,7 @@ contains
     ntxt = 18
     !
     ! -- Open the file
-    fname = trim(this%input_fname)//'.grb'
+    fname = trim(this%output_fname)
     iunit = getunit()
     write (this%iout, fmtgrdsave) iunit, trim(adjustl(fname))
     call openfile(iunit, this%iout, trim(adjustl(fname)), 'DATA(BINARY)', &

--- a/src/Model/ModelUtilities/DiscretizationBase.f90
+++ b/src/Model/ModelUtilities/DiscretizationBase.f90
@@ -32,6 +32,7 @@ module BaseDisModule
     character(len=LENMEMPATH) :: input_mempath = '' !< input context mempath
     character(len=LENMODELNAME), pointer :: name_model => null() !< name of the model
     character(len=LINELENGTH), pointer :: input_fname => null() !< input file name
+    character(len=LINELENGTH), pointer :: output_fname => null() !< output file name
     integer(I4B), pointer :: inunit => null() !< unit number for input file
     integer(I4B), pointer :: iout => null() !< unit number for output file
     integer(I4B), pointer :: nodes => null() !< number of nodes in solution
@@ -212,6 +213,7 @@ contains
     ! -- Strings
     deallocate (this%name_model)
     deallocate (this%input_fname)
+    deallocate (this%output_fname)
     !
     ! -- Scalars
     call mem_deallocate(this%inunit)
@@ -409,6 +411,7 @@ contains
     ! -- Allocate
     allocate (this%name_model)
     allocate (this%input_fname)
+    allocate (this%output_fname)
     !
     call mem_allocate(this%inunit, 'INUNIT', this%memoryPath)
     call mem_allocate(this%iout, 'IOUT', this%memoryPath)
@@ -428,6 +431,7 @@ contains
     this%name_model = name_model
     this%input_mempath = input_mempath
     this%input_fname = ''
+    this%output_fname = ''
     this%inunit = 0
     this%iout = 0
     this%nodes = 0
@@ -442,9 +446,14 @@ contains
     this%njas = 0
     this%lenuni = 0
     !
-    ! -- update input filename
+    ! -- update input and output filenames
     call mem_set_value(this%input_fname, 'INPUT_FNAME', &
                        this%input_mempath, found)
+    call mem_set_value(this%output_fname, 'GRB6_FILENAME', &
+                       this%input_mempath, found)
+    if (.not. found) then
+      this%output_fname = trim(this%input_fname)//'.grb'
+    end if
   end subroutine allocate_scalars
 
   !> @brief Allocate and initialize arrays


### PR DESCRIPTION
Add option to all discretization packages to configure the grb output file path, usage `GRB6 OUTFILE <filepath>`. Motivated by https://github.com/modflowpy/flopy/issues/2462

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Updated [develop.tex](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [x] Removed checklist items not relevant to this pull request