### PR TITLE
test: use devtools models api, misc cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,12 +228,6 @@ jobs:
         with:
           path: modflow6
 
-      - name: Checkout test models
-        uses: actions/checkout@v4
-        with:
-          repository: MODFLOW-ORG/modflow6-testmodels
-          path: modflow6-testmodels
-
       - name: Checkout examples
         uses: actions/checkout@v4
         with:
@@ -393,12 +387,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: modflow6
-
-      - name: Checkout test models
-        uses: actions/checkout@v4
-        with:
-          repository: MODFLOW-ORG/modflow6-testmodels
-          path: modflow6-testmodels
 
       - name: Checkout examples
         uses: actions/checkout@v4

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -75,12 +75,6 @@ jobs:
         with:
           path: modflow6
 
-      - name: Checkout modflow6-testmodels
-        uses: actions/checkout@v4
-        with:
-          repository: MODFLOW-ORG/modflow6-testmodels
-          path: modflow6-testmodels
-    
       - name: Checkout modflow6-examples
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/large.yml
+++ b/.github/workflows/large.yml
@@ -60,12 +60,6 @@ jobs:
         with:
           path: modflow6
 
-      - name: Checkout modflow6-largetestmodels
-        uses: actions/checkout@v4
-        with:
-          repository: MODFLOW-ORG/modflow6-largetestmodels
-          path: modflow6-largetestmodels
-
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.8.4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,13 +265,6 @@ jobs:
           name: bin-${{ steps.ostag.outputs.ostag }}
           path: modflow6/bin
 
-      - name: Checkout modflow6-testmodels
-        if: inputs.run_tests == true && runner.os != 'Windows'
-        uses: actions/checkout@v4
-        with:
-          repository: MODFLOW-ORG/modflow6-testmodels
-          path: modflow6-testmodels
-
       - name: Checkout modflow6-examples
         if: inputs.run_tests == true && runner.os != 'Windows'
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ autotest/notebooks/
 **.DS_Store
 # pixi environments
 .pixi
