### PR TITLE
fix(gwe-sfe): add support for strmbd-cond observation type in sfe

### DIFF
--- a/autotest/test_gwe_sfe_strmbedcond.py
+++ b/autotest/test_gwe_sfe_strmbedcond.py
@@ -666,17 +666,17 @@ def check_output(idx, test):
     df["sum_strmbd_cond"] = df.iloc[:, -3:].sum(axis=1)
     if name[-1] != "m":
         assert np.isclose(
-            out_bud_lst["STREAMBED-COND"],
+            out_bud_lst["STRMBD-COND"],
             abs(df.loc[0, "sum_strmbd_cond"]),
             atol=0.0001,
         ), "There is a streambed conductance discrepancy " + str(
-            out_bud_lst["STREAMBED-COND"] - abs(df.loc[0, "sum_strmbd_cond"])
+            out_bud_lst["STRMBD-COND"] - abs(df.loc[0, "sum_strmbd_cond"])
         )
     else:
         assert np.isclose(
-            in_bud_lst["STREAMBED-COND"], abs(df.loc[0, "sum_strmbd_cond"]), atol=0.0001
+            in_bud_lst["STRMBD-COND"], abs(df.loc[0, "sum_strmbd_cond"]), atol=0.0001
         ), "There is a streambed conductance discrepancy " + str(
-            out_bud_lst["STREAMBED-COND"] - abs(df.loc[0, "sum_strmbd_cond"])
+            out_bud_lst["STRMBD-COND"] - abs(df.loc[0, "sum_strmbd_cond"])
         )
 
     # Get temperature of streamwater
@@ -715,8 +715,8 @@ def check_output(idx, test):
         # Determine gw/sfe temperature gradient direction
         if sfe_temps[0, 0, 0, 0] > gw_temps[0, 0, 0, 0]:
             # conduction will be from stream to gw
