### PR TITLE
docs: tweak release notes section header format

### DIFF
--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -152,7 +152,7 @@ MODFLOW~6 is tested with a large number of example problems, and new capabilitie
 
 % -------------------------------------------------
 \section{Release History}
-A list of all MODFLOW 6 releases is shown in table \ref{tab:releases}.  Changes introduced in previous releases are described in Appendix~\ref{app:A}.
+A list of all previous MODFLOW 6 releases is shown in table \ref{tab:releases}.  Changes introduced in previous releases are described in Appendix~\ref{app:A}.
 
 \begin{table}[h]
 \begin{center}

--- a/doc/ReleaseNotes/develop.tex.jinja
+++ b/doc/ReleaseNotes/develop.tex.jinja
@@ -1,12 +1,13 @@
 \subsection{Version mf(( version ))---(( date ))}
 
 ([ for section_key, section_items in items|groupby("section") ])
-\textbf{\underline{(( sections[section_key] ))}}
+\underline{(( sections[section_key] ))}
 
 ([ for subsection_key, subsection_items in section_items|groupby("subsection") ])
 ([ set subsection = subsections[subsection_key] ])
 ([ if subsection|length > 0 ])
-\underline{(( subsection ))}
+\\[12pt]
+\textbf{(( subsection ))}
 ([ endif ])
 
 \begin{itemize}

--- a/doc/ReleaseNotes/develop.tex.jinja
+++ b/doc/ReleaseNotes/develop.tex.jinja
@@ -1,13 +1,9 @@
-\subsection{Version mf(( version ))---(( date ))}
-
 ([ for section_key, section_items in items|groupby("section") ])
-\underline{(( sections[section_key] ))}
-
+\subsection{(( sections[section_key].title() ))}
 ([ for subsection_key, subsection_items in section_items|groupby("subsection") ])
 ([ set subsection = subsections[subsection_key] ])
 ([ if subsection|length > 0 ])
-\vspace{5mm}
-\textbf{(( subsection ))}
+\subsubsection{(( subsection.title() ))}
 ([ endif ])
 
 \begin{itemize}
@@ -15,6 +11,5 @@
 \item (( item.description ))
 ([ endfor ])
 \end{itemize}
-
 ([ endfor ])
 ([ endfor ])

--- a/doc/ReleaseNotes/develop.tex.jinja
+++ b/doc/ReleaseNotes/develop.tex.jinja
@@ -6,7 +6,7 @@
 ([ for subsection_key, subsection_items in section_items|groupby("subsection") ])
 ([ set subsection = subsections[subsection_key] ])
 ([ if subsection|length > 0 ])
-\\[12pt]
+\vspace{5mm}
 \textbf{(( subsection ))}
 ([ endif ])
 

--- a/doc/ReleaseNotes/mk_releasenotes.py
+++ b/doc/ReleaseNotes/mk_releasenotes.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         trim_blocks=True,
         lstrip_blocks=True,
         line_statement_prefix="_",
-        keep_trailing_newline=True,
+        keep_trailing_newline=False,
         # since latex uses curly brackets,
         # replace block/var start/end tags
         block_start_string="([",

--- a/doc/mf6io/mf6ivar/deprecations.py
+++ b/doc/mf6io/mf6ivar/deprecations.py
@@ -48,10 +48,9 @@ def create_deprecations_file(dfndir, mddir, verbose):
             s += "| Model-Package | Option | Deprecated | Removed |\n"
             s += "|:--------------|:-------|:-----------|:--------|\n"
             for file, option, deprecated, removed in deprecations:
-                s += (
-                    f"| {file.stem} | {option} | {deprecated if deprecated else removed if removed else ''} "
-                    f"| {removed if removed else ''} |\n"
-                )
+                deprecated = deprecated if deprecated else removed if removed else ""
+                removed = removed if removed else ""
+                s += f"| {file.stem} | {option} | {deprecated} | {removed} |\n"
             if len(s) > 0:
                 s += "\n"
         f.write(s)


### PR DESCRIPTION
Better visual differentiation between section and subsection headers (tweak style and add vertical padding). Also apply ruff where lacking in previous commit