### PR TITLE
fix(par): avoid integer overflow of MPI message size

### DIFF
--- a/autotest/test_gwf_ifmod_idomain02.py
+++ b/autotest/test_gwf_ifmod_idomain02.py
@@ -1,0 +1,214 @@
+"""
+General test for the interface model approach.
+It compares the skewed decomposition of the domain
+to the trivial analytical result (constant gradient).
+In this case with the use of idomain to deactivate half
+of the sub-models. Note that the cells with idomain==0
+overlap with the active cells of the other model.
+
+     'leftmodel'         'rightmodel'
+
+    1 1 1 0 0 0 0       1 1 1 1 1 1 1
+    1 1 1 1 0 0 0       0 1 1 1 1 1 1
+    1 1 1 1 1 0 0   +   0 0 1 1 1 1 1
+    1 1 1 1 1 1 0       0 0 0 1 1 1 1
+    1 1 1 1 1 1 1       0 0 0 0 1 1 1
+
+We assert equality on the head values and check budgets.
+"""
+
+import os
+
+import flopy
+import numpy as np
+import pytest
+from flopy.mf6.utils import Mf6Splitter
+from framework import TestFramework
+
+cases = ["ifmod_skewed"]
+
+# some global convenience...:
+# model name
+mname = "skewed"
+
+# solver criterion
+hclose_check = 1e-9
+max_inner_it = 300
+nper = 1
+
+# model spatial discretization
+nlay = 1
+ncol = 10
+nrow = 5
+
+# idomain
+idomain = np.ones((nlay, nrow, ncol))
+
+delr = 1.0
+delc = 1.0
+area = delr * delc
+
+# top/bot of the aquifer
+tops = [1.0, 0.0]
+
+# hydraulic conductivity
+hk = 10.0
+
+# boundary stress period data
+h_left = 10.0
+h_right = 1.0
+
+# initial head
+h_start = 0.0
+
+# head boundaries
+lchd = [[(ilay, irow, 0), h_left] for irow in range(nrow) for ilay in range(nlay)]
+rchd = [
+    [(ilay, irow, ncol - 1), h_right] for irow in range(nrow) for ilay in range(nlay)
+]
+chd = lchd + rchd
+
+chd_spd = {0: chd}
+
+
+def get_model(idx, dir):
+    name = cases[idx]
+
+    # parameters and spd
+    # tdis
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((1.0, 1, 1))
+
+    # solver data
+    nouter, ninner = 100, max_inner_it
+    hclose, rclose, relax = hclose_check, 1e-3, 0.97
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=dir
+    )
+
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
+
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="CG",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename="gwf.ims",
+    )
+
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=mname, save_flows=True)
+
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        xorigin=0.0,
+        yorigin=0.0,
+        top=tops[0],
+        botm=tops[1:],
+        idomain=idomain,
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=h_start)
+
+    # node property flow
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf,
+        save_specific_discharge=True,
+        icelltype=0,
+        k=hk,
+    )
+
+    # chd file
+    chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd_spd)
+
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=f"{mname}.hds",
+        budget_filerecord=f"{mname}.cbc",
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
+    )
+
+    # split the model
+    splitter = Mf6Splitter(sim)
+    mask = np.zeros(shape=(nrow, ncol))
+    for irow in range(nrow):
+        istart = irow + 3
+        mask[irow, istart:] = 1
+    split_sim = splitter.split_model(mask)
+    split_sim.set_sim_path(dir)
+
+    return split_sim
+
+
+def build_models(idx, test):
+    sim = get_model(idx, test.workspace)
+    return sim, None
+
+
+def check_output(idx, test):
+    print("comparing heads to single model reference...")
+
+    sim = flopy.mf6.MFSimulation.load(sim_ws=test.workspace)
+
+    mname_left = sim.model_names[0]
+    mname_right = sim.model_names[1]
+
+    fpth = os.path.join(test.workspace, f"{mname_left}.hds")
+    hds_left = flopy.utils.HeadFile(fpth).get_alldata()
+    hds_left[hds_left == 1.0e30] = 0.0
+
+    fpth = os.path.join(test.workspace, f"{mname_right}.hds")
+    hds_right = flopy.utils.HeadFile(fpth).get_alldata()
+    hds_right[hds_right == 1.0e30] = 0.0
+
+    hds = np.zeros((nrow, ncol), dtype=float)
+    hds[:, 0:7] = hds[:, 0:7] + hds_left[:, :]
+    hds[:, 3:] = hds[:, 3:] + hds_right[:, :]
+
+    cst_gradient = np.linspace(10.0, 1.0, ncol)
+    for irow in range(nrow):
+        assert hds[irow, :] == pytest.approx(cst_gradient, rel=10 * hclose_check), (
+            f"Head values for row {irow} do not match analytical result. "
+            f"Expected {cst_gradient}, but got {hds[irow, :]}"
+        )
+
+    # check budget error from .lst file
+    for mname in [mname_left, mname_right]:
+        fpth = os.path.join(test.workspace, f"{mname}.lst")
+        for line in open(fpth):
+            if line.lstrip().startswith("PERCENT"):
+                cumul_balance_error = float(line.split()[3])
+                assert abs(cumul_balance_error) < 0.00001, (
+                    f"Cumulative balance error = {cumul_balance_error} for {mname}, "
+                    "should equal 0.0"
+                )
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.developmode
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        targets=targets,
+    )
+    test.run()

