### PR TITLE
fix(petsc): breaking changes in PETSc 3.23 

### DIFF
--- a/.github/actions/test-extended/action.yml
+++ b/.github/actions/test-extended/action.yml
@@ -10,20 +10,11 @@ runs:
         version: 13
 
     - name: Checkout PETSc
-      if: runner.os == 'Linux'
       uses: actions/checkout@v4
       with:
         repository: petsc/petsc
         path: petsc
-        ref: release
-
-    - name: Checkout PETSc
-      if: runner.os == 'macOS'
-      uses: actions/checkout@v4
-      with:
-        repository: petsc/petsc
-        path: petsc
-        ref: v3.22.1
+        ref: v3.22.5
 
     - name: Configure environment
       shell: bash


### PR DESCRIPTION
(see commit ce78bad in their repo) forces us to set back our version to 3.22 for the time being.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #xxxx
- [x] Removed checklist items not relevant to this pull request