### PR TITLE
docs(prt): fix ref to removed option, restore dfns

### DIFF
--- a/doc/mf6io/mf6ivar/deprecations.py
+++ b/doc/mf6io/mf6ivar/deprecations.py
@@ -49,7 +49,7 @@ def create_deprecations_file(dfndir, mddir, verbose):
             s += "|:--------------|:-------|:-----------|:--------|\n"
             for file, option, deprecated, removed in deprecations:
                 s += (
-                    f"| {file.stem} | {option} | {deprecated} "
+                    f"| {file.stem} | {option} | {deprecated if deprecated else removed if removed else ''} "
                     f"| {removed if removed else ''} |\n"
                 )
             if len(s) > 0:

--- a/doc/mf6io/mf6ivar/dfn/prt-oc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-oc.dfn
@@ -191,6 +191,75 @@ optional true
 longname track usertime
 description keyword to indicate that particle tracking output is to be written at user-specified times, provided as double precision values in the TRACKTIMES block.
 
+block options
+name track_timesrecord
+type record track_times times
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+removed 6.6.1
+
+block options
+name track_times
+type keyword
+reader urword
+in_record true
+tagged true
+shape
+longname
+description keyword indicating tracking times will follow
+removed 6.6.1
+
+block options
+name times
+type double precision
+shape (unknown)
+reader urword
+in_record true
+tagged false
+repeating true
+longname tracking times
+description times to track, relative to the beginning of the simulation.
+removed 6.6.1
+
+block options
+name track_timesfilerecord
+type record track_timesfile timesfile
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+removed 6.6.1
+
+block options
+name track_timesfile
+type keyword
+reader urword
+in_record true
+tagged true
+shape
+longname
+description keyword indicating tracking times file name will follow
+removed 6.6.1
+
+block options
+name timesfile
+type string
+preserve_case true
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the tracking times file
+removed 6.6.1
+
 # --------------------- prt oc dimensions ------------------
 
 block dimensions

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -169,6 +169,75 @@ longname drape
 description is a text keyword to indicate that if a particle's release point is in a cell that happens to be inactive at release time, the particle is to be moved to the topmost active cell below it, if any. By default, a particle is not released into the simulation if its release point's cell is inactive at release time.
 
 block options
+name release_timesrecord
+type record release_times times
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+removed 6.6.1
+
+block options
+name release_times
+type keyword
+reader urword
+in_record true
+tagged true
+shape
+longname
+description keyword indicating release times will follow
+removed 6.6.1
+
+block options
+name times
+type double precision
+shape (unknown)
+reader urword
+in_record true
+tagged false
+repeating true
+longname release times
+description times to release, relative to the beginning of the simulation.  RELEASE\_TIMES and RELEASE\_TIMESFILE are mutually exclusive.
+removed 6.6.1
+
+block options
+name release_timesfilerecord
+type record release_timesfile timesfile
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+removed 6.6.1
+
+block options
+name release_timesfile
+type keyword
+reader urword
+in_record true
+tagged true
+shape
+longname
+description keyword indicating release times file name will follow
+removed 6.6.1
+
+block options
+name timesfile
+type string
+preserve_case true
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the release times file.  RELEASE\_TIMES and RELEASE\_TIMESFILE are mutually exclusive.
+removed 6.6.1
+
+block options
 name dry_tracking_method
 type string
 valid drop stop stay

--- a/doc/mf6io/prt/oc.tex
+++ b/doc/mf6io/prt/oc.tex
@@ -11,7 +11,7 @@ The PRT Model distinguishes a number of tracking events that can trigger writing
  
 The Output Control package provides keyword options that correspond to the various types of tracking events that can trigger output. The keywords are of the form TRACK\_\textit{event}, where \textit{event} indicates the type of event. If no tracking event keywords are provided, output is triggered by all types of tracking events. If any tracking event keywords are provided, only the selected types of events trigger output. This mechanism can be used to filter out events that are not of interest, thereby limiting the size of output files and reducing the runtime spent on writing output.
  
-For instance, to configure PRT output for an endpoint analysis, provide the TRACK\_RELEASE and TRACK\_TERMINATE keywords. To configure PRT output for a timeseries analysis, provide the TRACK\_USERTIME keyword as well as a tracking time selection via the TRACK\_TIMES or TRACK\_TIMESFILE keyword.
+For instance, to configure PRT output for an endpoint analysis, provide the TRACK\_RELEASE and TRACK\_TERMINATE keywords. To configure PRT output for a timeseries analysis, provide the TRACK\_USERTIME keyword as well as a tracking time selection via the TRACKTIMES block.
 
 \vspace{5mm}
 \subsubsection{Structure of Blocks}


### PR DESCRIPTION
We had a lingering reference to TRACK_TIMES and TRACK_TIMESFILE, fix it. And also, I'm not sure why I removed the options from the DFNs in https://github.com/MODFLOW-ORG/modflow6/commit/bf47ec6f26597ccff3d8f100efe5c00037fb711d, for deprecations/removals we conventionally leave the options in the DFN and just mark them as such. The automation will then put them in the deprecation section in the release notes.