### PR TITLE
style(tsp-ssm): amend error message

### DIFF
--- a/src/Model/TransportModel/tsp-ssm.f90
+++ b/src/Model/TransportModel/tsp-ssm.f90
@@ -155,11 +155,12 @@ contains
     ! -- Check to make sure that there are flow packages
     if (this%fmi%nflowpack == 0) then
       write (errmsg, '(a)') 'SSM package does not detect any boundary flows &
-                            &that require SSM terms.  Activate GWF-GWT &
-                            &exchange or activate FMI package and provide a &
-                            &budget file that contains boundary flows.  If no &
-                            &boundary flows are present in corresponding GWF &
-                            &model then this SSM package should be removed.'
+                            &that require SSM terms.  Activate GWF-GWT (or &
+                            &GWF-GWE, as appropriate) exchange or activate &
+                            &FMI package and provide a budget file that &
+                            &contains boundary flows.  If no boundary flows &
+                            &are present in corresponding GWF model then this &
+                            &SSM package should be removed.'
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()
     end if


### PR DESCRIPTION
gwt-ssm.f90 was generalized and moved to tsp-ssm.f90 (#1398).  The error message modified by this PR should have been updated at that time to account for the fact that either a `GWF-GWT` or `GWF-GWE` exchange could be missing.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Closes issue #2258 
- [x] References pull request #1398 
- [x] Added new test or modified an existing test
- [x] Formatted new and modified Fortran source files with `fprettify`
