### PR TITLE
refactor(idm): set error for gridded read when model shape not known

### DIFF
--- a/src/Utilities/Idm/SourceCommon.f90
+++ b/src/Utilities/Idm/SourceCommon.f90
@@ -17,9 +17,9 @@ module SourceCommonModule
   public :: package_source_type
   public :: idm_component_type, idm_subcomponent_type, idm_subcomponent_name
   public :: set_model_shape
+  public :: check_model_shape
   public :: get_shape_from_string
   public :: get_layered_shape
-  public :: check_model_shape
   public :: file_ext
   public :: ifind_charstr
   public :: filein_fname
@@ -178,32 +178,6 @@ contains
       array_shape(i) = int_ptr
     end do
   end subroutine get_shape_from_string
-
-  subroutine check_model_shape(mshape, mf6_input, idt, input_fname)
-    use InputDefinitionModule, only: InputParamDefinitionType
-    use ModflowInputModule, only: ModflowInputType
-    integer(I4B), dimension(:), contiguous, pointer, intent(in) :: mshape !< model shape
-    type(ModflowInputType), intent(in) :: mf6_input !< description of input
-    type(InputParamDefinitionType), intent(in) :: idt !< input data type object describing this record
-    character(len=*), intent(in) :: input_fname !< ascii input file name
-
-    select case (idt%datatype)
-    case ('INTEGER1D', &
-          'INTEGER2D', &
-          'INTEGER3D', &
-          'DOUBLE1D', &
-          'DOUBLE2D', &
-          'DOUBLE3D')
-      if (.not. associated(mshape)) then
-        write (errmsg, '(a)') &
-          'Model "'//trim(mf6_input%component_name)//'" shape not known &
-          &for package gridded input read.'
-        call store_error(errmsg)
-        call store_error_filename(input_fname)
-      end if
-    case default
-    end select
-  end subroutine check_model_shape
 
   subroutine get_layered_shape(mshape, nlay, layer_shape)
     integer(I4B), dimension(:), intent(in) :: mshape
@@ -395,6 +369,40 @@ contains
     call mem_allocate(distype, 'DISENUM', model_mempath)
     distype = dis_type
   end subroutine set_model_shape
+
+  !> @brief routine to verify the model shape is set
+  !!
+  !! The model shape must be set in the memory manager because
+  !! individual packages need to know the shape of the arrays
+  !! to read.
+  !!
+  !<
+  subroutine check_model_shape(mshape, mf6_input, idt, input_fname)
+    use InputDefinitionModule, only: InputParamDefinitionType
+    use ModflowInputModule, only: ModflowInputType
+    integer(I4B), dimension(:), contiguous, pointer, intent(in) :: mshape !< model shape
+    type(ModflowInputType), intent(in) :: mf6_input !< description of input
+    type(InputParamDefinitionType), intent(in) :: idt !< input data type describing current read
+    character(len=*), intent(in) :: input_fname !< ascii input file name
+
+    select case (idt%datatype)
+    case ('INTEGER1D', &
+          'INTEGER2D', &
+          'INTEGER3D', &
+          'DOUBLE1D', &
+          'DOUBLE2D', &
+          'DOUBLE3D')
+      if (.not. associated(mshape)) then
+        write (errmsg, '(a)') &
+          'Model "'//trim(mf6_input%component_name)//'" discretization shape &
+          &not known for package gridded input read.'
+        call store_error(errmsg)
+        call store_error_filename(input_fname)
+      end if
+    case default
+      ! other data types reads not dependent on model shape
+    end select
+  end subroutine check_model_shape
 
   function ifind_charstr(array, str)
     use CharacterStringModule, only: CharacterStringType

--- a/src/Utilities/Idm/SourceCommon.f90
+++ b/src/Utilities/Idm/SourceCommon.f90
@@ -19,6 +19,7 @@ module SourceCommonModule
   public :: set_model_shape
   public :: get_shape_from_string
   public :: get_layered_shape
+  public :: check_model_shape
   public :: file_ext
   public :: ifind_charstr
   public :: filein_fname
@@ -177,6 +178,32 @@ contains
       array_shape(i) = int_ptr
     end do
   end subroutine get_shape_from_string
