### PR TITLE
chore(gwf-sfr): nit-linting (the linting form of nit-picking)

### DIFF
--- a/src/Model/GroundWaterFlow/gwf-sfr.f90
+++ b/src/Model/GroundWaterFlow/gwf-sfr.f90
@@ -288,14 +288,13 @@ module SfrModule
 contains
 
   !> @ brief Create a new package object
-    !!
-    !!  Create a new SFR Package object
-    !!
+  !!
+  !!  Create a new SFR Package object
   !<
   subroutine sfr_create(packobj, id, ibcnum, inunit, iout, namemodel, pakname)
     ! -- modules
     use MemoryHelperModule, only: create_mem_path
-    ! -- dummy variables
+    ! -- dummy
     class(BndType), pointer :: packobj !< pointer to default package type
     integer(I4B), intent(in) :: id !< package id
     integer(I4B), intent(in) :: ibcnum !< boundary condition number
@@ -303,7 +302,7 @@ contains
     integer(I4B), intent(in) :: iout !< unit number of model listing file
     character(len=*), intent(in) :: namemodel !< model name
     character(len=*), intent(in) :: pakname !< package name
-    ! -- local variables
+    ! -- local
     type(SfrType), pointer :: sfrobj
     !
     ! -- allocate the object and assign values to object variables
@@ -331,16 +330,15 @@ contains
   end subroutine sfr_create
 
   !> @ brief Allocate scalars
-    !!
-    !! Allocate and initialize scalars for the SFR package. The base model
-    !! allocate scalars method is also called.
-    !!
+  !!
+  !! Allocate and initialize scalars for the SFR package. The base model
+  !! allocate scalars method is also called.
   !<
   subroutine sfr_allocate_scalars(this)
     ! -- modules
     use MemoryManagerModule, only: mem_allocate, mem_setptr
     use MemoryHelperModule, only: create_mem_path
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
     !
     ! -- call standard BndType allocate scalars
@@ -402,16 +400,15 @@ contains
   end subroutine sfr_allocate_scalars
 
   !> @ brief Allocate arrays
-    !!
-    !! Allocate and initialize array for the SFR package.
-    !!
+  !!
+  !! Allocate and initialize array for the SFR package.
   !<
   subroutine sfr_allocate_arrays(this)
     ! -- modules
     use MemoryManagerModule, only: mem_allocate
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i
     integer(I4B) :: j
     !
@@ -611,14 +608,13 @@ contains
   end subroutine sfr_allocate_arrays
 
   !> @ brief Read dimensions for package
