### PR TITLE
chore(gwf-maw): correct typos in maw dfn file

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwf-maw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-maw.dfn
@@ -370,7 +370,7 @@ tagged false
 in_record true
 reader urword
 longname well bottom
-description bottom elevation of the multi-aquifer well. If CONDEQN is SPECIFIED, THIEM, SKIN, or COMPOSITE, BOTTOM is set to the cell bottom in the lowermost GWF cell connection in cases where the specified well bottom is above the bottom of this GWF cell. If CONDEQN is MEAN, BOTTOM is set to the lowermost GWF cell connection screen bottom in cases where the specified well bottom is above this value. The bottom elevation defines the lowest well head that will be simulated when the NEWTON UNDER\_RELAXATION option is specified in the GWF model name file. The bottom elevation is also used to calculate volumetric storage in the well.
+description bottom elevation of the multi-aquifer well. If CONDEQN is SPECIFIED, THIEM, SKIN, or CUMULATIVE, BOTTOM is set to the cell bottom in the lowermost GWF cell connection in cases where the specified well bottom is above the bottom of this GWF cell. If CONDEQN is MEAN, BOTTOM is set to the lowermost GWF cell connection screen bottom in cases where the specified well bottom is above this value. The bottom elevation defines the lowest well head that will be simulated when the NEWTON UNDER\_RELAXATION option is specified in the GWF model name file. The bottom elevation is also used to calculate volumetric storage in the well.
 
 block packagedata
 name strt
@@ -475,7 +475,7 @@ tagged false
 in_record true
 reader urword
 longname screen top
-description value that defines the top elevation of the screen for the multi-aquifer well connection. If CONDEQN is SPECIFIED, THIEM, SKIN, or COMPOSITE, SCRN\_TOP can be any value and is set to the top of the cell. If CONDEQN is MEAN, SCRN\_TOP is set to the multi-aquifer well connection cell top if the specified value is greater than the cell top. The program will terminate with an error if the screen top is less than the screen bottom.
+description value that defines the top elevation of the screen for the multi-aquifer well connection. If CONDEQN is SPECIFIED, THIEM, SKIN, or CUMULATIVE, SCRN\_TOP can be any value and is set to the top of the cell. If CONDEQN is MEAN, SCRN\_TOP is set to the multi-aquifer well connection cell top if the specified value is greater than the cell top. The program will terminate with an error if the screen top is less than the screen bottom.
 
 block connectiondata
 name scrn_bot
@@ -485,7 +485,7 @@ tagged false
 in_record true
 reader urword
 longname screen bottom
-description value that defines the bottom elevation of the screen for the multi-aquifer well connection. If CONDEQN is SPECIFIED, THIEM, SKIN, or COMPOSITE, SCRN\_BOT can be any value and is set to the bottom of the cell. If CONDEQN is MEAN, SCRN\_BOT is set to the multi-aquifer well connection cell bottom if the specified value is less than the cell bottom. The program will terminate with an error if the screen bottom is greater than the screen top.
+description value that defines the bottom elevation of the screen for the multi-aquifer well connection. If CONDEQN is SPECIFIED, THIEM, SKIN, or CUMULATIVE, SCRN\_BOT can be any value and is set to the bottom of the cell. If CONDEQN is MEAN, SCRN\_BOT is set to the multi-aquifer well connection cell bottom if the specified value is less than the cell bottom. The program will terminate with an error if the screen bottom is greater than the screen top.
 
 block connectiondata
 name hk_skin


### PR DESCRIPTION
Looking in the MAW source code, it looks like MF6 is expecting the keyword `CUMULATIVE`, not `COMPOSITE`.  

![maw](https://github.com/user-attachments/assets/17e68b05-587e-49f7-881e-82743eb0e4cf)

Thanks for pointing this out @mkennard-aquaveo.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Addresses issue #2293 
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
