### PR TITLE
docs(prt): fix removal version for prt prp/oc options

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/prt-oc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-oc.dfn
@@ -200,7 +200,7 @@ tagged true
 optional true
 longname
 description
-removed 6.6.1
+removed 6.6.0
 
 block options
 name track_times
@@ -211,7 +211,7 @@ tagged true
 shape
 longname
 description keyword indicating tracking times will follow
-removed 6.6.1
+removed 6.6.0
 
 block options
 name times
@@ -223,7 +223,7 @@ tagged false
 repeating true
 longname tracking times
 description times to track, relative to the beginning of the simulation.
-removed 6.6.1
+removed 6.6.0
 
 block options
 name track_timesfilerecord
@@ -234,7 +234,7 @@ tagged true
 optional true
 longname
 description
-removed 6.6.1
+removed 6.6.0
 
 block options
 name track_timesfile
@@ -245,7 +245,7 @@ tagged true
 shape
 longname
 description keyword indicating tracking times file name will follow
-removed 6.6.1
+removed 6.6.0
 
 block options
 name timesfile
@@ -258,7 +258,7 @@ tagged false
 optional false
 longname file keyword
 description name of the tracking times file
-removed 6.6.1
+removed 6.6.0
 
 # --------------------- prt oc dimensions ------------------
 

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -177,7 +177,7 @@ tagged true
 optional true
 longname
 description
-removed 6.6.1
+removed 6.6.0
 
 block options
 name release_times
@@ -188,7 +188,7 @@ tagged true
 shape
 longname
 description keyword indicating release times will follow
-removed 6.6.1
+removed 6.6.0
 
 block options
 name times
@@ -200,7 +200,7 @@ tagged false
 repeating true
 longname release times
 description times to release, relative to the beginning of the simulation.  RELEASE\_TIMES and RELEASE\_TIMESFILE are mutually exclusive.
-removed 6.6.1
+removed 6.6.0
 
 block options
 name release_timesfilerecord
@@ -211,7 +211,7 @@ tagged true
 optional true
 longname
 description
-removed 6.6.1
+removed 6.6.0
 
 block options
 name release_timesfile
@@ -222,7 +222,7 @@ tagged true
 shape
 longname
 description keyword indicating release times file name will follow
-removed 6.6.1
+removed 6.6.0
 
 block options
 name timesfile
@@ -235,7 +235,7 @@ tagged false
 optional false
 longname file keyword
 description name of the release times file.  RELEASE\_TIMES and RELEASE\_TIMESFILE are mutually exclusive.
-removed 6.6.1
+removed 6.6.0
 
 block options
 name dry_tracking_method


### PR DESCRIPTION
These were marked as removed in 6.6.1 but they were removed in 6.6.0.
