### PR TITLE
docs(prt-fmi): correct head/budgetfile keywords

### DIFF
--- a/doc/mf6io/mf6ivar/examples/prt-fmi-example.dat
+++ b/doc/mf6io/mf6ivar/examples/prt-fmi-example.dat
@@ -2,6 +2,6 @@ BEGIN OPTIONS
 END OPTIONS
 
 BEGIN PACKAGEDATA
-  PRTBUDGET FILEIN ../flow/mygwfmodel.bud
-  PRTHEAD FILEIN   ../flow/mygwfmodel.hds
+  GWFBUDGET FILEIN ../flow/mygwfmodel.bud
+  GWFHEAD FILEIN   ../flow/mygwfmodel.hds
 END PACKAGEDATA


### PR DESCRIPTION
The head and budget file keyword names in PRT FMI were described as `PRTHEAD` and `PRTBUDGET`. They should begin `GWF...` instead.