+
+  subroutine check_model_shape(mshape, mf6_input, idt, input_fname)
+    use InputDefinitionModule, only: InputParamDefinitionType
+    use ModflowInputModule, only: ModflowInputType
+    integer(I4B), dimension(:), contiguous, pointer, intent(in) :: mshape !< model shape
+    type(ModflowInputType), intent(in) :: mf6_input !< description of input
+    type(InputParamDefinitionType), intent(in) :: idt !< input data type object describing this record
+    character(len=*), intent(in) :: input_fname !< ascii input file name
+
+    select case (idt%datatype)
+    case ('INTEGER1D', &
+          'INTEGER2D', &
+          'INTEGER3D', &
+          'DOUBLE1D', &
+          'DOUBLE2D', &
+          'DOUBLE3D')
+      if (.not. associated(mshape)) then
+        write (errmsg, '(a)') &
+          'Model "'//trim(mf6_input%component_name)//'" shape not known &
+          &for package gridded input read.'
+        call store_error(errmsg)
+        call store_error_filename(input_fname)
+      end if
+    case default
+    end select
+  end subroutine check_model_shape
 
   subroutine get_layered_shape(mshape, nlay, layer_shape)
     integer(I4B), dimension(:), intent(in) :: mshape

--- a/src/Utilities/Idm/SourceCommon.f90
+++ b/src/Utilities/Idm/SourceCommon.f90
@@ -377,12 +377,11 @@ contains
   !! to read.
   !!
   !<
-  subroutine check_model_shape(mshape, mf6_input, idt, input_fname)
+  subroutine check_model_shape(mshape, idt, model_name, input_fname)
     use InputDefinitionModule, only: InputParamDefinitionType
-    use ModflowInputModule, only: ModflowInputType
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: mshape !< model shape
-    type(ModflowInputType), intent(in) :: mf6_input !< description of input
     type(InputParamDefinitionType), intent(in) :: idt !< input data type describing current read
+    character(len=*), intent(in) :: model_name !< name of model
     character(len=*), intent(in) :: input_fname !< ascii input file name
 
     select case (idt%datatype)
@@ -392,12 +391,14 @@ contains
           'DOUBLE1D', &
           'DOUBLE2D', &
           'DOUBLE3D')
-      if (.not. associated(mshape)) then
-        write (errmsg, '(a)') &
-          'Model "'//trim(mf6_input%component_name)//'" discretization shape &
-          &not known for package gridded input read.'
-        call store_error(errmsg)
-        call store_error_filename(input_fname)
+      if (idt%shape == 'NODES') then
+        if (.not. associated(mshape)) then
+          write (errmsg, '(a)') &
+            'Model "'//trim(model_name)//'" discretization shape &
+            &not known for package gridded input read.'
+          call store_error(errmsg)
+          call store_error_filename(input_fname)
+        end if
       end if
     case default
       ! other data types reads not dependent on model shape

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -415,7 +415,8 @@ contains
                                      tag, this%filename)
 
     ! verify model shape
-    call check_model_shape(this%mshape, this%mf6_input, idt, this%filename)
+    call check_model_shape(this%mshape, idt, this%mf6_input%component_name, &
+                           this%filename)
 
     ! allocate and load data type
     select case (idt%datatype)

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -391,6 +391,7 @@ contains
   !<
   recursive subroutine parse_tag(this, iblk, recursive_call)
     use ArrayHandlersModule, only: expandarray
+    use SourceCommonModule, only: check_model_shape
     class(LoadMf6FileType) :: this
     integer(I4B), intent(in) :: iblk
     logical(LGP), intent(in) :: recursive_call !< true if recursive call
@@ -412,6 +413,9 @@ contains
                                      this%mf6_input%subcomponent_type, &
                                      this%mf6_input%block_dfns(iblk)%blockname, &
                                      tag, this%filename)
+
+    ! verify model shape
+    call check_model_shape(this%mshape, this%mf6_input, idt, this%filename)
 
     ! allocate and load data type
     select case (idt%datatype)


### PR DESCRIPTION
Set an error when an input read dependent on discretization model shape does not have the shape:
  - https://github.com/MODFLOW-ORG/modflow6/issues/2255

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Referenced issue or pull request #xxxx
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).