### PR TITLE
Ensure system libdir's pkgconfig is added to PKG_CONFIG_PATH

### DIFF
--- a/.github/actions/test-extended/action.yml
+++ b/.github/actions/test-extended/action.yml
@@ -40,7 +40,7 @@ runs:
     - name: Configure environment
       shell: bash
       run: |
-        echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/petsc/arch-gcc-opt/lib/pkgconfig" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/petsc/arch-gcc-opt/lib/pkgconfig:$(nc-config --libdir)/pkgconfig" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/petsc/arch-gcc-opt/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "$GITHUB_WORKSPACE/petsc/arch-gcc-opt/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
This is a follow-up to #2345 to fix pkg-config's ability to search system-installed libraries.