### PR TITLE
fix(ci): macos extended build

### DIFF
--- a/.github/actions/test-extended/action.yml
+++ b/.github/actions/test-extended/action.yml
@@ -48,7 +48,7 @@ runs:
       run: |
         brew install netcdf-fortran
         nc-config --all
-        nf-config
+        nf-config --all
 
     - name: Build modflow6
       shell: bash


### PR DESCRIPTION
Fix macOS extended build: ```netcdf-fortran``` in the environment was recently upgraded from ```4.6.1``` to ```4.6.2``` which included a change to the ```nf-config``` interface.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).