--- a/autotest/test_par_gwf_idomain02.py
+++ b/autotest/test_par_gwf_idomain02.py
@@ -1,0 +1,39 @@
+"""
+This tests reuses the simulation data in test_gwf_ifmod_idomain02.py
+and runs it in parallel on two cpus
+"""
+
+import pytest
+from framework import TestFramework
+
+cases = ["par_idomain_skewed"]
+
+
+def build_models(idx, test):
+    from test_gwf_ifmod_idomain02 import build_models as build
+
+    sim, dummy = build(idx, test)
+    return sim, dummy
+
+
+def check_output(idx, test):
+    from test_gwf_ifmod_idomain02 import check_output as check
+
+    check(idx, test)
+
+
+@pytest.mark.parallel
+@pytest.mark.developmode
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        compare=None,
+        parallel=True,
+        ncpus=2,
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -29,4 +29,7 @@ description = "Added interbed-compaction-pct observation to the CSUB package."
 [[items]]
 section = "fixes"
 description = "The mf6io.pdf guide for the SFE Package lists the availability of the STRMBD-COND observation type.  However, the SFE Package did not actually support this observation type and if listed would cause the program to exit with error message.  Functionality has been added to SFE for writing the amount of streambed conductive heat exchange to the CSV output file that contains the user-specified observations."
+
+[[items]]
+section = "fixes"
 description = "Fixed a variable overflow in the MPI communication for parallel simulations that could cause a memory exception when running a parallel simulation with truly large subdomains (~20M nodes or more)."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -29,3 +29,4 @@ description = "Added interbed-compaction-pct observation to the CSUB package."
 [[items]]
 section = "fixes"
 description = "The mf6io.pdf guide for the SFE Package lists the availability of the STRMBD-COND observation type.  However, the SFE Package did not actually support this observation type and if listed would cause the program to exit with error message.  Functionality has been added to SFE for writing the amount of streambed conductive heat exchange to the CSV output file that contains the user-specified observations."
+description = "Fixed a variable overflow in the MPI communication for parallel simulations that could cause a memory exception when running a parallel simulation with truly large subdomains (~20M nodes or more)."

--- a/src/Distributed/MpiRouter.f90
+++ b/src/Distributed/MpiRouter.f90
@@ -297,6 +297,7 @@ contains
         write (this%imon, '(4x,a,i0)') "receiving from process: ", rnk
       end if
 