-    !!
-    !!  Read dimensions for the SFR package.
-    !!
+  !!
+  !!  Read dimensions for the SFR package.
   !<
   subroutine sfr_read_dimensions(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     character(len=LINELENGTH) :: keyword
     integer(I4B) :: ierr
     logical(LGP) :: isfound
@@ -700,19 +696,18 @@ contains
   end subroutine sfr_read_dimensions
 
   !> @ brief Read additional options for package
-    !!
-    !!  Read additional options for SFR package.
-    !!
+  !!
+  !!  Read additional options for SFR package.
   !<
   subroutine sfr_options(this, option, found)
     ! -- modules
     use OpenSpecModule, only: access, form
     use InputOutputModule, only: getunit, assign_iounit, openfile
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
     character(len=*), intent(inout) :: option !< option keyword string
     logical(LGP), intent(inout) :: found !< boolean indicating if option found
-    ! -- local variables
+    ! -- local
     real(DP) :: r
     character(len=MAXCHARLEN) :: fname
     character(len=MAXCHARLEN) :: keyword
@@ -865,14 +860,13 @@ contains
   end subroutine sfr_options
 
   !> @ brief Allocate and read method for package
-    !!
-    !!  Method to read and prepare period data for the SFR package.
-    !!
+  !!
+  !!  Method to read and prepare period data for the SFR package.
   !<
   subroutine sfr_ar(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: n
     integer(I4B) :: ierr
     !
@@ -933,16 +927,15 @@ contains
   end subroutine sfr_ar
 
   !> @ brief Read packagedata for the package
-    !!
-    !!  Method to read packagedata for each reach for the SFR package.
-    !!
+  !!
+  !!  Method to read packagedata for each reach for the SFR package.
   !<
   subroutine sfr_read_packagedata(this)
     ! -- modules
     use TimeSeriesManagerModule, only: read_value_or_time_series_adv
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     character(len=LINELENGTH) :: text
     character(len=LINELENGTH) :: cellid
     character(len=10) :: cnum
@@ -1184,17 +1177,16 @@ contains
   end subroutine sfr_read_packagedata
 
   !> @ brief Read crosssection block for the package
-    !!
-    !!  Method to read crosssection data for the SFR package.
-    !!
+  !!
+  !!  Method to read crosssection data for the SFR package.
   !<
   subroutine sfr_read_crossection(this)
     ! -- modules
     use MemoryManagerModule, only: mem_reallocate
     use sfrCrossSectionManager, only: cross_section_cr, SfrCrossSection
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     character(len=LINELENGTH) :: keyword
     character(len=LINELENGTH) :: line
     logical(LGP) :: isfound
@@ -1323,17 +1315,16 @@ contains
   end subroutine sfr_read_crossection
 
   !> @ brief Read connectiondata for the package
-    !!
-    !!  Method to read connectiondata for each reach for the SFR package.
-    !!
+  !!
+  !!  Method to read connectiondata for each reach for the SFR package.
   !<
   subroutine sfr_read_connectiondata(this)
     ! -- modules
     use MemoryManagerModule, only: mem_reallocate
     use SparseModule, only: sparsematrix
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     character(len=LINELENGTH) :: line
     logical(LGP) :: isfound
     logical(LGP) :: endOfBlock
@@ -1601,16 +1592,15 @@ contains
   end subroutine sfr_read_connectiondata
 
   !> @ brief Read diversions for the package
-    !!
-    !!  Method to read diversions for the SFR package.
-    !!
+  !!
+  !!  Method to read diversions for the SFR package.
   !<
   subroutine sfr_read_diversions(this)
     ! -- modules
     use MemoryManagerModule, only: mem_reallocate
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     character(len=10) :: cnum
     character(len=10) :: cval
     integer(I4B) :: j
@@ -1803,14 +1793,13 @@ contains
   !> @ brief Read initialstages data for the package
   !!
   !!  Method to read initialstages data for each reach for the SFR package.
-  !!
   !<
   subroutine sfr_read_initial_stages(this)
     ! -- modules
     use TimeSeriesManagerModule, only: read_value_or_time_series_adv
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: n
     integer(I4B) :: ierr
     logical(LGP) :: isfound
@@ -1900,18 +1889,17 @@ contains
   end subroutine sfr_read_initial_stages
 
   !> @ brief Read and prepare period data for package
-    !!
-    !!  Method to read and prepare period data for the SFR package.
-    !!
+  !!
+  !!  Method to read and prepare period data for the SFR package.
   !<
   subroutine sfr_rp(this)
     ! -- modules
     use TdisModule, only: kper, nper
     use MemoryManagerModule, only: mem_reallocate
     use sfrCrossSectionManager, only: cross_section_cr, SfrCrossSection
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     character(len=LINELENGTH) :: title
     character(len=LINELENGTH) :: line
     character(len=LINELENGTH) :: crossfile
@@ -2082,17 +2070,16 @@ contains
   end subroutine sfr_rp
 
   !> @ brief Advance the package
-    !!
-    !!  Advance data in the SFR package. The method sets advances
-    !!  time series, time array series, and observation data.
-    !!
+  !!
+  !!  Advance data in the SFR package. The method sets advances
+  !!  time series, time array series, and observation data.
   !<
   subroutine sfr_ad(this)
     ! -- modules
     use TimeSeriesManagerModule, only: var_timeseries
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: n
     integer(I4B) :: iaux
 
@@ -2151,15 +2138,14 @@ contains
   end subroutine sfr_ad
 
   !> @ brief Formulate the package hcof and rhs terms.
-    !!
-    !!  Formulate the hcof and rhs terms for the WEL package that will be
-    !!  added to the coefficient matrix and right-hand side vector.
-    !!
+  !!
+  !!  Formulate the hcof and rhs terms for the WEL package that will be
+  !!  added to the coefficient matrix and right-hand side vector.
   !<
   subroutine sfr_cf(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: n
     integer(I4B) :: igwfnode
     !
@@ -2180,19 +2166,18 @@ contains
   end subroutine sfr_cf
 
   !> @ brief Copy hcof and rhs terms into solution.
-    !!
-    !!  Add the hcof and rhs terms for the SFR package to the
-    !!  coefficient matrix and right-hand side vector.
-    !!
+  !!
+  !!  Add the hcof and rhs terms for the SFR package to the
+  !!  coefficient matrix and right-hand side vector.
   !<
   subroutine sfr_fc(this, rhs, ia, idxglo, matrix_sln)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     real(DP), dimension(:), intent(inout) :: rhs !< right-hand side vector for model
     integer(I4B), dimension(:), intent(in) :: ia !< solution CRS row pointers
     integer(I4B), dimension(:), intent(in) :: idxglo !< mapping vector for model (local) to solution (global)
     class(MatrixBaseType), pointer :: matrix_sln !< solution coefficient matrix
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i
     integer(I4B) :: j
     integer(I4B) :: n
@@ -2281,19 +2266,18 @@ contains
   end subroutine sfr_fc
 
   !> @ brief Add Newton-Raphson terms for package into solution.
-    !!
-    !!  Calculate and add the Newton-Raphson terms for the SFR package to the
-    !!  coefficient matrix and right-hand side vector.
-    !!
+  !!
+  !!  Calculate and add the Newton-Raphson terms for the SFR package to the
+  !!  coefficient matrix and right-hand side vector.
   !<
   subroutine sfr_fn(this, rhs, ia, idxglo, matrix_sln)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     real(DP), dimension(:), intent(inout) :: rhs !< right-hand side vector for model
     integer(I4B), dimension(:), intent(in) :: ia !< solution CRS row pointers
     integer(I4B), dimension(:), intent(in) :: idxglo !< mapping vector for model (local) to solution (global)
     class(MatrixBaseType), pointer :: matrix_sln !< solution coefficient matrix
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i
     integer(I4B) :: j
     integer(I4B) :: n
@@ -2332,15 +2316,14 @@ contains
   end subroutine sfr_fn
 
   !> @ brief Convergence check for package.
-    !!
-    !!  Perform additional convergence checks on the flow between the SFR package
-    !!  and the model it is attached to.
-    !!
+  !!
+  !!  Perform additional convergence checks on the flow between the SFR package
+  !!  and the model it is attached to.
   !<
   subroutine sfr_cc(this, innertot, kiter, iend, icnvgmod, cpak, ipak, dpak)
     ! -- modules
     use TdisModule, only: totim, kstp, kper, delt
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
     integer(I4B), intent(in) :: innertot !< total number of inner iterations
     integer(I4B), intent(in) :: kiter !< Picard iteration number
@@ -2349,7 +2332,7 @@ contains
     character(len=LENPAKLOC), intent(inout) :: cpak !< string for user node
     integer(I4B), intent(inout) :: ipak !< location of the maximum dependent variable change
     real(DP), intent(inout) :: dpak !< maximum dependent variable change
-    ! -- local variables
+    ! -- local
     character(len=LENPAKLOC) :: cloc
     character(len=LINELENGTH) :: tag
     integer(I4B) :: icheck
@@ -2535,19 +2518,18 @@ contains
   end subroutine sfr_cc
 
   !> @ brief Calculate package flows.
-    !!
-    !!  Calculate the flow between connected SFR package control volumes.
-    !!
+  !!
+  !!  Calculate the flow between connected SFR package control volumes.
   !<
   subroutine sfr_cq(this, x, flowja, iadv)
     ! -- modules
     use BudgetModule, only: BudgetType
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
     real(DP), dimension(:), intent(in) :: x !< current dependent-variable value
     real(DP), dimension(:), contiguous, intent(inout) :: flowja !< flow between two connected control volumes
     integer(I4B), optional, intent(in) :: iadv !< flag that indicates if this is an advance package
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i
     real(DP) :: qext
     ! -- for budget
@@ -2613,18 +2595,17 @@ contains
   end subroutine sfr_cq
 
   !> @ brief Output package flow terms.
-    !!
-    !!  Output SFR package flow terms.
-    !!
+  !!
+  !!  Output SFR package flow terms.
   !<
   subroutine sfr_ot_package_flows(this, icbcfl, ibudfl)
     ! -- modules
     use TdisModule, only: kstp, kper, delt, pertim, totim
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: icbcfl !< flag and unit number for cell-by-cell output
     integer(I4B), intent(in) :: ibudfl !< flag indication if cell-by-cell data should be saved
-    ! -- local variables
+    ! -- local
     integer(I4B) :: ibinun
     character(len=20), dimension(:), allocatable :: cellidstr
     integer(I4B) :: n
@@ -2667,19 +2648,18 @@ contains
   end subroutine sfr_ot_package_flows
 
   !> @ brief Output package dependent-variable terms.
-    !!
-    !!  Output SFR boundary package dependent-variable terms.
-    !!
+  !!
+  !!  Output SFR boundary package dependent-variable terms.
   !<
   subroutine sfr_ot_dv(this, idvsave, idvprint)
     ! -- modules
     use TdisModule, only: kstp, kper, pertim, totim
     use InputOutputModule, only: ulasav
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: idvsave !< flag and unit number for dependent-variable output
     integer(I4B), intent(in) :: idvprint !< flag indicating if dependent-variable should be written to the model listing file
-    ! -- local variables
+    ! -- local
     character(len=20) :: cellid
     integer(I4B) :: ibinun
     integer(I4B) :: n
@@ -2780,9 +2760,8 @@ contains
   end subroutine sfr_ot_dv
 
   !> @ brief Output advanced package budget summary.
-    !!
-    !!  Output SFR package budget summary.
-    !!
+  !!
+  !!  Output SFR package budget summary.
   !<
   subroutine sfr_ot_bdsummary(this, kstp, kper, iout, ibudfl)
     ! -- module
@@ -2798,14 +2777,13 @@ contains
   end subroutine sfr_ot_bdsummary
 
   !> @ brief Deallocate package memory
-    !!
-    !!  Deallocate SFR package scalars and arrays.
-    !!
+  !!
+  !!  Deallocate SFR package scalars and arrays.
   !<
   subroutine sfr_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     !
     ! -- deallocate arrays
@@ -2937,13 +2915,12 @@ contains
   end subroutine sfr_da
 
   !> @ brief Define the list label for the package
-    !!
-    !!  Method defined the list label for the SFR package. The list label is
-    !!  the heading that is written to iout when PRINT_INPUT option is used.
-    !!
+  !!
+  !!  Method defined the list label for the SFR package. The list label is
+  !!  the heading that is written to iout when PRINT_INPUT option is used.
   !<
   subroutine define_listlabel(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
     !
     ! -- create the header list label
@@ -2968,15 +2945,14 @@ contains
   ! -- Procedures related to observations (type-bound)
 
   !> @brief Determine if observations are supported.
-    !!
-    !! Function to determine if observations are supported by the SFR package.
-    !! Observations are supported by the SFR package.
-    !!
-    !! @return  sfr_obs_supported       boolean indicating if observations are supported
-    !!
+  !!
+  !! Function to determine if observations are supported by the SFR package.
+  !! Observations are supported by the SFR package.
+  !!
+  !! @return  sfr_obs_supported       boolean indicating if observations are supported
   !<
   logical function sfr_obs_supported(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     !
     ! -- set boolean
@@ -2984,14 +2960,13 @@ contains
   end function sfr_obs_supported
 
   !> @brief Define the observation types available in the package
-    !!
-    !! Method to define the observation types available in the SFR package.
-    !!
+  !!
+  !! Method to define the observation types available in the SFR package.
   !<
   subroutine sfr_df_obs(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: indx
     !
     ! -- Store obs type and assign procedure pointer
@@ -3081,14 +3056,13 @@ contains
   end subroutine sfr_df_obs
 
   !> @brief Save observations for the package
-    !!
-    !! Method to save simulated values for the SFR package.
-    !!
+  !!
+  !! Method to save simulated values for the SFR package.
   !<
   subroutine sfr_bd_obs(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i
     integer(I4B) :: j
     integer(I4B) :: n
@@ -3174,16 +3148,15 @@ contains
   end subroutine sfr_bd_obs
 
   !> @brief Read and prepare observations for a package
-    !!
-    !! Method to read and prepare observations for a SFR package.
-    !!
+  !!
+  !! Method to read and prepare observations for a SFR package.
   !<
   subroutine sfr_rp_obs(this)
     ! -- modules
     use TdisModule, only: kper
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i
     integer(I4B) :: j
     integer(I4B) :: nn1
@@ -3285,17 +3258,16 @@ contains
   ! -- Procedures related to observations (NOT type-bound)
 
   !> @brief Process observation IDs for a package
-    !!
-    !! Method to process observation ID strings for a SFR package.
-    !!
+  !!
+  !! Method to process observation ID strings for a SFR package.
   !<
   subroutine sfr_process_obsID(obsrv, dis, inunitobs, iout)
-    ! -- dummy variables
+    ! -- dummy
     type(ObserveType), intent(inout) :: obsrv !< Observation object
     class(DisBaseType), intent(in) :: dis !< Discretization object
     integer(I4B), intent(in) :: inunitobs !< file unit number for the package observation file
     integer(I4B), intent(in) :: iout !< model listing file unit number
-    ! -- local variables
+    ! -- local
     integer(I4B) :: nn1
     integer(I4B) :: icol
     integer(I4B) :: istart
@@ -3326,19 +3298,18 @@ contains
   !
 
   !> @brief Set period data
-    !!
-    !! Method to read and set period data for a SFR package reach.
-    !!
+  !!
+  !! Method to read and set period data for a SFR package reach.
   !<
   subroutine sfr_set_stressperiod(this, n, ichkustrm, crossfile)
     ! -- modules
     use TimeSeriesManagerModule, only: read_value_or_time_series_adv
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     integer(I4B), intent(inout) :: ichkustrm !< flag indicating if upstream fraction data specified
     character(len=LINELENGTH), intent(inout) :: crossfile !< cross-section file name
-    ! -- local variables
+    ! -- local
     character(len=10) :: cnum
     character(len=LINELENGTH) :: text
     character(len=LINELENGTH) :: caux
@@ -3522,19 +3493,18 @@ contains
   end subroutine sfr_set_stressperiod
 
   !> @brief Solve reach continuity equation
-    !!
-    !! Method to solve the continuity equation for a SFR package reach.
-    !!
+  !!
+  !! Method to solve the continuity equation for a SFR package reach.
   !<
   subroutine sfr_solve(this, n, h, hcof, rhs, update)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: h !< groundwater head in cell connected to reach
     real(DP), intent(inout) :: hcof !< coefficient term added to the diagonal
     real(DP), intent(inout) :: rhs !< right-hand side term
     logical(LGP), intent(in), optional :: update !< boolean indicating if the reach depth and stage variables should be updated to current iterate
-    ! -- local variables
+    ! -- local
     logical(LGP) :: lupdate
     integer(I4B) :: i
     integer(I4B) :: ii
@@ -3700,18 +3670,17 @@ contains
   end subroutine sfr_solve
 
   !> @brief Update flow terms
-    !!
-    !! Method to update downstream flow and groundwater leakage terms for
-    !! a SFR package reach.
-    !!
+  !!
+  !! Method to update downstream flow and groundwater leakage terms for
+  !! a SFR package reach.
   !<
   subroutine sfr_update_flows(this, n, qd, qgwf)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(inout) :: qd !< downstream reach flow
     real(DP), intent(in) :: qgwf !< groundwater leakage for reach
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i
     integer(I4B) :: n2
     integer(I4B) :: idiv
@@ -3771,13 +3740,12 @@ contains
   end subroutine sfr_update_flows
 
   !> @brief Adjust runoff and evaporation
-    !!
-    !! Method to adjust runoff and evaporation for a SFR package reach
-    !! based on the total reach flow.
-    !!
+  !!
+  !! Method to adjust runoff and evaporation for a SFR package reach
+  !! based on the total reach flow.
   !<
   subroutine sfr_adjust_ro_ev(this, qc, qu, qi, qr, qro, qe, qfrommvr)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     real(DP), intent(inout) :: qc !< total reach volumetric flow
     real(DP), intent(in) :: qu !< upstream reach volumetric flow
@@ -3786,7 +3754,7 @@ contains
     real(DP), intent(inout) :: qro !< reach volumetric runoff
     real(DP), intent(inout) :: qe !< reach volumetric evaporation
     real(DP), intent(in) :: qfrommvr !< reach volumetric flow from mover
-    ! -- local variables
+    ! -- local
     real(DP) :: qt
     !
     ! -- adjust runoff or evaporation if sum of sources is negative
@@ -3813,19 +3781,18 @@ contains
   end subroutine sfr_adjust_ro_ev
 
   !> @brief Calculate downstream flow term
-    !!
-    !! Method to calculate downstream flow for a SFR package reach.
-    !!
+  !!
+  !! Method to calculate downstream flow for a SFR package reach.
   !<
   subroutine sfr_calc_qd(this, n, depth, hgwf, qgwf, qd)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: depth !< reach depth
     real(DP), intent(in) :: hgwf !< groundwater head in connected GWF cell
     real(DP), intent(inout) :: qgwf !< groundwater leakage for reach
     real(DP), intent(inout) :: qd !< residual
-    ! -- local variables
+    ! -- local
     real(DP) :: qsrc
     !
     ! -- initialize residual
@@ -3846,18 +3813,17 @@ contains
   end subroutine sfr_calc_qd
 
   !> @brief Calculate sum of sources
-    !!
-    !! Method to calculate the sum of sources for reach, excluding
-    !! reach leakage, for a SFR package reach.
-    !!
+  !!
+  !! Method to calculate the sum of sources for reach, excluding
+  !! reach leakage, for a SFR package reach.
   !<
   subroutine sfr_calc_qsource(this, n, depth, qsrc)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: depth !< reach depth
     real(DP), intent(inout) :: qsrc !< sum of sources for reach
-    ! -- local variables
+    ! -- local
     real(DP) :: qu
     real(DP) :: qi
     real(DP) :: qr
@@ -3895,18 +3861,17 @@ contains
   end subroutine sfr_calc_qsource
 
   !> @brief Calculate streamflow
-    !!
-    !! Method to calculate the streamflow using Manning's equation for a
-    !! SFR package reach.
-    !!
+  !!
+  !! Method to calculate the streamflow using Manning's equation for a
+  !! SFR package reach.
   !<
   subroutine sfr_calc_qman(this, n, depth, qman)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: depth !< reach depth
     real(DP), intent(inout) :: qman !< streamflow
-    ! -- local variables
+    ! -- local
     integer(I4B) :: npts
     integer(I4B) :: i0
     integer(I4B) :: i1
@@ -3965,14 +3930,13 @@ contains
   end subroutine sfr_calc_qman
 
   !> @brief Calculate reach-aquifer exchange
-    !!
-    !! Method to calculate the reach-aquifer exchange for a SFR package reach.
-    !! The reach-aquifer exchange is relative to the reach. Calculated flow
-    !! is positive if flow is from the aquifer to the reach.
-    !!
+  !!
+  !! Method to calculate the reach-aquifer exchange for a SFR package reach.
+  !! The reach-aquifer exchange is relative to the reach. Calculated flow
+  !! is positive if flow is from the aquifer to the reach.
   !<
   subroutine sfr_calc_qgwf(this, n, depth, hgwf, qgwf, gwfhcof, gwfrhs)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: depth !< reach depth
@@ -3980,7 +3944,7 @@ contains
     real(DP), intent(inout) :: qgwf !< reach-aquifer exchange
     real(DP), intent(inout), optional :: gwfhcof !< diagonal coefficient term for reach
     real(DP), intent(inout), optional :: gwfrhs !< right-hand side term for reach
-    ! -- local variables
+    ! -- local
     integer(I4B) :: node
     real(DP) :: tp
     real(DP) :: bt
@@ -4034,18 +3998,17 @@ contains
   end subroutine sfr_calc_qgwf
 
   !> @brief Determine if a reach is connected to a gwf cell
-    !!
-    !! Function to determine if a reach is connected to a gwf cell. If connected,
-    !! the return value is 1. Otherwise, the return value is 0.
-    !!
+  !!
+  !! Function to determine if a reach is connected to a gwf cell. If connected,
+  !! the return value is 1. Otherwise, the return value is 0.
   !<
   function sfr_gwf_conn(this, n)
     ! -- return variable
     integer(I4B) :: sfr_gwf_conn !< flag indicating if reach is connected to a gwf cell
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
-    ! -- local variables
+    ! -- local
     integer(I4B) :: node
 
     sfr_gwf_conn = 0
@@ -4056,19 +4019,18 @@ contains
   end function sfr_gwf_conn
 
   !> @brief Calculate reach-aquifer conductance
-    !!
-    !! Method to calculate the reach-aquifer conductance for a SFR package reach.
-    !!
+  !!
+  !! Method to calculate the reach-aquifer conductance for a SFR package reach.
   !<
   subroutine sfr_calc_cond(this, n, depth, cond, hsfr, h_temp)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: depth !< reach depth
     real(DP), intent(inout) :: cond !< reach-aquifer conductance
     real(DP), intent(in), optional :: hsfr !< stream stage
     real(DP), intent(in), optional :: h_temp !< head in gw cell
-    ! -- local variables
+    ! -- local
     integer(I4B) :: node
     real(DP) :: wp
     real(DP) :: vscratio
@@ -4101,21 +4063,20 @@ contains
   end subroutine sfr_calc_cond
 
   !> @brief Calculate diversion flow
-    !!
-    !! Method to calculate the diversion flow for a diversion connected
-    !! to a SFR package reach. The downstream flow for a reach is passed
-    !! in and adjusted by the diversion flow amount calculated in this
-    !! method.
-    !!
+  !!
+  !! Method to calculate the diversion flow for a diversion connected
+  !! to a SFR package reach. The downstream flow for a reach is passed
+  !! in and adjusted by the diversion flow amount calculated in this
+  !! method.
   !<
   subroutine sfr_calc_div(this, n, i, qd, qdiv)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     integer(I4B), intent(in) :: i !< diversion number in reach
     real(DP), intent(inout) :: qd !< remaining downstream flow for reach
     real(DP), intent(inout) :: qdiv !< diversion flow for diversion i
-    ! -- local variables
+    ! -- local
     character(len=10) :: cp
     integer(I4B) :: jpos
     integer(I4B) :: n2
@@ -4159,17 +4120,16 @@ contains
   end subroutine sfr_calc_div
 
   !> @brief Calculate the depth at the midpoint
-    !!
-    !! Method to calculate the depth at the midpoint of a reach.
-    !!
+  !!
+  !! Method to calculate the depth at the midpoint of a reach.
   !<
   subroutine sfr_calc_reach_depth(this, n, q1, d1)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: q1 !< streamflow
     real(DP), intent(inout) :: d1 !< stream depth at midpoint of reach
-    ! -- local variables
+    ! -- local
     real(DP) :: w
     real(DP) :: s
     real(DP) :: r
@@ -4194,18 +4154,17 @@ contains
   end subroutine sfr_calc_reach_depth
 
   !> @brief Calculate the depth at the midpoint of a irregular cross-section
-    !!
-    !! Method to calculate the depth at the midpoint of a reach with a
-    !! irregular cross-section using Newton-Raphson.
-    !!
+  !!
+  !! Method to calculate the depth at the midpoint of a reach with a
+  !! irregular cross-section using Newton-Raphson.
   !<
   subroutine sfr_calc_xs_depth(this, n, qrch, d)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: qrch !< streamflow
     real(DP), intent(inout) :: d !< stream depth at midpoint of reach
-    ! -- local variables
+    ! -- local
     integer(I4B) :: iter
     real(DP) :: perturbation
     real(DP) :: q0
@@ -4243,15 +4202,14 @@ contains
   end subroutine sfr_calc_xs_depth
 
   !> @brief Check unit conversion data
-    !!
-    !! Method to check unit conversion data for a SFR package. This method
-    !! also calculates unitconv that is used in the Manning's equation.
-    !!
+  !!
+  !! Method to check unit conversion data for a SFR package. This method
+  !! also calculates unitconv that is used in the Manning's equation.
   !<
   subroutine sfr_check_conversion(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     ! -- formats
     character(len=*), parameter :: fmtunitconv_error = &
       &"('SFR (',a,') UNIT_CONVERSION SPECIFIED VALUE (',g0,') AND', &
@@ -4280,14 +4238,13 @@ contains
   end subroutine sfr_check_conversion
 
   !> @brief Check storage weight
-    !!
-    !! Method to check the kinematic storage weight for a SFR package.
-    !! If the kinematic storage weight has not been set it is set to
-    !! the default value.
-    !!
+  !!
+  !! Method to check the kinematic storage weight for a SFR package.
+  !! If the kinematic storage weight has not been set it is set to
+  !! the default value.
   !<
   subroutine sfr_check_storage_weight(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     ! -- formats
     character(len=*), parameter :: fmtweight = &
@@ -4305,16 +4262,15 @@ contains
   end subroutine sfr_check_storage_weight
 
   !> @brief Check reach data
-    !!
-    !! Method to check specified data for a SFR package. This method
-    !! also creates the tables used to print input data, if this
-    !! option in enabled in the SFR package.
-    !!
+  !!
+  !! Method to check specified data for a SFR package. This method
+  !! also creates the tables used to print input data, if this
+  !! option in enabled in the SFR package.
   !<
   subroutine sfr_check_reaches(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     character(len=5) :: crch
     character(len=10) :: cval
     character(len=30) :: nodestr
@@ -4424,16 +4380,15 @@ contains
   end subroutine sfr_check_reaches
 
   !> @brief Check connection data
-    !!
-    !! Method to check connection data for a SFR package. This method
-    !! also creates the tables used to print input data, if this
-    !! option in enabled in the SFR package.
-    !!
+  !!
+  !! Method to check connection data for a SFR package. This method
+  !! also creates the tables used to print input data, if this
+  !! option in enabled in the SFR package.
   !<
   subroutine sfr_check_connections(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     logical(LGP) :: lreorder
     character(len=5) :: crch
     character(len=5) :: crch2
@@ -4702,16 +4657,15 @@ contains
   end subroutine sfr_check_connections
 
   !> @brief Check diversions data
-    !!
-    !! Method to check diversion data for a SFR package. This method
-    !! also creates the tables used to print input data, if this
-    !! option in enabled in the SFR package.
-    !!
+  !!
+  !! Method to check diversion data for a SFR package. This method
+  !! also creates the tables used to print input data, if this
+  !! option in enabled in the SFR package.
   !<
   subroutine sfr_check_diversions(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     character(len=LINELENGTH) :: title
     character(len=LINELENGTH) :: text
     character(len=5) :: crch
@@ -4809,12 +4763,11 @@ contains
   end subroutine sfr_check_diversions
 
   !> @brief Check initial stage data
-    !!
-    !! Method to check initial data for a SFR package and calculates
-    !! the initial upstream and downstream flows for the reach based
-    !! on the initial staalso creates the tables used to print input
-    !! data, if this option in enabled in the SFR package.
-    !!
+  !!
+  !! Method to check initial data for a SFR package and calculates
+  !! the initial upstream and downstream flows for the reach based
+  !! on the initial staalso creates the tables used to print input
+  !! data, if this option in enabled in the SFR package.
   !<
   subroutine sfr_check_initialstages(this)
     class(SfrType) :: this !< SfrType object
@@ -4866,16 +4819,15 @@ contains
   end subroutine sfr_check_initialstages
 
   !> @brief Check upstream fraction data
-    !!
-    !! Method to check upstream fraction data for a SFR package.
-    !! This method  also creates the tables used to print input data,
-    !! if this option in enabled in the SFR package.
-    !!
+  !!
+  !! Method to check upstream fraction data for a SFR package.
+  !! This method  also creates the tables used to print input data,
+  !! if this option in enabled in the SFR package.
   !<
   subroutine sfr_check_ustrf(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     character(len=LINELENGTH) :: title
     character(len=LINELENGTH) :: text
     logical(LGP) :: lcycle
@@ -5070,16 +5022,15 @@ contains
   end subroutine sfr_check_ustrf
 
   !> @brief Setup budget object for package
-    !!
-    !! Method to set up the budget object that stores all the sfr flows
-    !! The terms listed here must correspond in number and order to the ones
-    !! listed in the sfr_fill_budobj method.
-    !!
+  !!
+  !! Method to set up the budget object that stores all the sfr flows
+  !! The terms listed here must correspond in number and order to the ones
+  !! listed in the sfr_fill_budobj method.
   !<
   subroutine sfr_setup_budobj(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: nbudterm
     integer(I4B) :: i
     integer(I4B) :: n
@@ -5286,16 +5237,15 @@ contains
   end subroutine sfr_setup_budobj
 
   !> @brief Copy flow terms into budget object for package
-    !!
-    !! Method to copy flows into the budget object that stores all the sfr flows
-    !! The terms listed here must correspond in number and order to the ones
-    !! added in the sfr_setup_budobj method.
-    !!
+  !!
+  !! Method to copy flows into the budget object that stores all the sfr flows
+  !! The terms listed here must correspond in number and order to the ones
+  !! added in the sfr_setup_budobj method.
   !<
   subroutine sfr_fill_budobj(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: naux
     integer(I4B) :: i
     integer(I4B) :: n
@@ -5519,16 +5469,15 @@ contains
   end subroutine sfr_fill_budobj
 
   !> @brief Setup stage table object for package
-    !!
-    !! Method to set up the table object that is used to write the sfr
-    !! stage data. The terms listed here must correspond in number and
-    !! order to the ones written to the stage table in the sfr_ot method.
-    !!
+  !!
+  !! Method to set up the table object that is used to write the sfr
+  !! stage data. The terms listed here must correspond in number and
+  !! order to the ones written to the stage table in the sfr_ot method.
   !<
   subroutine sfr_setup_tableobj(this)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: nterms
     character(len=LINELENGTH) :: title
     character(len=LINELENGTH) :: text
@@ -5598,18 +5547,17 @@ contains
   ! -- reach geometry functions
 
   !> @brief Calculate wetted area
-    !!
-    !! Function to calculate the wetted area for a SFR package reach.
-    !!
+  !!
+  !! Function to calculate the wetted area for a SFR package reach.
   !<
   function calc_area_wet(this, n, depth)
     ! -- return variable
     real(DP) :: calc_area_wet !< wetted area
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: depth !< reach depth
-    ! -- local variables
+    ! -- local
     integer(I4B) :: npts
     integer(I4B) :: i0
     integer(I4B) :: i1
@@ -5627,18 +5575,17 @@ contains
   end function calc_area_wet
 
   !> @brief Calculate wetted perimeter
-    !!
-    !! Function to calculate the wetted perimeter for a SFR package reach.
-    !!
+  !!
+  !! Function to calculate the wetted perimeter for a SFR package reach.
   !<
   function calc_perimeter_wet(this, n, depth)
     ! -- return variable
     real(DP) :: calc_perimeter_wet !< wetted perimeter
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: depth !< reach depth
-    ! -- local variables
+    ! -- local
     integer(I4B) :: npts
     integer(I4B) :: i0
     integer(I4B) :: i1
@@ -5656,17 +5603,16 @@ contains
   end function calc_perimeter_wet
 
   !> @brief Calculate maximum surface area
-    !!
-    !! Function to calculate the maximum surface area for a SFR package reach.
-    !!
+  !!
+  !! Function to calculate the maximum surface area for a SFR package reach.
   !<
   function calc_surface_area(this, n)
     ! -- return variable
     real(DP) :: calc_surface_area !< surface area
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
-    ! -- local variables
+    ! -- local
     integer(I4B) :: npts
     integer(I4B) :: i0
     integer(I4B) :: i1
@@ -5685,18 +5631,17 @@ contains
   end function calc_surface_area
 
   !> @brief Calculate wetted surface area
-    !!
-    !! Function to calculate the wetted surface area for a SFR package reach.
-    !!
+  !!
+  !! Function to calculate the wetted surface area for a SFR package reach.
   !<
   function calc_surface_area_wet(this, n, depth)
     ! -- return variable
     real(DP) :: calc_surface_area_wet !< wetted surface area
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: depth !< reach depth
-    ! -- local variables
+    ! -- local
     real(DP) :: top_width
     !
     ! -- Calculate wetted surface area
@@ -5705,18 +5650,17 @@ contains
   end function calc_surface_area_wet
 
   !> @brief Calculate wetted top width
-    !!
-    !! Function to calculate the wetted top width for a SFR package reach.
-    !!
+  !!
+  !! Function to calculate the wetted top width for a SFR package reach.
   !<
   function calc_top_width_wet(this, n, depth)
     ! -- return variable
     real(DP) :: calc_top_width_wet !< wetted top width
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: depth !< reach depth
-    ! -- local variables
+    ! -- local
     integer(I4B) :: npts
     integer(I4B) :: i0
     integer(I4B) :: i1
@@ -5738,16 +5682,15 @@ contains
   end function calc_top_width_wet
 
   !> @brief Activate density terms
-    !!
-    !! Method to activate addition of density terms for a SFR package reach.
-    !!
+  !!
+  !! Method to activate addition of density terms for a SFR package reach.
   !<
   subroutine sfr_activate_density(this)
     ! -- modules
     use MemoryManagerModule, only: mem_reallocate
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i
     integer(I4B) :: j
     !
@@ -5765,17 +5708,16 @@ contains
   end subroutine sfr_activate_density
 
   !> @brief Activate viscosity terms
-    !!
-    !! Method to activate addition of viscosity terms for exchange
-    !! with groundwater along a SFR package reach.
-    !!
+  !!
+  !! Method to activate addition of viscosity terms for exchange
+  !! with groundwater along a SFR package reach.
   !<
   subroutine sfr_activate_viscosity(this)
     ! -- modules
     use MemoryManagerModule, only: mem_reallocate
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i
     integer(I4B) :: j
     !
@@ -5793,20 +5735,19 @@ contains
   end subroutine sfr_activate_viscosity
 
   !> @brief Calculate density terms
-    !!
-    !! Method to galculate groundwater-reach density exchange terms for a
-    !! SFR package reach.
-    !!
-    !! Member variable used here
-    !!   denseterms  : shape (3, MAXBOUND), filled by buoyancy package
-    !!                   col 1 is relative density of sfr (densesfr / denseref)
-    !!                   col 2 is relative density of gwf cell (densegwf / denseref)
-    !!                   col 3 is elevation of gwf cell
-    !!
+  !!
+  !! Method to galculate groundwater-reach density exchange terms for a
+  !! SFR package reach.
+  !!
+  !! Member variable used here
+  !!   denseterms  : shape (3, MAXBOUND), filled by buoyancy package
+  !!                   col 1 is relative density of sfr (densesfr / denseref)
+  !!                   col 2 is relative density of gwf cell (densegwf / denseref)
+  !!                   col 3 is elevation of gwf cell
   !<
   subroutine sfr_calculate_density_exchange(this, n, stage, head, cond, &
                                             bots, flow, gwfhcof, gwfrhs)
-    ! -- dummy variables
+    ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: stage !< reach stage
@@ -5816,7 +5757,7 @@ contains
     real(DP), intent(inout) :: flow !< calculated flow, updated here with density terms
     real(DP), intent(inout) :: gwfhcof !< GWF diagonal coefficient, updated here with density terms
     real(DP), intent(inout) :: gwfrhs !< GWF right-hand-side value, updated here with density terms
-    ! -- local variables
+    ! -- local
     real(DP) :: ss
     real(DP) :: hh
     real(DP) :: havg


### PR DESCRIPTION
Docstrings in SFR had a different indentation than the rest of the code

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted modified Fortran source files with `fprettify`