-            assert in_bud_lst["STREAMBED-COND"] == 0.0, msg2
-            assert out_bud_lst["STREAMBED-COND"] > 0.0, msg2
+            assert in_bud_lst["STRMBD-COND"] == 0.0, msg2
+            assert out_bud_lst["STRMBD-COND"] > 0.0, msg2
 
             slp = trenddetector(
                 np.arange(0, sfe_temps.shape[-1]), sfe_temps[0, 0, 0, :]
@@ -727,8 +727,8 @@ def check_output(idx, test):
             assert slp > 0.0, msg4
 
         else:
-            assert in_bud_lst["STREAMBED-COND"] > 0.0, msg2
-            assert out_bud_lst["STREAMBED-COND"] == 0.0, msg2
+            assert in_bud_lst["STRMBD-COND"] > 0.0, msg2
+            assert out_bud_lst["STRMBD-COND"] == 0.0, msg2
 
     # streamflow gain from aquifer ("into stream")
     if name[-1] == "i":
@@ -739,8 +739,8 @@ def check_output(idx, test):
         # Determine gw/sfe temperature gradient direction
         if sfe_temps[0, 0, 0, 0] > gw_temps[0, 0, 0, 0]:
             # conduction will be from stream to gw
-            assert in_bud_lst["STREAMBED-COND"] == 0.0, msg2
-            assert out_bud_lst["STREAMBED-COND"] > 0.0, msg2
+            assert in_bud_lst["STRMBD-COND"] == 0.0, msg2
+            assert out_bud_lst["STRMBD-COND"] > 0.0, msg2
 
             slp = trenddetector(
                 np.arange(0, sfe_temps.shape[-1]), sfe_temps[0, 0, 0, :]
@@ -751,8 +751,8 @@ def check_output(idx, test):
             assert slp > 0.0, msg4
 
         else:
-            assert in_bud_lst["STREAMBED-COND"] > 0.0, msg2
-            assert out_bud_lst["STREAMBED-COND"] == 0.0, msg2
+            assert in_bud_lst["STRMBD-COND"] > 0.0, msg2
+            assert out_bud_lst["STRMBD-COND"] == 0.0, msg2
 
     # streamflow loss to aquifer ("out of stream")
     if name[-1] == "o":
@@ -763,8 +763,8 @@ def check_output(idx, test):
         # Determine gw/sfe temperature gradient direction
         if sfe_temps[0, 0, 0, 0] > gw_temps[0, 0, 0, 0]:
             # conduction will be from stream to gw
-            assert in_bud_lst["STREAMBED-COND"] == 0.0, msg2
-            assert out_bud_lst["STREAMBED-COND"] > 0.0, msg2
+            assert in_bud_lst["STRMBD-COND"] == 0.0, msg2
+            assert out_bud_lst["STRMBD-COND"] > 0.0, msg2
 
             slp = trenddetector(
                 np.arange(0, sfe_temps.shape[-1]), sfe_temps[0, 0, 0, :]
@@ -775,8 +775,8 @@ def check_output(idx, test):
             assert slp < 0.0, msg4
 
         else:
-            assert in_bud_lst["STREAMBED-COND"] > 0.0, msg2
-            assert out_bud_lst["STREAMBED-COND"] == 0.0, msg2
+            assert in_bud_lst["STRMBD-COND"] > 0.0, msg2
+            assert out_bud_lst["STRMBD-COND"] == 0.0, msg2
 
     # Reverse temperature gradient  (cold stream, warm aquifer)
     # Loss of streamwater to aquifer
@@ -789,12 +789,12 @@ def check_output(idx, test):
         # Determine gw/sfe temperature gradient direction
         if sfe_temps[0, 0, 0, 0] > gw_temps[0, 0, 0, 0]:
             # conduction will be from stream to gw
-            assert in_bud_lst["STREAMBED-COND"] == 0.0, msg2
-            assert out_bud_lst["STREAMBED-COND"] > 0.0, msg2
+            assert in_bud_lst["STRMBD-COND"] == 0.0, msg2
+            assert out_bud_lst["STRMBD-COND"] > 0.0, msg2
 
         else:
-            assert in_bud_lst["STREAMBED-COND"] > 0.0, msg2
-            assert out_bud_lst["STREAMBED-COND"] == 0.0, msg2
+            assert in_bud_lst["STRMBD-COND"] > 0.0, msg2
+            assert out_bud_lst["STRMBD-COND"] == 0.0, msg2
 
             slp = trenddetector(
                 np.arange(0, sfe_temps.shape[-1]), sfe_temps[0, 0, 0, :]

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -25,3 +25,7 @@ description = "A new example was added demonstrating transient thermal loading o
 section = "features"
 subsection = "internal"
 description = "Added interbed-compaction-pct observation to the CSUB package."
+
+[[items]]
+section = "fixes"
+description = "The mf6io.pdf guide for the SFE Package lists the availability of the STRMBD-COND observation type.  However, the SFE Package did not actually support this observation type and if listed would cause the program to exit with error message.  Functionality has been added to SFE for writing the amount of streambed conductive heat exchange to the CSV output file that contains the user-specified observations."

--- a/src/Model/GroundWaterEnergy/gwe-sfe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-sfe.f90
@@ -573,7 +573,6 @@ contains
     ! -- local
     integer(I4B) :: j, n1, n2
     integer(I4B) :: nlist
-    integer(I4B) :: igwfnode
     integer(I4B) :: idiag
     real(DP) :: q
     !
@@ -1014,7 +1013,6 @@ contains
     real(DP), intent(inout) :: v
     integer(I4B), intent(in) :: jj
     logical, intent(inout) :: found
-    real(DP), dimension(:), pointer :: x
     ! -- local
     integer(I4B) :: n1, n2
     !

--- a/src/Model/GroundWaterEnergy/gwe-sfe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-sfe.f90
@@ -890,13 +890,9 @@ contains
     ! -- dummy
     class(GweSfeType) :: this
     integer(I4B), intent(in) :: ientry
-    real(DP), intent(inout), optional :: rrate
-    ! -- local
-    integer(I4B) :: i
-    real(DP) :: qbnd
+    real(DP), intent(inout) :: rrate
     !
-    qbnd = this%budobj%budterm(this%idxbudsbcd)%flow(ientry)
-    rrate = qbnd
+    rrate = this%budobj%budterm(this%idxbudsbcd)%flow(ientry)
   end subroutine sfe_strmbd_cond_amt
 
   !> @brief Observations

--- a/src/Model/GroundWaterEnergy/gwe-sfe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-sfe.f90
@@ -291,11 +291,10 @@ contains
     integer(I4B), dimension(:), intent(in) :: idxglo
     class(MatrixBaseType), pointer :: matrix_sln
     ! -- local
-    integer(I4B) :: j, n, n1, n2
+    integer(I4B) :: j, n1, n2
     integer(I4B) :: iloc
     integer(I4B) :: iposd, iposoffd
     integer(I4B) :: ipossymd, ipossymoffd
-    integer(I4B) :: auxpos
     real(DP) :: rrate
     real(DP) :: rhsval
     real(DP) :: hcofval

--- a/src/Model/GroundWaterEnergy/gwe-sfe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-sfe.f90
@@ -628,7 +628,7 @@ contains
     !
     ! -- Strmbd-cond. The idxbudgwf index is used since it contains the
     !    sfe/cell mapping information
-    this%gwtemp = x
+    this%gwtemp = x(1:this%dis%nodes)
     idx = idx + 1
     nlist = this%flowbudptr%budterm(this%idxbudgwf)%nlist
     call this%budobj%budterm(idx)%reset(nlist)
@@ -1157,7 +1157,7 @@ contains
     call mem_allocate(this%rfeatthk, this%ncv, 'RFEATTHK', this%memoryPath)
     call mem_allocate(this%lauxvar, this%naux, this%ncv, 'LAUXVAR', &
                       this%memoryPath)
-    call mem_allocate(this%gwtemp, this%dis%njas, 'GWTEMP', this%memoryPath)
+    call mem_allocate(this%gwtemp, this%dis%nodes, 'GWTEMP', this%memoryPath)
     !
     ! -- stream boundary and temperatures
     if (this%imatrows == 0) then

--- a/src/Model/GroundWaterEnergy/gwe-sfe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-sfe.f90
@@ -1157,7 +1157,7 @@ contains
     call mem_allocate(this%rfeatthk, this%ncv, 'RFEATTHK', this%memoryPath)
     call mem_allocate(this%lauxvar, this%naux, this%ncv, 'LAUXVAR', &
                       this%memoryPath)
-    call mem_allocate(this%gwtemp, this%dis%nodes, 'GWTEMP', this%memoryPath)
+    call mem_allocate(this%gwtemp, this%dis%njas, 'GWTEMP', this%memoryPath)
     !
     ! -- stream boundary and temperatures
     if (this%imatrows == 0) then


### PR DESCRIPTION
In the MF6io guide, in the SFE observations section, one of the observation types listed was `STRMBD-COND`.  However, there was no actual support for this observation type in the src code.  This PR adds support for it and tests that it is working OK by modifying an existing autotest (`test_gwe_sfe_strmbedcond.py`)

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Addresses and closes issue #2264
- [x] Related to #1493 
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.tex](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users