### PR TITLE
ci: fix exclusion of large models in commit-triggered tests

### DIFF
--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -6,6 +6,7 @@ python_files =
 markers =
     slow: tests taking more than a few seconds to complete
     repo: tests using models loaded from an external repository
+    large: tests using large/slow models from another repository
     regression: tests comparing results from different versions
     developmode: tests that should only run with IDEVELOPMODE = 1
     gwf: tests for groundwater flow models

--- a/autotest/test_largetestmodels.py
+++ b/autotest/test_largetestmodels.py
@@ -19,6 +19,7 @@ SKIP = [
 ]
 
 
+@pytest.mark.large
 @pytest.mark.regression
 @pytest.mark.slow
 @pytest.mark.parametrize("model_name", MODELS)


### PR DESCRIPTION
Since #2265 large models were not excluded as they should be from the standard CI tests