### PR TITLE
test: clean up unused unit tests

### DIFF
--- a/autotest/TestArrayHandlers.f90
+++ b/autotest/TestArrayHandlers.f90
@@ -24,10 +24,6 @@ contains
                              test_ExpandArray2D_int), &
                 new_unittest("ExpandArray2D_dbl", &
                              test_ExpandArray2D_dbl), &
-                ! new_unittest("ExtendPtrArray_int", &
-                !              test_ExtendPtrArray_int), &
-                ! new_unittest("ExtendPtrArray_dbl", &
-                !              test_ExtendPtrArray_dbl), &
                 new_unittest("remove_character", &
                              test_remove_character) &
                 ]
@@ -257,88 +253,6 @@ contains
       deallocate (a)
     end do
   end subroutine test_ExpandArray2D_dbl
-
-  !> @brief Test 1D int ptr array expansion
-  subroutine test_ExtendPtrArray_int(error)
-    type(error_type), allocatable, intent(out) :: error
-    integer(I4B), allocatable, target :: aa(:)
-    integer(I4B), pointer, contiguous :: a(:)
-    integer(I4B) :: i, lb, n1, n2
-
-    n1 = 2 ! starting size
-    n2 = 5 ! expanded size
-    do lb = -1, 1 ! test with default lower bound (1) as well as 0 and -1
-      ! allocate/populate array and set pointer
-      allocate (aa(lb:(lb + n1 - 1)))
-      aa(lb) = lb
-      aa(lb + 1) = lb + 1
-      a => aa
-
-      ! resize array and check new size and bounds
-      call ExtendPtrArray(a, n2 - n1)
-      call check(error, size(a, 1) == n2, &
-                 "unexpected size: "//to_string(size(a, 1)))
-      call check(error, lbound(a, 1) == lb, &
-                 "unexpected lower bound: "//to_string(lbound(a, 1)))
-      call check(error, ubound(a, 1) == lb + n2 - 1, &
-                 "unexpected upper bound: "//to_string(ubound(a, 1)))
-      if (allocated(error)) return
-
-      ! set new array elements and check new/old contents
-      do i = lb + n1 - 1, lb + n2 - 1
-        a(i) = i
-      end do
-      do i = lb, lb + n2 - 1
-        call check(error, a(i) == i, &
-                   "unexpected value "//to_string(a(i)) &
-                   //" at i="//to_string(i))
-        if (allocated(error)) return
-      end do
-      nullify (a)
-      deallocate (aa)
-    end do
-  end subroutine test_ExtendPtrArray_int
-
-  !> @brief Test 1D dbl ptr array expansion
-  subroutine test_ExtendPtrArray_dbl(error)
-    type(error_type), allocatable, intent(out) :: error
-    real(DP), allocatable, target :: aa(:)
-    real(DP), pointer, contiguous :: a(:)
-    integer(I4B) :: i, lb, n1, n2
-
-    n1 = 2 ! starting size
-    n2 = 5 ! expanded size
-    do lb = -1, 1 ! test with default lower bound (1) as well as 0 and -1
-      ! allocate/populate array and set pointer
-      allocate (aa(lb:(lb + n1 - 1)))
-      aa(lb) = real(lb)
-      aa(lb + 1) = real(lb + 1)
-      a => aa
-
-      ! resize array and check new size and bounds
-      call ExtendPtrArray(a, n2 - n1)
-      call check(error, size(a, 1) == n2, &
-                 "unexpected size: "//to_string(size(a, 1)))
-      call check(error, lbound(a, 1) == lb, &
-                 "unexpected lower bound: "//to_string(lbound(a, 1)))
-      call check(error, ubound(a, 1) == lb + n2 - 1, &
-                 "unexpected upper bound: "//to_string(ubound(a, 1)))
-      if (allocated(error)) return
-
-      ! set new array elements and check new/old contents
-      do i = lb + n1 - 1, n2
-        a(i) = real(i)
-      end do
-      do i = lb, lb + n2 - 1
-        call check(error, a(i) == real(i), &
-                   "unexpected value "//to_string(a(i)) &
-                   //" at i="//to_string(i))
-        if (allocated(error)) return
-      end do
-      nullify (a)
-      deallocate (aa)
-    end do
-  end subroutine test_ExtendPtrArray_dbl
 
   subroutine test_remove_character(error)
     type(error_type), allocatable, intent(out) :: error


### PR DESCRIPTION
These are not being used and need some attention if we want to use them. They are causing compile-time warnings. Remove them for now. Nothing is ever truly gone with source control.