+      ! call extended type size function (*_x) to avoid overflow for large submodels
       call MPI_Type_size_x(body_rcv_t(i), msg_size, ierr)
       if (msg_size > 0) then
         call MPI_Irecv(MPI_BOTTOM, 1, body_rcv_t(i), rnk, stage, &
@@ -316,6 +317,7 @@ contains
         write (this%imon, '(4x,a,i0)') "sending to process: ", rnk
       end if
 
+      ! call extended type size function (*_x) to avoid overflow for large submodels
       call MPI_Type_size_x(body_snd_t(i), msg_size, ierr)
       if (msg_size > 0) then
         call MPI_Isend(MPI_Bottom, 1, body_snd_t(i), rnk, stage, &

--- a/src/Distributed/MpiRouter.f90
+++ b/src/Distributed/MpiRouter.f90
@@ -242,7 +242,8 @@ contains
     ! local
     integer(I4B) :: i
     integer(I4B) :: rnk
-    integer :: ierr, msg_size
+    integer :: ierr
+    integer(kind=MPI_COUNT_KIND) :: msg_size !< need a longer int here, msg size can be > 2^31
     logical(LGP) :: from_cache
     ! mpi handles
     integer, dimension(:), allocatable :: rcv_req
@@ -296,7 +297,7 @@ contains
         write (this%imon, '(4x,a,i0)') "receiving from process: ", rnk
       end if
 
-      call MPI_Type_size(body_rcv_t(i), msg_size, ierr)
+      call MPI_Type_size_x(body_rcv_t(i), msg_size, ierr)
       if (msg_size > 0) then
         call MPI_Irecv(MPI_BOTTOM, 1, body_rcv_t(i), rnk, stage, &
                        this%mpi_world%comm, rcv_req(i), ierr)
@@ -315,7 +316,7 @@ contains
         write (this%imon, '(4x,a,i0)') "sending to process: ", rnk
       end if
 
-      call MPI_Type_size(body_snd_t(i), msg_size, ierr)
+      call MPI_Type_size_x(body_snd_t(i), msg_size, ierr)
       if (msg_size > 0) then
         call MPI_Isend(MPI_Bottom, 1, body_snd_t(i), rnk, stage, &
                        this%mpi_world%comm, snd_req(i), ierr)

--- a/src/Distributed/VirtualBase.f90
+++ b/src/Distributed/VirtualBase.f90
@@ -57,7 +57,7 @@ module VirtualBaseModule
   end type
 
   type, public, extends(VirtualDataType) :: VirtualIntType
-    integer(I4B), private, pointer :: intsclr
+    integer(I4B), private, pointer :: intsclr => null()
   contains
     procedure :: vm_allocate => vm_allocate_int
     procedure :: vm_deallocate => vm_deallocate_int
@@ -65,7 +65,7 @@ module VirtualBaseModule
   end type
 
   type, public, extends(VirtualDataType) :: VirtualInt1dType
-    integer(I4B), dimension(:), pointer, contiguous :: int1d
+    integer(I4B), dimension(:), pointer, contiguous :: int1d => null()
   contains
     procedure :: vm_allocate => vm_allocate_int1d
     procedure :: vm_deallocate => vm_deallocate_int1d
@@ -74,7 +74,7 @@ module VirtualBaseModule
   end type
 
   type, public, extends(VirtualDataType) :: VirtualDblType
-    real(DP), private, pointer :: dblsclr
+    real(DP), private, pointer :: dblsclr => null()
   contains
     procedure :: vm_allocate => vm_allocate_dbl
     procedure :: vm_deallocate => vm_deallocate_dbl
@@ -82,7 +82,7 @@ module VirtualBaseModule
   end type
 
   type, public, extends(VirtualDataType) :: VirtualDbl1dType
-    real(DP), dimension(:), pointer, contiguous :: dbl1d
+    real(DP), dimension(:), pointer, contiguous :: dbl1d => null()
   contains
     procedure :: vm_allocate => vm_allocate_dbl1d
     procedure :: vm_deallocate => vm_deallocate_dbl1d
@@ -91,7 +91,7 @@ module VirtualBaseModule
   end type
 
   type, public, extends(VirtualDataType) :: VirtualDbl2dType
-    real(DP), dimension(:, :), pointer, contiguous :: dbl2d
+    real(DP), dimension(:, :), pointer, contiguous :: dbl2d => null()
   contains
     procedure :: vm_allocate => vm_allocate_dbl2D
     procedure :: vm_deallocate => vm_deallocate_dbl2D


### PR DESCRIPTION
This can occur for truly large models, think  ~50M nodes or more.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.tex](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).