### PR TITLE
feat(csub): add percent compaction observation

### DIFF
--- a/doc/Common/gwf-csubobs.tex
+++ b/doc/Common/gwf-csubobs.tex
@@ -14,6 +14,7 @@ CSUB & estress-cell & cellid & -- & effective stress in a GWF cell. \\
 CSUB & gstress-cell & cellid & -- & geostatic stress in a GWF cell. \\
 
 CSUB & interbed-compaction & icsubno  & -- & interbed compaction in a interbed. \\
+CSUB & interbed-compaction-pct & icsubno  & -- & interbed percent compaction in a interbed. \\
 CSUB & inelastic-compaction &  icsubno & -- & inelastic interbed compaction in a interbed. \\
 CSUB & elastic-compaction &  icsubno & -- & elastic interbed compaction a interbed. \\
 CSUB & coarse-compaction & cellid  & -- & elastic compaction in coarse-grained materials in a GWF cell. \\

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -20,3 +20,8 @@ description = "The binary grid file's name may now be specified in all discretiz
 [[items]]
 section = "examples"
 description = "A new example was added demonstrating transient thermal loading of multiple borehole heat exchangers with the Groundwater Energy (GWE) model. The simulated GWE results match the temperature change predicted by the analytical solution for the multiple borehole heat exchangers used in this problem."
+
+[[items]]
+section = "features"
+subsection = "internal"
+description = "Added interbed-compaction-pct observation to the CSUB package."

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -7078,7 +7078,6 @@ contains
                 v = this%tcomp(n)
               case ('INTERBED-COMPACTION-PCT')
                 b0 = this%thickini(n)
-                ! b1 = this%csub_calc_interbed_thickness(n)
                 if (this%idelay(n) /= 0) then
                   b0 = b0 * this%rnb(n)
                 end if

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -419,9 +419,6 @@ contains
     !
     ! - observation data
     call this%obs%obs_ar()
-
-    ! setup tables
-    call this%csub_initialize_tables()
     !
     ! -- terminate if errors dimensions block data
     if (count_errors() > 0) then
@@ -543,6 +540,9 @@ contains
     if (this%ninterbeds > 0) then
       call this%csub_read_packagedata()
     end if
+    !
+    ! setup package convergence tables
+    call this%csub_initialize_tables()
     !
     ! -- calculate the coarse-grained material thickness without the interbeds
     do node = 1, this%dis%nodes
@@ -6889,6 +6889,11 @@ contains
     this%obs%obsData(indx)%ProcessIdPtr => csub_process_obsID
     !
     ! -- Store obs type and assign procedure pointer
+    !    for interbed-compaction-pct observation type.
+    call this%obs%StoreObsType('interbed-compaction-pct', .false., indx)
+    this%obs%obsData(indx)%ProcessIdPtr => csub_process_obsID
+    !
+    ! -- Store obs type and assign procedure pointer
     !    for delay-preconstress observation type.
     call this%obs%StoreObsType('delay-preconstress', .false., indx)
     this%obs%obsData(indx)%ProcessIdPtr => csub_process_obsID
@@ -6953,6 +6958,7 @@ contains
     real(DP) :: v
     real(DP) :: r
     real(DP) :: f
+    real(DP) :: b0
     !
     ! -- Fill simulated values for all csub observations
     if (this%obs%npakobs > 0) then
@@ -7070,6 +7076,13 @@ contains
                 v = this%cg_es(n)
               case ('INTERBED-COMPACTION')
                 v = this%tcomp(n)
+              case ('INTERBED-COMPACTION-PCT')
+                b0 = this%thickini(n)
+                ! b1 = this%csub_calc_interbed_thickness(n)
+                if (this%idelay(n) /= 0) then
+                  b0 = b0 * this%rnb(n)
+                end if
+                v = DHUNDRED * this%tcomp(n) / b0
               case ('INELASTIC-COMPACTION')
                 v = this%tcompi(n)
               case ('ELASTIC-COMPACTION')
@@ -7249,7 +7262,8 @@ contains
                  obsrv%ObsTypeId == 'THETA' .or. &
                  obsrv%ObsTypeId == 'INTERBED-COMPACTION' .or. &
                  obsrv%ObsTypeId == 'INELASTIC-COMPACTION' .or. &
-                 obsrv%ObsTypeId == 'ELASTIC-COMPACTION') then
+                 obsrv%ObsTypeId == 'ELASTIC-COMPACTION' .or. &
+                 obsrv%ObsTypeId == 'INTERBED-COMPACTION-PCT') then
           if (this%ninterbeds > 0) then
             j = obsrv%NodeNumber
             if (j < 1 .or. j > this%ninterbeds) then
@@ -7368,6 +7382,7 @@ contains
         obsrv%ObsTypeId == 'THETA' .or. &
         obsrv%ObsTypeId == 'THICKNESS' .or. &
         obsrv%ObsTypeId == 'INTERBED-COMPACTION' .or. &
+        obsrv%ObsTypeId == 'INTERBED-COMPACTION-PCT' .or. &
         obsrv%ObsTypeId == 'INELASTIC-COMPACTION' .or. &
         obsrv%ObsTypeId == 'ELASTIC-COMPACTION' .or. &
         obsrv%ObsTypeId == 'DELAY-HEAD' .or. &


### PR DESCRIPTION
Add interbed-compaction-pct observation to CSUB. Also moved CSUB convergence table initialization after reading interbed data to eliminate false warning.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.tex](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).