+
+**/*.lock

--- a/autotest/test_largetestmodels.py
+++ b/autotest/test_largetestmodels.py
@@ -1,10 +1,17 @@
 from shutil import copytree
 
+import modflow_devtools.models as models
 import pytest
-from common_regression import get_mf6_comparison, setup_mf6, setup_mf6_comparison
+from compare import (
+    Comparison,
+    detect_comparison,
+    setup_comparison,
+    setup_simulation,
+)
 from framework import TestFramework
 
-excluded_models = [
+MODELS = [m for m in models.get_models().keys() if m.startswith("large/")]
+SKIP = [
     "test1002_biscqtg_disv_gnc_nr_dev",
     "test1002_biscqtg_disv_nr_MD_dev",
     "test1002_biscqtg_disv_nr_RCM_dev",
@@ -13,29 +20,44 @@ excluded_models = [
 
 
 @pytest.mark.regression
-@pytest.mark.repo
 @pytest.mark.slow
+@pytest.mark.parametrize("model_name", MODELS)
 def test_model(
+    model_name,
+    tmp_path,
     function_tmpdir,
-    # https://modflow-devtools.readthedocs.io/en/latest/md/fixtures.html#large-test-models
-    large_test_model,
     markers,
     original_regression,
     targets,
 ):
-    model_path = large_test_model.parent
-    model_name = model_path.name
-    excluded = model_name in excluded_models
-    compare = (
-        get_mf6_comparison(model_path) if original_regression else "mf6_regression"
-    )
-    dev_only = "dev" in model_name and "not developmode" in markers
-    if excluded or dev_only:
-        reason = "excluded" if excluded else "developmode only"
+    models.copy_to(tmp_path, model_name)
+
+    # skip this one?
+    skip = any(s in model_name for s in SKIP)
+    devonly = "dev" in model_name and "not developmode" in markers
+    if skip or devonly:
+        reason = "excluded" if skip else "developmode only"
         pytest.skip(f"Skipping: {model_name} ({reason})")
 
     # setup test workspace and framework
-    setup_mf6(src=model_path, dst=function_tmpdir)
+    setup_simulation(src=tmp_path, dst=function_tmpdir)
+
+    # setup comparison workspace
+    if (
+        compare := detect_comparison(tmp_path)
+        if original_regression
+        else Comparison.MF6_REGRESSION
+    ) == Comparison.MF6_REGRESSION:
+        copytree(function_tmpdir, function_tmpdir / compare.value)
+    else:
+        setup_comparison(
+            function_tmpdir,
+            function_tmpdir / compare.value,
+            compare.value,
+            overwrite=True,
+        )
+
+    # run the test
     test = TestFramework(
         name=model_name,
         workspace=function_tmpdir,
@@ -43,12 +65,4 @@ def test_model(
         compare=compare,
         verbose=False,
     )
-
-    # setup comparison workspace
-    if compare == "mf6_regression":
-        copytree(function_tmpdir, function_tmpdir / compare)
-    else:
-        setup_mf6_comparison(model_path, function_tmpdir, compare, overwrite=True)
-
-    # run the test
     test.run()

--- a/autotest/test_testmodels_mf5to6.py
+++ b/autotest/test_testmodels_mf5to6.py
@@ -4,12 +4,12 @@ from shutil import copytree
 
 import flopy
 import pytest
-from common_regression import (
-    get_mf6_comparison,
+from compare import (
+    detect_comparison,
     get_namefiles,
-    setup_mf6,
-    setup_mf6_comparison,
+    setup_comparison,
     setup_model,
+    setup_simulation,
 )
 from framework import TestFramework
 
@@ -79,11 +79,9 @@ def test_model(
 
     # setup mf6 workspace and framework
     mf6_workspace = function_tmpdir / "mf6"
-    setup_mf6(src=mf5to6_workspace, dst=mf6_workspace)
+    setup_simulation(src=mf5to6_workspace, dst=mf6_workspace)
     compare = (
-        get_mf6_comparison(mf5to6_workspace)
-        if original_regression
-        else "mf6_regression"
+        detect_comparison(mf5to6_workspace) if original_regression else "mf6_regression"
     )
     test = TestFramework(
         name=model_path.name,
@@ -97,7 +95,7 @@ def test_model(
     if compare == "mf6_regression":
         copytree(mf5to6_workspace, mf6_workspace / compare)
     else:
-        setup_mf6_comparison(mf5to6_workspace, mf6_workspace, compare, overwrite=True)
+        setup_comparison(mf5to6_workspace, mf6_workspace, compare, overwrite=True)
 
     # run the test
     test.run()

--- a/autotest/test_testmodels_mf6.py
+++ b/autotest/test_testmodels_mf6.py
@@ -1,10 +1,17 @@
 from shutil import copytree
 
+import modflow_devtools.models as models
 import pytest
-from common_regression import get_mf6_comparison, setup_mf6, setup_mf6_comparison
+from compare import (
+    Comparison,
+    detect_comparison,
+    setup_comparison,
+    setup_simulation,
+)
 from framework import TestFramework
 
-excluded_models = [
+MODELS = [m for m in models.get_models().keys() if m.startswith("test/")]
+SKIP = [
     "alt_model",
     "test205_gwtbuy-henrytidal",
     # todo reinstate after 6.5.0 release
@@ -23,29 +30,43 @@ excluded_models = [
 ]
 
 
-@pytest.mark.repo
 @pytest.mark.regression
+@pytest.mark.parametrize("model_name", MODELS)
 def test_model(
+    model_name,
+    tmp_path,
     function_tmpdir,
     markers,
     original_regression,
     targets,
-    # https://modflow-devtools.readthedocs.io/en/latest/md/fixtures.html#modflow-6-test-models
-    test_model_mf6,
 ):
-    model_path = test_model_mf6.parent
-    model_name = model_path.name
-    excluded = model_name in excluded_models
-    compare = (
-        get_mf6_comparison(model_path) if original_regression else "mf6_regression"
-    )
-    dev_only = "dev" in model_name and "not developmode" in markers
-    if excluded or dev_only:
-        reason = "excluded" if excluded else "developmode only"
+    models.copy_to(tmp_path, model_name)
+
+    skip = any(s in model_name for s in SKIP)
+    devonly = "dev" in model_name and "not developmode" in markers
+    if skip or devonly:
+        reason = "excluded" if skip else "developmode only"
         pytest.skip(f"Skipping: {model_name} ({reason})")
 
     # setup test workspace and framework
-    setup_mf6(src=model_path, dst=function_tmpdir)
+    setup_simulation(src=tmp_path, dst=function_tmpdir)
+
+    # setup comparison workspace
+    if (
+        compare := detect_comparison(tmp_path)
+        if original_regression
+        else Comparison.MF6_REGRESSION
+    ) == Comparison.MF6_REGRESSION:
+        copytree(function_tmpdir, function_tmpdir / compare.value)
+    else:
+        setup_comparison(
+            function_tmpdir,
+            function_tmpdir / compare.value,
+            compare.value,
+            overwrite=True,
+        )
+
+    # run the test
     test = TestFramework(
         name=model_name,
         workspace=function_tmpdir,
@@ -53,12 +74,4 @@ def test_model(
         compare=compare,
         verbose=False,
     )
-
-    # setup comparison workspace
-    if compare == "mf6_regression":
-        copytree(function_tmpdir, function_tmpdir / compare)
-    else:
-        setup_mf6_comparison(model_path, function_tmpdir, compare, overwrite=True)
-
-    # run the test
     test.run()


### PR DESCRIPTION
Replace [the old fixtures](https://modflow-devtools.readthedocs.io/en/latest/md/fixtures.html#loading-example-models) with the new models module for accessing models from various repositories. Also some renaming and cleanup in the regression/comparison utilities.