### PR TITLE
docs(mf6io): modelname description incomplete in buy and vsc packages

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwf-buy.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-buy.dfn
@@ -131,7 +131,7 @@ tagged false
 shape
 reader urword
 longname modelname
-description name of GWT model used to simulate a species that will be used in the density equation of state.  This name will have no effect if the simulation does not include a GWT model that corresponds to this GWF model.
+description name of a GWT or GWE model used to simulate a species that will be used in the density equation of state.  This name will have no effect if the simulation does not include a GWT or GWE model that corresponds to this GWF model.
 
 block packagedata
 name auxspeciesname

--- a/doc/mf6io/mf6ivar/dfn/gwf-vsc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-vsc.dfn
@@ -160,7 +160,7 @@ tagged false
 shape
 reader urword
 longname modelname
-description name of a GWT model used to simulate a species that will be used in the viscosity equation of state.  This name will have no effect if the simulation does not include a GWT model that corresponds to this GWF model.
+description name of a GWT or GWE model used to simulate a species that will be used in the viscosity equation of state.  This name will have no effect if the simulation does not include a GWT or GWE model that corresponds to this GWF model.
 
 block packagedata
 name auxspeciesname


### PR DESCRIPTION
GWE should have been listed in the description of the modelname parameter for both the `BUY` and `VSC` Packages.  

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Addresses issue #2261 
- [x] Related to pull requests #1071 and #374 
- [x] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)