### PR TITLE
fix(mst): fix decay/production with negative concentrations

### DIFF
--- a/autotest/test_gwt_mst07_1storder.py
+++ b/autotest/test_gwt_mst07_1storder.py
@@ -1,0 +1,154 @@
+"""
+Test first-order decay by running a one-cell model with ten 1-day time steps
+with a decay rate of 1.  And a starting concentration of -10.  Results should
+remain -10 throughout the simulation.
+"""
+
+import os
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = ["mst07_1stord"]
+
+
+def build_models(idx, test):
+    nlay, nrow, ncol = 1, 1, 1
+    nper = 1
+    perlen = [10.0]
+    nstp = [10]
+    tsmult = [1.0]
+    delr = 1.0
+    delc = 1.0
+    top = 1.0
+    botm = 0.0
+
+    nouter, ninner = 100, 300
+    hclose, rclose, relax = 1e-6, 1e-6, 1.0
+
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+    name = cases[idx]
+
+    # build MODFLOW 6 files
+    ws = test.workspace
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
+
+    # create gwt model
+    gwtname = "gwt_" + name
+    gwt = flopy.mf6.MFModel(
+        sim,
+        model_type="gwt6",
+        modelname=gwtname,
+        model_nam_file=f"{gwtname}.nam",
+    )
+    gwt.name_file.save_flows = True
+
+    # create iterative model solution and register the gwt model with it
+    imsgwt = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename=f"{gwtname}.ims",
+    )
+    sim.register_ims_package(imsgwt, [gwt.name])
+
+    dis = flopy.mf6.ModflowGwtdis(
+        gwt,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        idomain=1,
+        filename=f"{gwtname}.dis",
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwtic(gwt, strt=-10.0, filename=f"{gwtname}.ic")
+
+    # mass storage and transfer
+    mst = flopy.mf6.ModflowGwtmst(gwt, porosity=1, first_order_decay=True, decay=1.0)
+
+    srcs = {0: [[(0, 0, 0), 0.00]]}
+    src = flopy.mf6.ModflowGwtsrc(
+        gwt,
+        maxbound=len(srcs),
+        stress_period_data=srcs,
+        save_flows=False,
+        pname="SRC-1",
+    )
+
+    # output control
+    oc = flopy.mf6.ModflowGwtoc(
+        gwt,
+        budget_filerecord=f"{gwtname}.bud",
+        concentration_filerecord=f"{gwtname}.ucn",
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
+        printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
+    )
+    print(gwt.modelgrid.zcellcenters)
+    return sim, None
+
+
+def check_output(idx, test):
+    name = test.name
+    gwtname = "gwt_" + name
+
+    fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
+    cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
+    conc = cobj.get_ts((0, 0, 0))
+
+    # The answer
+    # print(conc[:, 1])
+    cres = np.array(10 * [-10.0])
+    assert np.allclose(cres, conc[:, 1]), (
+        "simulated concentrations do not match with known solution. "
+        f"{conc[:, 1]} {cres}"
+    )
+
+    # Check budget file
+    fpth = os.path.join(test.workspace, f"{gwtname}.bud")
+    try:
+        bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
+    except:
+        assert False, f'could not load data from "{fpth}"'
+    decay_list = bobj.get_data(text="DECAY-AQUEOUS")
+    decay_rate = [dr[0] for dr in decay_list]
+    decay_rate_answer = np.array(10 * [0.0])
+    assert np.allclose(decay_rate, decay_rate_answer), (
+        "simulated decay rates do not match with known solution. "
+        f"{decay_rate} {decay_rate_answer}"
+    )
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+    )
+    test.run()

--- a/doc/ReleaseNotes/appendixA.tex
+++ b/doc/ReleaseNotes/appendixA.tex
@@ -1,5 +1,6 @@
 This appendix describes changes introduced into MODFLOW~6 in previous releases. These changes may substantially affect users.
 
+        \input{./previous/v6.6.2.tex}
         \input{./previous/v6.6.1.tex}
         \input{./previous/v6.6.0.tex}
         \input{./previous/v6.5.0.tex}

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -1,0 +1,18 @@
+[sections]
+features = "NEW FUNCTIONALITY"
+fixes = "BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY"
+examples = "EXAMPLES"
+
+[subsections]
+basic = "BASIC FUNCTIONALITY"
+internal = "INTERNAL FLOW PACKAGES"
+stress = "STRESS PACKAGES"
+advanced = "ADVANCED STRESS PACKAGES"
+solution = "SOLUTION"
+exchanges = "EXCHANGES"
+parallel = "PARALLEL"
+
+[[items]]
+section = "fixes"
+subsection = "internal"
+description = "Fixed first-order decay in GWT so that production/decay does not occur when aqueous or sorbed concentration are negative."

--- a/doc/ReleaseNotes/previous/v6.6.1.tex
+++ b/doc/ReleaseNotes/previous/v6.6.1.tex
@@ -3,7 +3,8 @@
 	
 \subsection{Version mf6.6.1---February 7, 2025}
 
-\underline{NEW FUNCTIONALITY}
+\textbf{\underline{NEW FUNCTIONALITY}}
+
 \begin{itemize}
 	\item Support for adjusting time step lengths using the adaptive time stepping (ATS) capability was added to the GWT Advection (ADV) Package of the Groundwater Transport (GWT) Model in release 6.6.0.  The same functionality that was added to GWT is now available with the Groundwater Energy Transport (GWE) Model.  A description of how this functionality works and how to activate it can be found in the release notes for version 6.6.0 (Appendix A) and in the MODFLOW 6 input-output guide.
 	\item The binary grid file written by MODFLOW 6 for DISU models did not include the IDOMAIN array.  The binary grid file now includes IDOMAIN for all discretization types, including DISU.
