### PR TITLE
ci: use separate step for example tests with gfortran on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,11 +334,20 @@ jobs:
 
       - name: Test examples
         working-directory: modflow6
+        if: runner.os != 'Windows'
         shell: pixi run bash -e {0}
         run: |
           cp -R bin/* ~/.local/bin/modflow/
           cd ../modflow6-examples/autotest
           pytest -v -n auto test_scripts.py
+
+      - name: Test examples
+        working-directory: modflow6
+        if: runner.os == 'Windows'
+        run: |
+          cp -R bin/* /c/Users/runneradmin/.local/bin/modflow/
+          cd ../modflow6-examples/autotest
+          pixi run --manifest-path ../../modflow6/pixi.toml pytest -v -n auto test_scripts.py
 
       - name: Upload failed test output
         if: failure()


### PR DESCRIPTION
Seems like the `pixi run bash -e {0}` trick has stopped working on Windows. I used `tmate-action` to log into the runner and tried running `pixi shell` and got a shell not configured error. Use `pixi run --manifest-path ...` instead.

Also fix the path to copy mf6 exes to, on Windows bash `$HOME` and `~` now seem to resolve not to the real runner home directory `c/Users/runneradmin` but to a fake bash home directory. Also a recent change?