### PR TITLE
docs(rtd): add idm and distribution pages to dev docs

### DIFF
--- a/.build_rtd_docs/conf.py
+++ b/.build_rtd_docs/conf.py
@@ -97,7 +97,7 @@ dst = os.path.join(dstdir, "DISTRIBUTION.md")
 shutil.copy(src, dst)
 
 fpth = "IDM.md"
-src = os.path.join("..", "utils", "idmloader", fpth)
+src = os.path.join("..", fpth)
 dst = os.path.join(dstdir, fpth)
 shutil.copy(src, dst)
 

--- a/.build_rtd_docs/conf.py
+++ b/.build_rtd_docs/conf.py
@@ -91,6 +91,11 @@ src = os.path.join("..", fpth)
 dst = os.path.join(dstdir, fpth)
 shutil.copy(src, dst)
 
+fpth = "IDM.md"
+src = os.path.join("..", "utils", "idmloader", fpth)
+dst = os.path.join(dstdir, fpth)
+shutil.copy(src, dst)
+
 dstdir = "_migration"
 if os.path.isdir(dstdir):
     shutil.rmtree(dstdir)

--- a/.build_rtd_docs/conf.py
+++ b/.build_rtd_docs/conf.py
@@ -91,6 +91,11 @@ src = os.path.join("..", fpth)
 dst = os.path.join(dstdir, fpth)
 shutil.copy(src, dst)
 
+fpth = "README.md"
+src = os.path.join("..", "distribution")
+dst = os.path.join(dstdir, "DISTRIBUTION.md")
+shutil.copy(src, dst)
+
 fpth = "IDM.md"
 src = os.path.join("..", "utils", "idmloader", fpth)
 dst = os.path.join(dstdir, fpth)

--- a/.build_rtd_docs/dev.rst
+++ b/.build_rtd_docs/dev.rst
@@ -11,6 +11,7 @@ This section contains developer documentation, including contributor conventions
    _dev/CONTRIBUTING.md
    _dev/DEVELOPER.md
    _dev/EXTENDED.md
+   _dev/DISTRIBUTION.md
    _dev/styleguide.md
    _dev/dfn.md
    _dev/IDM.md

--- a/.build_rtd_docs/dev.rst
+++ b/.build_rtd_docs/dev.rst
@@ -13,3 +13,4 @@ This section contains developer documentation, including contributor conventions
    _dev/EXTENDED.md
    _dev/styleguide.md
    _dev/dfn.md
+   _dev/IDM.md

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -1,6 +1,6 @@
 # Distributing MODFLOW 6
 
-This document describes release procedures for MODFLOW 6. This folder contains scripts to automate MODFLOW 6 distribution tasks.
+This document describes release procedures for MODFLOW 6.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->


### PR DESCRIPTION
After this, I think all the developer-facing markdown documents scattered around the repo will be collected in https://modflow6.readthedocs.io/en/stable/dev.html. We still have some things on the [wiki](https://github.com/MODFLOW-ORG/modflow6/wiki), though, in particular for the extended build. @mjr-deltares what do you think is the right place for the extended build docs? should we consolidate somehow?