### PR TITLE
chore(update_flopy): remove unneeded steps from update_flopy.py

### DIFF
--- a/.github/actions/test-extended/action.yml
+++ b/.github/actions/test-extended/action.yml
@@ -46,7 +46,9 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install netcdf-fortran@4.6.1
+        brew tap-new $USER/oldformulae || true
+        brew extract --version=4.6.1 netcdf-fortran $USER/oldformulae || true
+        brew install $USER/oldformulae/netcdf-fortran@4.6.1
         nc-config --all
         nf-config --all
 

--- a/.github/actions/test-extended/action.yml
+++ b/.github/actions/test-extended/action.yml
@@ -37,7 +37,7 @@ runs:
         sudo apt-get update
         sudo apt-get install build-essential \
           libnetcdf-dev \
-          libnetcdff-dev \
+          libnetcdff-dev=4.6.1 \
           netcdf-bin
         nc-config --all
         nf-config --all
@@ -46,7 +46,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install netcdf-fortran
+        brew install netcdf-fortran@4.6.1
         nc-config --all
         nf-config --all
 

--- a/.github/actions/test-extended/action.yml
+++ b/.github/actions/test-extended/action.yml
@@ -37,7 +37,7 @@ runs:
         sudo apt-get update
         sudo apt-get install build-essential \
           libnetcdf-dev \
-          libnetcdff-dev=4.6.0 \
+          libnetcdff-dev \
           netcdf-bin
         nc-config --all
         nf-config --all
@@ -46,9 +46,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew tap-new $USER/oldformulae || true
-        brew extract --version=4.6.1 netcdf-fortran $USER/oldformulae || true
-        brew install $USER/oldformulae/netcdf-fortran@4.6.1
+        brew install netcdf-fortran
         nc-config --all
         nf-config --all
 

--- a/.github/actions/test-extended/action.yml
+++ b/.github/actions/test-extended/action.yml
@@ -37,7 +37,7 @@ runs:
         sudo apt-get update
         sudo apt-get install build-essential \
           libnetcdf-dev \
-          libnetcdff-dev=4.6.1 \
+          libnetcdff-dev=4.6.0 \
           netcdf-bin
         nc-config --all
         nf-config --all

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ doc/ReleaseNotes/run-time-comparison.tex
 doc/ReleaseNotes/deprecations.tex
 doc/mf6io/mf6ivar/md
 doc/mf6io/mf6ivar/tex
+doc/mf6io/mf6ivar/dfn/toml
 
 # Intel Fortran Visual Studio intermediate files
 msvs/*.fdz

--- a/autotest/update_flopy.py
+++ b/autotest/update_flopy.py
@@ -1,13 +1,11 @@
 import argparse
 import importlib
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 import flopy
-import pytest
 from conftest import project_root_path
 
 dfn_path = project_root_path / "doc" / "mf6io" / "mf6ivar" / "dfn"
@@ -23,22 +21,6 @@ def test_delete_mf6():
     delete_files(files, pth, exclude="mfsimulation.py")
 
 
-@pytest.mark.parametrize("path", [dfn_path])
-def test_copy_dfn(path):
-    files = [
-        entry for entry in os.listdir(path) if os.path.isfile(os.path.join(path, entry))
-    ]
-    pth1 = os.path.join(fpy_path, "mf6", "data", "dfn")
-    for fn in files:
-        ext = os.path.splitext(fn)[1].lower()
-        if "dfn" in ext:
-            fpth0 = os.path.join(path, fn)
-            fpth1 = os.path.join(pth1, fn)
-            print(f'copying {fn} from "{path}" to "{pth1}"')
-            shutil.copyfile(fpth0, fpth1)
-
-
-@pytest.mark.order(after="test_copy_dfn")
 def test_create_packages():
     # get list of files in mf6/modflow
     pth = os.path.join(fpy_path, "mf6", "modflow")
@@ -106,5 +88,4 @@ if __name__ == "__main__":
     print(f"Updating flopy packages from DFN files in: {path}")
 
     test_delete_mf6()
-    test_copy_dfn(path)
     test_create_packages()

--- a/autotest/update_flopy.py
+++ b/autotest/update_flopy.py
@@ -23,16 +23,6 @@ def test_delete_mf6():
     delete_files(files, pth, exclude="mfsimulation.py")
 
 
-@pytest.mark.order(after="test_delete_mf6")
-def test_delete_dfn():
-    pth = os.path.join(fpy_path, "mf6", "data", "dfn")
-    files = [
-        entry for entry in os.listdir(pth) if os.path.isfile(os.path.join(pth, entry))
-    ]
-    delete_files(files, pth, exclude="flopy.dfn")
-
-
-@pytest.mark.order(after="test_delete_dfn")
 @pytest.mark.parametrize("path", [dfn_path])
 def test_copy_dfn(path):
     files = [
@@ -89,7 +79,7 @@ def list_files(pth, exts=["py"]):
             print(f"    {idx:5d} - {fn}")
 
 
-def delete_files(files, pth, allow_failure=False, exclude=None):
+def delete_files(files, pth, exclude=None):
     if exclude is None:
         exclude = []
     else:
@@ -105,9 +95,6 @@ def delete_files(files, pth, allow_failure=False, exclude=None):
             os.remove(fpth)
         except:
             print(f"could not remove...{fn}")
-            if not allow_failure:
-                return False
-    return True
 
 
 if __name__ == "__main__":
@@ -119,6 +106,5 @@ if __name__ == "__main__":
     print(f"Updating flopy packages from DFN files in: {path}")
 
     test_delete_mf6()
-    test_delete_dfn()
     test_copy_dfn(path)
     test_create_packages()

--- a/pixi.toml
+++ b/pixi.toml
@@ -108,7 +108,7 @@ autotest = { cmd = "pytest -v -n auto --durations 0 --keep-failed .failed", cwd 
 
 # common developer tasks
 update-fortran-definitions = { cmd = "cat dfns.txt | xargs python scripts/dfn2f90.py", cwd = "utils/idmloader" }
-update-flopy = { cmd = "python update_flopy.py", cwd = "autotest" }
+update-flopy = "python -m flopy.mf6.utils.generate_classes --dfnpath doc/mf6io/mf6ivar/dfn"
 build-makefiles = { cmd = "python build_makefiles.py", cwd = "distribution" }
 run-mf6ivar = { cmd = "python mf6ivar.py", cwd = "doc/mf6io/mf6ivar" }
 prepare-pull-request = {depends-on = ["fix-style", "fix-python-style", "build-makefiles", "run-mf6ivar", "update-fortran-definitions"]}


### PR DESCRIPTION
No longer need to delete/copy the flopy DFN directory since we removed DFNs from flopy.

Also, just invoke flopy codegen directly in the `update-flopy` pixi task like `python -m flopy.mf6.utils.generate_classes --dfnpath doc/mf6io/mf6ivar/dfn`, instead of running `update_flopy.py`. The script doesn't do much anymore, besides saving some typing. I considered removing it, but I know not everyone uses pixi.