### PR TITLE
refactor(dfn2f90.py): accept 1+ dfn files or directories

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -102,7 +102,7 @@ get-exes = { cmd = "pytest -v --durations 0 get_exes.py", cwd = "autotest" }
 autotest = { cmd = "pytest -v -n auto --durations 0 --keep-failed .failed", cwd = "autotest" }
 
 # common developer tasks
-update-fortran-definitions = { cmd = "python dfn2f90.py", cwd = "utils/idmloader/scripts" }
+update-fortran-definitions = { cmd = "cat dfns.txt | xargs python scripts/dfn2f90.py", cwd = "utils/idmloader" }
 update-flopy = { cmd = "python update_flopy.py", cwd = "autotest" }
 build-makefiles = { cmd = "python build_makefiles.py", cwd = "distribution" }
 run-mf6ivar = { cmd = "python mf6ivar.py", cwd = "doc/mf6io/mf6ivar" }

--- a/utils/idmloader/dfns.txt
+++ b/utils/idmloader/dfns.txt
@@ -1,12 +1,5 @@
-# Add a new DFN parameter set to MF6
-# by adding a new entry to this list
-# ----------------------------------
-
-# simulation
 sim-nam.dfn
 sim-tdis.dfn
-
-# gwf model
 gwf-nam.dfn
 gwf-chd.dfn
 gwf-dis.dfn
@@ -23,8 +16,6 @@ gwf-rcha.dfn
 gwf-riv.dfn
 gwf-sto.dfn
 gwf-wel.dfn
-
-# gwt model
 gwt-nam.dfn
 gwt-dis.dfn
 gwt-disu.dfn
@@ -32,8 +23,6 @@ gwt-disv.dfn
 gwt-dsp.dfn
 gwt-cnc.dfn
 gwt-ic.dfn
-
-# gwe model
 gwe-nam.dfn
 gwe-ic.dfn
 gwe-ctp.dfn
@@ -41,8 +30,6 @@ gwe-cnd.dfn
 gwe-disv.dfn
 gwe-disu.dfn
 gwe-dis.dfn
-
-# swf model
 swf-nam.dfn
 swf-disv1d.dfn
 swf-dis2d.dfn
@@ -57,8 +44,6 @@ swf-pcp.dfn
 swf-evp.dfn
 swf-sto.dfn
 swf-zdg.dfn
-
-# chf model
 chf-nam.dfn
 chf-disv1d.dfn
 chf-cxs.dfn
@@ -71,8 +56,6 @@ chf-pcp.dfn
 chf-evp.dfn
 chf-sto.dfn
 chf-zdg.dfn
-
-# olf model
 olf-nam.dfn
 olf-dis2d.dfn
 olf-disv2d.dfn
@@ -85,14 +68,10 @@ olf-pcp.dfn
 olf-evp.dfn
 olf-sto.dfn
 olf-zdg.dfn
-
-# prt model
 prt-nam.dfn
 prt-dis.dfn
 prt-disv.dfn
 prt-mip.dfn
-
-# exchanges
 exg-chfgwf.dfn
 exg-gwfgwf.dfn
 exg-gwfgwt.dfn
@@ -101,7 +80,5 @@ exg-gwfgwe.dfn
 exg-gwegwe.dfn
 exg-gwfprt.dfn
 exg-olfgwf.dfn
-
-# utils
 utl-hpc.dfn
 utl-ncf.dfn

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -999,7 +999,7 @@ if __name__ == "__main__":
         dfn = [Path(dfn)]
     else:
         raise ValueError(f"Unexpected dfn type: {type(dfn)}")
-    
+
     # dfns might be dirs, expand to list of files
     exts = [
         "*.dfn",
@@ -1018,7 +1018,7 @@ if __name__ == "__main__":
             if len(p.parts) == 1:
                 p = DFN_PATH / p
             dfns.append(p)
-    
+
     pprint(dfns)
     assert all(p.is_file() for p in dfns)
 

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -5,8 +5,6 @@ from pathlib import Path
 from pprint import pprint
 from typing import Optional
 
-import yaml
-
 MF6_LENVARNAME = 16
 F90_LINELEN = 82
 PROJ_ROOT_PATH = Path(__file__).parents[3]
@@ -970,12 +968,10 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
-        "-d",
-        "--dfn",
-        required=False,
-        default=DEFAULT_DFNS_PATH,
-        help="Path to a DFN file, or to a text or YAML file listing DFN files "
-        "(one per line)",
+        "dfn",
+        nargs="*",
+        default=DFN_PATH,
+        help="Path to one or more DFN files or directories containing DFN files",
     )
     parser.add_argument(
         "-o",
@@ -993,27 +989,41 @@ if __name__ == "__main__":
         help="Whether to show verbose output",
     )
     args = parser.parse_args()
-    dfn = Path(args.dfn)
+    dfn = args.dfn
     outdir = Path(args.outdir) if args.outdir else Path.cwd()
     verbose = args.verbose
 
-    if dfn.suffix.lower() in [".txt"]:
-        dfns = open(dfn, "r").readlines()
-        dfns = [l.strip() for l in dfns]
-        dfns = [l for l in dfns if not l.startswith("#") and l.lower().endswith(".dfn")]
-        if dfn == DEFAULT_DFNS_PATH:
-            dfns = [DFN_PATH / p for p in dfns]
-    elif dfn.suffix.lower() in [".yml", ".yaml"]:
-        dfns = yaml.safe_load(open(dfn, "r"))
-    elif dfn.suffix.lower() in [".dfn"]:
-        dfns = [dfn]
-
-    assert all(p.is_file() for p in dfns), (
-        f"DFNs not found: {[p for p in dfns if not p.is_file()]}"
-    )
+    if isinstance(dfn, list):
+        dfn = [Path(p) for p in dfn]
+    elif isinstance(dfn, (str, Path)):
+        dfn = [Path(dfn)]
+    else:
+        raise ValueError(f"Unexpected dfn type: {type(dfn)}")
+    
+    # dfns might be dirs, expand to list of files
+    exts = [
+        "*.dfn",
+        # TODO support toml
+    ]
+    dfns = []
+    for p in dfn:
+        if p.is_dir():
+            for ext in exts:
+                dfns.extend(p.glob(ext))
+        else:
+            # if we only have a filename, assume
+            # it's in the default dfn directory.
+            # TODO remove when idm supports all dfns
+            # and we no longer have to specify files.
+            if len(p.parts) == 1:
+                p = DFN_PATH / p
+            dfns.append(p)
+    
+    pprint(dfns)
+    assert all(p.is_file() for p in dfns)
 
     if verbose:
-        print("Converting DFNs:")
+        print("Generating Fortran source files from DFNs:")
         pprint(dfns)
 
     dfn_d = {}


### PR DESCRIPTION
Instead of accepting a text file specifying DFN files &mdash; a temporary measure while IDM supports a subset of the full specification &mdash; just accept one or more path arguments, each of which can be a DFN file or a folder containing DFN files, and feed the `dfns.txt` file to this from the shell.

A prep step before code generation is switched to consume TOML DFNs, coming shortly.

**Note to model developers**: after this, the behavior of running `dfn2f90.py` directly with no arguments will change to include all DFNs by default. To get the old behavior (i.e. the subset of DFNs IDM supports), it will be necessary to use the pixi task or feed `dfns.txt` to the script with e.g. 

```shell
cat dfns.txt | xargs python ...
```