@@ -18,7 +19,8 @@
 %	\item xxx
 %\end{itemize}
 
-\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
+\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}}
+
 \underline{BASIC FUNCTIONALITY}
 \begin{itemize}
 	\item GWT, GWE and PRT Models require a grid identical to the grid of the corresponding GWF Model. Previously, GWT, GWE and PRT exchanges performed a minimal check that the grids have the same number of active nodes. Exchanges will now also perform an additional check that grid IDOMAIN arrays are identical.

--- a/doc/ReleaseNotes/previous/v6.6.2.tex
+++ b/doc/ReleaseNotes/previous/v6.6.2.tex
@@ -1,11 +1,12 @@
-\subsection{Version mf6.0.0---August 10, 2017}
+\subsection{Version mf6.6.2---May 12, 2025}
 
-\textbf{\underline{{EXAMPLES}}
+\textbf{\underline{EXAMPLES}}
 \begin{itemize}
 \item A new example was added demonstrating transient thermal loading of multiple borehole heat exchangers with the Groundwater Energy (GWE) model. The simulated GWE results match the temperature change predicted by the analytical solution for the multiple borehole heat exchangers used in this problem.
 \end{itemize}
 
-\textbf{\underline{{NEW FUNCTIONALITY}}
+\textbf{\underline{NEW FUNCTIONALITY}}
+
 \underline{BASIC FUNCTIONALITY}
 \begin{itemize}
 \item The binary grid file's name may now be specified in all discretization packages with option GRB6 FILEOUT followed by a file path. If this option is not provided, the binary grid file will be named as before, identical to the discretization file name plus a ``.grb'' extension. Note that renaming the binary grid file may break downstream integrations which expect the default name.
@@ -16,7 +17,7 @@
 \item Added interbed-compaction-pct observation to the CSUB package.
 \end{itemize}
 
-\textbf{\underline{{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}}
+\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}}
 \begin{itemize}
 \item The mf6io.pdf guide for the SFE Package lists the availability of the STRMBD-COND observation type.  However, the SFE Package did not actually support this observation type and if listed would cause the program to exit with error message.  Functionality has been added to SFE for writing the amount of streambed conductive heat exchange to the CSV output file that contains the user-specified observations.
 \item Fixed a variable overflow in the MPI communication for parallel simulations that could cause a memory exception when running a parallel simulation with truly large subdomains (~20M nodes or more).

--- a/src/Model/GroundWaterTransport/gwt-mst.f90
+++ b/src/Model/GroundWaterTransport/gwt-mst.f90
@@ -504,7 +504,7 @@ contains
           !
           ! -- first order decay rate is a function of concentration, so add
           !    to left hand side
-          if (cnew(n) < DZERO) then
+          if (cnew(n) > DZERO) then
             hhcof = -term * distcoef
           end if
         case (SORPTION_FREUND)

--- a/src/Model/GroundWaterTransport/gwt-mst.f90
+++ b/src/Model/GroundWaterTransport/gwt-mst.f90
@@ -296,8 +296,10 @@ contains
         !
         ! -- first order decay rate is a function of concentration, so add
         !    to left hand side
-        hhcof = -this%decay(n) * vcell * swtpdt * this%thetam(n)
-        call matrix_sln%add_value_pos(idxglo(idiag), hhcof)
+        if (cnew(n) > DZERO) then
+          hhcof = -this%decay(n) * vcell * swtpdt * this%thetam(n)
+          call matrix_sln%add_value_pos(idxglo(idiag), hhcof)
+        end if
       case (DECAY_ZERO_ORDER)
         !
         ! -- Call function to get zero-order decay rate, which may be changed
@@ -497,13 +499,14 @@ contains
       ! -- add sorbed mass decay rate terms to accumulators
       select case (this%idcy)
       case (DECAY_FIRST_ORDER)
-        !
         select case (this%isrb)
         case (SORPTION_LINEAR)
           !
           ! -- first order decay rate is a function of concentration, so add
           !    to left hand side
-          hhcof = -term * distcoef
+          if (cnew(n) < DZERO) then
+            hhcof = -term * distcoef
+          end if
         case (SORPTION_FREUND)
           !
           ! -- nonlinear Freundlich sorption, so add to RHS
@@ -671,7 +674,9 @@ contains
       hhcof = DZERO
       rrhs = DZERO
       if (this%idcy == DECAY_FIRST_ORDER) then
-        hhcof = -this%decay(n) * vcell * swtpdt * this%thetam(n)
+        if (cnew(n) > DZERO) then
+          hhcof = -this%decay(n) * vcell * swtpdt * this%thetam(n)
+        end if
       elseif (this%idcy == DECAY_ZERO_ORDER) then
         decay_rate = get_zero_order_decay(this%decay(n), this%decaylast(n), &
                                           0, cold(n), cnew(n), delt)
@@ -795,13 +800,16 @@ contains
       ! -- add sorbed mass decay rate terms to accumulators
       select case (this%idcy)
       case (DECAY_FIRST_ORDER)
+
         !
         select case (this%isrb)
         case (SORPTION_LINEAR)
           !
           ! -- first order decay rate is a function of concentration, so add
           !    to left hand side
-          hhcof = -term * distcoef
+          if (cnew(n) > DZERO) then
+            hhcof = -term * distcoef
+          end if
         case (SORPTION_FREUND)
           !
           ! -- nonlinear Freundlich sorption, so add to RHS


### PR DESCRIPTION
Add fix to prevent aqueous and sorbed production/decay in GWT if concentrations are negative.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
