### PR TITLE
feat(idm):  integrate GWF CSUB package

### DIFF
--- a/.github/common/check_format.py
+++ b/.github/common/check_format.py
@@ -24,7 +24,10 @@ excludedirs = [
 ]
 
 # exclude these files from checks
-excludefiles = [PROJ_ROOT / "src" / "Idm" / "gwf-stoidm.f90"]
+excludefiles = [
+    PROJ_ROOT / "src" / "Idm" / "gwf-stoidm.f90",
+    PROJ_ROOT / "src" / "Idm" / "gwf-csubidm.f90",
+]
 
 # commands
 fprettify = "fprettify -c .fprettify.yaml"

--- a/autotest/test_gwf_csub_subwt02.py
+++ b/autotest/test_gwf_csub_subwt02.py
@@ -319,7 +319,7 @@ def get_model(idx, ws):
         gwf,
         # print_input=True,
         # interbed_stress_offset=True,
-        boundnames=True,
+        boundnames=False,
         compression_indices=True,
         update_material_properties=ump[idx],
         effective_stress_lag=True,

--- a/doc/mf6io/framework/processing_of_input.tex
+++ b/doc/mf6io/framework/processing_of_input.tex
@@ -19,6 +19,7 @@ SIM/TDIS & TDIS6 \\
 \hline
 GWF/NAM & GWF name file \\
 GWF/CHD & CHD6 \\
+GWF/CSUB & CSUB6 \\
 GWF/DIS & DIS6 \\
 GWF/DISU & DISU6 \\
 GWF/DISV & DISV6 \\

--- a/doc/mf6io/mf6ivar/dfn/gwf-csub.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-csub.dfn
@@ -59,6 +59,7 @@ reader urword
 optional true
 longname keyword to indicate that preconsolidation heads will be specified
 description keyword to indicate that preconsolidation heads will be specified for no-delay and delay interbeds in the PACKAGEDATA block. If the SPECIFIED\_INITIAL\_INTERBED\_STATE option is specified in the OPTIONS block, user-specified preconsolidation heads in the PACKAGEDATA block are absolute values. Otherwise, user-specified preconsolidation heads in the PACKAGEDATA block are relative to steady-state or initial heads.
+mf6internal precon_head
 
 block options
 name ndelaycells
@@ -75,6 +76,7 @@ reader urword
 optional true
 longname keyword to indicate CR and CC are read instead of SSE and SSV
 description keyword to indicate that the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified.
+mf6internal icompress
 
 block options
 name update_material_properties
@@ -83,6 +85,7 @@ reader urword
 optional true
 longname keyword to indicate material properties can change during the simulations
 description keyword to indicate that the thickness and void ratio of coarse-grained and interbed sediments (delay and no-delay) will vary during the simulation. If not specified, the thickness and void ratio of coarse-grained and interbed sediments will not vary during the simulation.
+mf6internal matprop
 
 block options
 name cell_fraction
@@ -99,6 +102,7 @@ reader urword
 optional true
 longname keyword to indicate that absolute initial states will be specified
 description keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\_INITIAL\_INTERBED\_STATE option is equivalent to specifying the SPECIFIED\_INITIAL\_PRECONSOLITATION\_STRESS and SPECIFIED\_INITIAL\_DELAY\_HEAD. If SPECIFIED\_INITIAL\_INTERBED\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values of the first stress period if steady-state or initial stresses and GWF heads if the first stress period is transient.
+mf6internal interbed_state
 
 block options
 name specified_initial_preconsolidation_stress
@@ -107,6 +111,7 @@ reader urword
 optional true
 longname keyword to indicate that absolute initial preconsolidation stresses (head) will be specified
 description keyword to indicate that absolute preconsolidation stresses (heads) will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\_INITIAL\_PRECONSOLITATION\_STRESS and SPECIFIED\_INITIAL\_INTERBED\_STATE are not specified then preconsolidation stress (head) values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses (heads) if the first stress period is transient.
+mf6internal precon_stress
 
 block options
 name specified_initial_delay_head
@@ -115,6 +120,7 @@ reader urword
 optional true
 longname keyword to indicate that absolute initial delay bed heads will be specified
 description keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\_INITIAL\_DELAY\_HEAD and SPECIFIED\_INITIAL\_INTERBED\_STATE are not specified then delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient.
+mf6internal delay_head
 
 block options
 name effective_stress_lag
@@ -123,6 +129,7 @@ reader urword
 optional true
 longname keyword to indicate that specific storage will be calculate using the effective stress from the previous time step
 description keyword to indicate the effective stress from the previous time step will be used to calculate specific storage values. This option can 1) help with convergence in models with thin cells and water table elevations close to land surface; 2) is identical to the approach used in the SUBWT package for MODFLOW-2005; and 3) is only used if the effective-stress formulation is being used. By default, current effective stress values are used to calculate specific storage values.
+mf6internal stress_lag
 
 
 # csub csv strain output
@@ -135,6 +142,7 @@ tagged true
 optional true
 longname
 description
+mf6internal strainibfr
 
 block options
 name strain_csv_interbed
@@ -146,6 +154,7 @@ tagged true
 optional false
 longname budget keyword
 description keyword to specify the record that corresponds to final interbed strain output.
+mf6internal csvinterbed
 
 block options
 name fileout
@@ -161,6 +170,7 @@ description keyword to specify that an output filename is expected next.
 block options
 name interbedstrain_filename
 type string
+preserve_case true
 shape
 in_record true
 reader urword
@@ -168,6 +178,7 @@ tagged false
 optional false
 longname file keyword
 description name of the comma-separated-values output file to write final interbed strain information.
+mf6internal interbedstrainfn
 
 block options
 name straincg_filerecord
@@ -178,6 +189,7 @@ tagged true
 optional true
 longname
 description
+mf6internal straincgfr
 
 block options
 name strain_csv_coarse
@@ -189,10 +201,12 @@ tagged true
 optional false
 longname budget keyword
 description keyword to specify the record that corresponds to final coarse-grained material strain output.
+mf6internal csvcoarse
 
 block options
 name coarsestrain_filename
 type string
+preserve_case true
 shape
 in_record true
 reader urword
@@ -200,6 +214,7 @@ tagged false
 optional false
 longname file keyword
 description name of the comma-separated-values output file to write final coarse-grained material strain information.
+mf6internal coarsestrainfn
 
 # binary compaction output
 block options
@@ -211,6 +226,7 @@ tagged true
 optional true
 longname
 description
+mf6internal cmpfr
 
 block options
 name compaction
@@ -226,6 +242,7 @@ description keyword to specify that record corresponds to the compaction.
 block options
 name compaction_filename
 type string
+preserve_case true
 shape
 in_record true
 reader urword
@@ -233,6 +250,7 @@ tagged false
 optional false
 longname file keyword
 description name of the binary output file to write compaction information.
+mf6internal cmpfn
 
 block options
 name compaction_elastic_filerecord
@@ -243,6 +261,7 @@ tagged true
 optional true
 longname
 description
+mf6internal cmpelasticfr
 
 block options
 name compaction_elastic
@@ -254,10 +273,12 @@ tagged true
 optional false
 longname elastic interbed compaction keyword
 description keyword to specify that record corresponds to the elastic interbed compaction binary file.
+mf6internal cmpelastic
 
 block options
 name elastic_compaction_filename
 type string
+preserve_case true
 shape
 in_record true
 reader urword
@@ -265,6 +286,7 @@ tagged false
 optional false
 longname file keyword
 description name of the binary output file to write elastic interbed compaction information.
+mf6internal elasticcmpfn
 
 block options
 name compaction_inelastic_filerecord
@@ -275,6 +297,7 @@ tagged true
 optional true
 longname
 description
+mf6internal cmpinelasticfr
 
 block options
 name compaction_inelastic
@@ -286,10 +309,12 @@ tagged true
 optional false
 longname inelastic interbed compaction keyword
 description keyword to specify that record corresponds to the inelastic interbed compaction binary file.
+mf6internal cmpinelastic
 
 block options
 name inelastic_compaction_filename
 type string
+preserve_case true
 shape
 in_record true
 reader urword
@@ -297,6 +322,7 @@ tagged false
 optional false
 longname file keyword
 description name of the binary output file to write inelastic interbed compaction information.
+mf6internal inelasticcmpfn
 
 block options
 name compaction_interbed_filerecord
@@ -307,6 +333,7 @@ tagged true
 optional true
 longname
 description
+mf6internal cmpinterbedfr
 
 block options
 name compaction_interbed
@@ -318,10 +345,12 @@ tagged true
 optional false
 longname interbed compaction keyword
 description keyword to specify that record corresponds to the interbed compaction binary file.
+mf6internal cmpinterbed
 
 block options
 name interbed_compaction_filename
 type string
+preserve_case true
 shape
 in_record true
 reader urword
@@ -329,6 +358,7 @@ tagged false
 optional false
 longname file keyword
 description name of the binary output file to write interbed compaction information.
+mf6internal interbedcmpfn
 
 block options
 name compaction_coarse_filerecord
@@ -339,6 +369,7 @@ tagged true
 optional true
 longname
 description
+mf6internal cmpcoarsefr
 
 block options
 name compaction_coarse
@@ -350,10 +381,12 @@ tagged true
 optional false
 longname coarse compaction keyword
 description keyword to specify that record corresponds to the elastic coarse-grained material compaction binary file.
+mf6internal cmpcoarse
 
 block options
 name coarse_compaction_filename
 type string
+preserve_case true
 shape
 in_record true
 reader urword
@@ -361,6 +394,7 @@ tagged false
 optional false
 longname file keyword
 description name of the binary output file to write elastic coarse-grained material compaction information.
+mf6internal cmpcoarsefn
 
 block options
 name zdisplacement_filerecord
@@ -371,6 +405,7 @@ tagged true
 optional true
 longname
 description
+mf6internal zdispfr
 
 block options
 name zdisplacement
@@ -386,6 +421,7 @@ description keyword to specify that record corresponds to the z-displacement bin
 block options
 name zdisplacement_filename
 type string
+preserve_case true
 shape
 in_record true
 reader urword
@@ -393,6 +429,7 @@ tagged false
 optional false
 longname file keyword
 description name of the binary output file to write z-displacement information.
+mf6internal zdispfn
 
 block options
 name package_convergence_filerecord
@@ -403,6 +440,7 @@ tagged true
 optional true
 longname
 description
+mf6internal pkgconvergefr
 
 block options
 name package_convergence
@@ -414,10 +452,12 @@ tagged true
 optional false
 longname package_convergence keyword
 description keyword to specify that record corresponds to the package convergence comma spaced values file. Package convergence data is for delay interbeds. A warning message will be issued if package convergence data is requested but delay interbeds are not included in the package.
+mf6internal pkgconverge
 
 block options
 name package_convergence_filename
 type string
+preserve_case true
 shape
 in_record true
 reader urword
@@ -425,6 +465,7 @@ tagged false
 optional false
 longname file keyword
 description name of the comma spaced values output file to write package convergence information.
+mf6internal pkgconvergefn
 
 block options
 name ts_filerecord
@@ -461,6 +502,7 @@ description keyword to specify that an input filename is expected next.
 block options
 name ts6_filename
 type string
+preserve_case true
 in_record true
 reader urword
 optional false
@@ -492,6 +534,7 @@ description keyword to specify that record corresponds to an observations file.
 block options
 name obs6_filename
 type string
+preserve_case true
 in_record true
 tagged false
 reader urword
@@ -516,6 +559,7 @@ reader urword
 optional true
 longname maximum number of stress offset cells
 description is the maximum number of cells that can have a specified stress offset.  More than 1 stress offset can be assigned to a GWF cell. By default, MAXSIG0 is 0.
+mf6internal maxbound
 
 
 # --------------------- gwf csub griddata ---------------------
@@ -526,6 +570,8 @@ type double precision
 shape (nodes)
 valid
 reader readarray
+layered true
+netcdf true
 longname elastic coarse specific storage
 description is the initial elastic coarse-grained material specific storage or recompression index. The recompression index is specified if COMPRESSION\_INDICES is specified in the OPTIONS block.  Specified or calculated elastic coarse-grained material specific storage values are not adjusted from initial values if HEAD\_BASED is specified in the OPTIONS block.
 default_value 1e-5
@@ -536,6 +582,8 @@ type double precision
 shape (nodes)
 valid
 reader readarray
+layered true
+netcdf true
 longname initial coarse-grained material porosity
 description is the initial porosity of coarse-grained materials.
 default_value 0.2
@@ -546,6 +594,8 @@ type double precision
 shape (nodes)
 valid
 reader readarray
+layered true
+netcdf true
 optional true
 longname specific gravity of moist sediments
 description is the specific gravity of moist or unsaturated sediments.  If not specified, then a default value of 1.7 is assigned.
@@ -556,6 +606,8 @@ type double precision
 shape (nodes)
 valid
 reader readarray
+layered true
+netcdf true
 optional true
 longname specific gravity of saturated sediments
 description is the specific gravity of saturated sediments. If not specified, then a default value of 2.0 is assigned.
@@ -567,6 +619,7 @@ name packagedata
 type recarray icsubno cellid cdelay pcs0 thick_frac rnb ssv_cc sse_cr theta kv h0 boundname
 shape (ninterbeds)
 reader urword
+optional true
 longname
 description
 
@@ -590,6 +643,7 @@ in_record true
 reader urword
 longname cell identifier
 description REPLACE cellid {}
+mf6internal cellid_pkgdata
 
 block packagedata
 name cdelay
@@ -715,6 +769,7 @@ shape (maxsig0)
 reader urword
 longname
 description
+mf6internal spd
 
 block period
 name cellid

--- a/make/makefile
+++ b/make/makefile
@@ -193,6 +193,7 @@ $(OBJDIR)/gwf-drngidm.o \
 $(OBJDIR)/gwf-disvidm.o \
 $(OBJDIR)/gwf-disuidm.o \
 $(OBJDIR)/gwf-disidm.o \
+$(OBJDIR)/gwf-csubidm.o \
 $(OBJDIR)/gwf-chdidm.o \
 $(OBJDIR)/gwe-namidm.o \
 $(OBJDIR)/gwe-icidm.o \

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -169,6 +169,7 @@
 		<File RelativePath="..\src\Idm\gwe-icidm.f90"/>
 		<File RelativePath="..\src\Idm\gwe-namidm.f90"/>
 		<File RelativePath="..\src\Idm\gwf-chdidm.f90"/>
+		<File RelativePath="..\src\Idm\gwf-csubidm.f90"/>
 		<File RelativePath="..\src\Idm\gwf-disidm.f90"/>
 		<File RelativePath="..\src\Idm\gwf-disuidm.f90"/>
 		<File RelativePath="..\src\Idm\gwf-disvidm.f90"/>

--- a/src/Idm/gwf-csubidm.f90
+++ b/src/Idm/gwf-csubidm.f90
@@ -1,0 +1,1508 @@
+! ** Do Not Modify! MODFLOW 6 system generated file. **
+module GwfCsubInputModule
+  use ConstantsModule, only: LENVARNAME
+  use InputDefinitionModule, only: InputParamDefinitionType, &
+                                   InputBlockDefinitionType
+  private
+  public gwf_csub_param_definitions
+  public gwf_csub_aggregate_definitions
+  public gwf_csub_block_definitions
+  public GwfCsubParamFoundType
+  public gwf_csub_multi_package
+  public gwf_csub_subpackages
+
+  type GwfCsubParamFoundType
+    logical :: boundnames = .false.
+    logical :: print_input = .false.
+    logical :: save_flows = .false.
+    logical :: gammaw = .false.
+    logical :: beta = .false.
+    logical :: head_based = .false.
+    logical :: precon_head = .false.
+    logical :: ndelaycells = .false.
+    logical :: icompress = .false.
+    logical :: matprop = .false.
+    logical :: cell_fraction = .false.
+    logical :: interbed_state = .false.
+    logical :: precon_stress = .false.
+    logical :: delay_head = .false.
+    logical :: stress_lag = .false.
+    logical :: strainibfr = .false.
+    logical :: csvinterbed = .false.
+    logical :: fileout = .false.
+    logical :: interbedstrainfn = .false.
+    logical :: straincgfr = .false.
+    logical :: csvcoarse = .false.
+    logical :: coarsestrainfn = .false.
+    logical :: cmpfr = .false.
+    logical :: compaction = .false.
+    logical :: cmpfn = .false.
+    logical :: cmpelasticfr = .false.
+    logical :: cmpelastic = .false.
+    logical :: elasticcmpfn = .false.
+    logical :: cmpinelasticfr = .false.
+    logical :: cmpinelastic = .false.
+    logical :: inelasticcmpfn = .false.
+    logical :: cmpinterbedfr = .false.
+    logical :: cmpinterbed = .false.
+    logical :: interbedcmpfn = .false.
+    logical :: cmpcoarsefr = .false.
+    logical :: cmpcoarse = .false.
+    logical :: cmpcoarsefn = .false.
+    logical :: zdispfr = .false.
+    logical :: zdisplacement = .false.
+    logical :: zdispfn = .false.
+    logical :: pkgconvergefr = .false.
+    logical :: pkgconverge = .false.
+    logical :: pkgconvergefn = .false.
+    logical :: ts_filerecord = .false.
+    logical :: ts6 = .false.
+    logical :: filein = .false.
+    logical :: ts6_filename = .false.
+    logical :: obs_filerecord = .false.
+    logical :: obs6 = .false.
+    logical :: obs6_filename = .false.
+    logical :: ninterbeds = .false.
+    logical :: maxbound = .false.
+    logical :: cg_ske_cr = .false.
+    logical :: cg_theta = .false.
+    logical :: sgm = .false.
+    logical :: sgs = .false.
+    logical :: icsubno = .false.
+    logical :: cellid_pkgdata = .false.
+    logical :: cdelay = .false.
+    logical :: pcs0 = .false.
+    logical :: thick_frac = .false.
+    logical :: rnb = .false.
+    logical :: ssv_cc = .false.
+    logical :: sse_cr = .false.
+    logical :: theta = .false.
+    logical :: kv = .false.
+    logical :: h0 = .false.
+    logical :: boundname = .false.
+    logical :: cellid = .false.
+    logical :: sig0 = .false.
+  end type GwfCsubParamFoundType
+
+  logical :: gwf_csub_multi_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_csub_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_boundnames = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'BOUNDNAMES', & ! tag name
+    'BOUNDNAMES', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_print_input = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'PRINT_INPUT', & ! tag name
+    'PRINT_INPUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'print input to listing file', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_save_flows = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'SAVE_FLOWS', & ! tag name
+    'SAVE_FLOWS', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'keyword to save CSUB flows', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_gammaw = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'GAMMAW', & ! tag name
+    'GAMMAW', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'unit weight of water', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_beta = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'BETA', & ! tag name
+    'BETA', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'compressibility of water', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_head_based = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'HEAD_BASED', & ! tag name
+    'HEAD_BASED', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'keyword to indicate the head-based formulation will be used', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_precon_head = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'INITIAL_PRECONSOLIDATION_HEAD', & ! tag name
+    'PRECON_HEAD', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'keyword to indicate that preconsolidation heads will be specified', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_ndelaycells = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'NDELAYCELLS', & ! tag name
+    'NDELAYCELLS', & ! fortran variable
+    'INTEGER', & ! type
+    '', & ! shape
+    'number of interbed cell nodes', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_icompress = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPRESSION_INDICES', & ! tag name
+    'ICOMPRESS', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'keyword to indicate CR and CC are read instead of SSE and SSV', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_matprop = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'UPDATE_MATERIAL_PROPERTIES', & ! tag name
+    'MATPROP', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'keyword to indicate material properties can change during the simulations', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cell_fraction = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'CELL_FRACTION', & ! tag name
+    'CELL_FRACTION', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'keyword to indicate cell fraction interbed thickness', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_interbed_state = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'SPECIFIED_INITIAL_INTERBED_STATE', & ! tag name
+    'INTERBED_STATE', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'keyword to indicate that absolute initial states will be specified', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_precon_stress = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'SPECIFIED_INITIAL_PRECONSOLIDATION_STRESS', & ! tag name
+    'PRECON_STRESS', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'keyword to indicate that absolute initial preconsolidation stresses (head) will be specified', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_delay_head = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'SPECIFIED_INITIAL_DELAY_HEAD', & ! tag name
+    'DELAY_HEAD', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'keyword to indicate that absolute initial delay bed heads will be specified', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_stress_lag = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'EFFECTIVE_STRESS_LAG', & ! tag name
+    'STRESS_LAG', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'keyword to indicate that specific storage will be calculate using the effective stress from the previous time step', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_strainibfr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'STRAINIB_FILERECORD', & ! tag name
+    'STRAINIBFR', & ! fortran variable
+    'RECORD STRAIN_CSV_INTERBED FILEOUT INTERBEDSTRAIN_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_csvinterbed = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'STRAIN_CSV_INTERBED', & ! tag name
+    'CSVINTERBED', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'budget keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_fileout = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_interbedstrainfn = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'INTERBEDSTRAIN_FILENAME', & ! tag name
+    'INTERBEDSTRAINFN', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_straincgfr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'STRAINCG_FILERECORD', & ! tag name
+    'STRAINCGFR', & ! fortran variable
+    'RECORD STRAIN_CSV_COARSE FILEOUT COARSESTRAIN_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_csvcoarse = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'STRAIN_CSV_COARSE', & ! tag name
+    'CSVCOARSE', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'budget keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_coarsestrainfn = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COARSESTRAIN_FILENAME', & ! tag name
+    'COARSESTRAINFN', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpfr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION_FILERECORD', & ! tag name
+    'CMPFR', & ! fortran variable
+    'RECORD COMPACTION FILEOUT COMPACTION_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_compaction = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION', & ! tag name
+    'COMPACTION', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'compaction keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpfn = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION_FILENAME', & ! tag name
+    'CMPFN', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpelasticfr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION_ELASTIC_FILERECORD', & ! tag name
+    'CMPELASTICFR', & ! fortran variable
+    'RECORD COMPACTION_ELASTIC FILEOUT ELASTIC_COMPACTION_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpelastic = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION_ELASTIC', & ! tag name
+    'CMPELASTIC', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'elastic interbed compaction keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_elasticcmpfn = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'ELASTIC_COMPACTION_FILENAME', & ! tag name
+    'ELASTICCMPFN', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpinelasticfr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION_INELASTIC_FILERECORD', & ! tag name
+    'CMPINELASTICFR', & ! fortran variable
+    'RECORD COMPACTION_INELASTIC FILEOUT INELASTIC_COMPACTION_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpinelastic = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION_INELASTIC', & ! tag name
+    'CMPINELASTIC', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'inelastic interbed compaction keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_inelasticcmpfn = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'INELASTIC_COMPACTION_FILENAME', & ! tag name
+    'INELASTICCMPFN', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpinterbedfr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION_INTERBED_FILERECORD', & ! tag name
+    'CMPINTERBEDFR', & ! fortran variable
+    'RECORD COMPACTION_INTERBED FILEOUT INTERBED_COMPACTION_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpinterbed = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION_INTERBED', & ! tag name
+    'CMPINTERBED', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'interbed compaction keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_interbedcmpfn = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'INTERBED_COMPACTION_FILENAME', & ! tag name
+    'INTERBEDCMPFN', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpcoarsefr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION_COARSE_FILERECORD', & ! tag name
+    'CMPCOARSEFR', & ! fortran variable
+    'RECORD COMPACTION_COARSE FILEOUT COARSE_COMPACTION_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpcoarse = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COMPACTION_COARSE', & ! tag name
+    'CMPCOARSE', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'coarse compaction keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cmpcoarsefn = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'COARSE_COMPACTION_FILENAME', & ! tag name
+    'CMPCOARSEFN', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_zdispfr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'ZDISPLACEMENT_FILERECORD', & ! tag name
+    'ZDISPFR', & ! fortran variable
+    'RECORD ZDISPLACEMENT FILEOUT ZDISPLACEMENT_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_zdisplacement = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'ZDISPLACEMENT', & ! tag name
+    'ZDISPLACEMENT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'budget keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_zdispfn = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'ZDISPLACEMENT_FILENAME', & ! tag name
+    'ZDISPFN', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_pkgconvergefr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'PACKAGE_CONVERGENCE_FILERECORD', & ! tag name
+    'PKGCONVERGEFR', & ! fortran variable
+    'RECORD PACKAGE_CONVERGENCE FILEOUT PACKAGE_CONVERGENCE_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_pkgconverge = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'PACKAGE_CONVERGENCE', & ! tag name
+    'PKGCONVERGE', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'package_convergence keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_pkgconvergefn = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'PACKAGE_CONVERGENCE_FILENAME', & ! tag name
+    'PKGCONVERGEFN', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_ts_filerecord = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'TS_FILERECORD', & ! tag name
+    'TS_FILERECORD', & ! fortran variable
+    'RECORD TS6 FILEIN TS6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_ts6 = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'TS6', & ! tag name
+    'TS6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'head keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_filein = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEIN', & ! tag name
+    'FILEIN', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_ts6_filename = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'TS6_FILENAME', & ! tag name
+    'TS6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file name of time series information', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_obs_filerecord = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'OBS_FILERECORD', & ! tag name
+    'OBS_FILERECORD', & ! fortran variable
+    'RECORD OBS6 FILEIN OBS6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_obs6 = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'OBS6', & ! tag name
+    'OBS6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'obs keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_obs6_filename = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'OPTIONS', & ! block
+    'OBS6_FILENAME', & ! tag name
+    'OBS6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'obs6 input filename', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_ninterbeds = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'DIMENSIONS', & ! block
+    'NINTERBEDS', & ! tag name
+    'NINTERBEDS', & ! fortran variable
+    'INTEGER', & ! type
+    '', & ! shape
+    'number of CSUB interbed systems', & ! longname
+    .true., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_maxbound = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'DIMENSIONS', & ! block
+    'MAXSIG0', & ! tag name
+    'MAXBOUND', & ! fortran variable
+    'INTEGER', & ! type
+    '', & ! shape
+    'maximum number of stress offset cells', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cg_ske_cr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'GRIDDATA', & ! block
+    'CG_SKE_CR', & ! tag name
+    'CG_SKE_CR', & ! fortran variable
+    'DOUBLE1D', & ! type
+    'NODES', & ! shape
+    'elastic coarse specific storage', & ! longname
+    .true., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .true., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cg_theta = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'GRIDDATA', & ! block
+    'CG_THETA', & ! tag name
+    'CG_THETA', & ! fortran variable
+    'DOUBLE1D', & ! type
+    'NODES', & ! shape
+    'initial coarse-grained material porosity', & ! longname
+    .true., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .true., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_sgm = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'GRIDDATA', & ! block
+    'SGM', & ! tag name
+    'SGM', & ! fortran variable
+    'DOUBLE1D', & ! type
+    'NODES', & ! shape
+    'specific gravity of moist sediments', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .true., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_sgs = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'GRIDDATA', & ! block
+    'SGS', & ! tag name
+    'SGS', & ! fortran variable
+    'DOUBLE1D', & ! type
+    'NODES', & ! shape
+    'specific gravity of saturated sediments', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .true., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_icsubno = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'ICSUBNO', & ! tag name
+    'ICSUBNO', & ! fortran variable
+    'INTEGER', & ! type
+    '', & ! shape
+    'CSUB id number for this entry', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cellid_pkgdata = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'CELLID', & ! tag name
+    'CELLID_PKGDATA', & ! fortran variable
+    'INTEGER1D', & ! type
+    'NCELLDIM', & ! shape
+    'cell identifier', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cdelay = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'CDELAY', & ! tag name
+    'CDELAY', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'delay type', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_pcs0 = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'PCS0', & ! tag name
+    'PCS0', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'initial stress', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_thick_frac = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'THICK_FRAC', & ! tag name
+    'THICK_FRAC', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'interbed thickness or cell fraction', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_rnb = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'RNB', & ! tag name
+    'RNB', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'delay interbed material factor', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_ssv_cc = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'SSV_CC', & ! tag name
+    'SSV_CC', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'initial interbed inelastic specific storage', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_sse_cr = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'SSE_CR', & ! tag name
+    'SSE_CR', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'initial interbed elastic specific storage', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_theta = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'THETA', & ! tag name
+    'THETA', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'initial interbed porosity', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_kv = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'KV', & ! tag name
+    'KV', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'delay interbed vertical hydraulic conductivity', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_h0 = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'H0', & ! tag name
+    'H0', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'initial delay interbed head', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_boundname = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'BOUNDNAME', & ! tag name
+    'BOUNDNAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'well name', & ! longname
+    .false., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_cellid = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PERIOD', & ! block
+    'CELLID', & ! tag name
+    'CELLID', & ! fortran variable
+    'INTEGER1D', & ! type
+    'NCELLDIM', & ! shape
+    'cell identifier', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_sig0 = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PERIOD', & ! block
+    'SIG0', & ! tag name
+    'SIG0', & ! fortran variable
+    'DOUBLE', & ! type
+    '', & ! shape
+    'well stress offset', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .true. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwf_csub_param_definitions(*) = &
+    [ &
+    gwfcsub_boundnames, &
+    gwfcsub_print_input, &
+    gwfcsub_save_flows, &
+    gwfcsub_gammaw, &
+    gwfcsub_beta, &
+    gwfcsub_head_based, &
+    gwfcsub_precon_head, &
+    gwfcsub_ndelaycells, &
+    gwfcsub_icompress, &
+    gwfcsub_matprop, &
+    gwfcsub_cell_fraction, &
+    gwfcsub_interbed_state, &
+    gwfcsub_precon_stress, &
+    gwfcsub_delay_head, &
+    gwfcsub_stress_lag, &
+    gwfcsub_strainibfr, &
+    gwfcsub_csvinterbed, &
+    gwfcsub_fileout, &
+    gwfcsub_interbedstrainfn, &
+    gwfcsub_straincgfr, &
+    gwfcsub_csvcoarse, &
+    gwfcsub_coarsestrainfn, &
+    gwfcsub_cmpfr, &
+    gwfcsub_compaction, &
+    gwfcsub_cmpfn, &
+    gwfcsub_cmpelasticfr, &
+    gwfcsub_cmpelastic, &
+    gwfcsub_elasticcmpfn, &
+    gwfcsub_cmpinelasticfr, &
+    gwfcsub_cmpinelastic, &
+    gwfcsub_inelasticcmpfn, &
+    gwfcsub_cmpinterbedfr, &
+    gwfcsub_cmpinterbed, &
+    gwfcsub_interbedcmpfn, &
+    gwfcsub_cmpcoarsefr, &
+    gwfcsub_cmpcoarse, &
+    gwfcsub_cmpcoarsefn, &
+    gwfcsub_zdispfr, &
+    gwfcsub_zdisplacement, &
+    gwfcsub_zdispfn, &
+    gwfcsub_pkgconvergefr, &
+    gwfcsub_pkgconverge, &
+    gwfcsub_pkgconvergefn, &
+    gwfcsub_ts_filerecord, &
+    gwfcsub_ts6, &
+    gwfcsub_filein, &
+    gwfcsub_ts6_filename, &
+    gwfcsub_obs_filerecord, &
+    gwfcsub_obs6, &
+    gwfcsub_obs6_filename, &
+    gwfcsub_ninterbeds, &
+    gwfcsub_maxbound, &
+    gwfcsub_cg_ske_cr, &
+    gwfcsub_cg_theta, &
+    gwfcsub_sgm, &
+    gwfcsub_sgs, &
+    gwfcsub_icsubno, &
+    gwfcsub_cellid_pkgdata, &
+    gwfcsub_cdelay, &
+    gwfcsub_pcs0, &
+    gwfcsub_thick_frac, &
+    gwfcsub_rnb, &
+    gwfcsub_ssv_cc, &
+    gwfcsub_sse_cr, &
+    gwfcsub_theta, &
+    gwfcsub_kv, &
+    gwfcsub_h0, &
+    gwfcsub_boundname, &
+    gwfcsub_cellid, &
+    gwfcsub_sig0 &
+    ]
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_packagedata = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PACKAGEDATA', & ! block
+    'PACKAGEDATA', & ! tag name
+    'PACKAGEDATA', & ! fortran variable
+    'RECARRAY ICSUBNO CELLID CDELAY PCS0 THICK_FRAC RNB SSV_CC SSE_CR THETA KV H0 BOUNDNAME', & ! type
+    'NINTERBEDS', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfcsub_spd = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'CSUB', & ! subcomponent
+    'PERIOD', & ! block
+    'STRESS_PERIOD_DATA', & ! tag name
+    'SPD', & ! fortran variable
+    'RECARRAY CELLID SIG0', & ! type
+    'MAXSIG0', & ! shape
+    '', & ! longname
+    .true., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwf_csub_aggregate_definitions(*) = &
+    [ &
+    gwfcsub_packagedata, &
+    gwfcsub_spd &
+    ]
+
+  type(InputBlockDefinitionType), parameter :: &
+    gwf_csub_block_definitions(*) = &
+    [ &
+    InputBlockDefinitionType( &
+    'OPTIONS', & ! blockname
+    .false., & ! required
+    .false., & ! aggregate
+    .false. & ! block_variable
+    ), &
+    InputBlockDefinitionType( &
+    'DIMENSIONS', & ! blockname
+    .true., & ! required
+    .false., & ! aggregate
+    .false. & ! block_variable
+    ), &
+    InputBlockDefinitionType( &
+    'GRIDDATA', & ! blockname
+    .true., & ! required
+    .false., & ! aggregate
+    .false. & ! block_variable
+    ), &
+    InputBlockDefinitionType( &
+    'PACKAGEDATA', & ! blockname
+    .false., & ! required
+    .true., & ! aggregate
+    .false. & ! block_variable
+    ), &
+    InputBlockDefinitionType( &
+    'PERIOD', & ! blockname
+    .true., & ! required
+    .true., & ! aggregate
+    .true. & ! block_variable
+    ) &
+    ]
+
+end module GwfCsubInputModule

--- a/src/Idm/selector/IdmGwfDfnSelector.f90
+++ b/src/Idm/selector/IdmGwfDfnSelector.f90
@@ -7,6 +7,7 @@ module IdmGwfDfnSelectorModule
                                    InputBlockDefinitionType
   use GwfNamInputModule
   use GwfChdInputModule
+  use GwfCsubInputModule
   use GwfDisInputModule
   use GwfDisuInputModule
   use GwfDisvInputModule
@@ -62,6 +63,8 @@ contains
       call set_param_pointer(input_definition, gwf_nam_param_definitions)
     case ('CHD')
       call set_param_pointer(input_definition, gwf_chd_param_definitions)
+    case ('CSUB')
+      call set_param_pointer(input_definition, gwf_csub_param_definitions)
     case ('DIS')
       call set_param_pointer(input_definition, gwf_dis_param_definitions)
     case ('DISU')
@@ -108,6 +111,8 @@ contains
       call set_param_pointer(input_definition, gwf_nam_aggregate_definitions)
     case ('CHD')
       call set_param_pointer(input_definition, gwf_chd_aggregate_definitions)
+    case ('CSUB')
+      call set_param_pointer(input_definition, gwf_csub_aggregate_definitions)
     case ('DIS')
       call set_param_pointer(input_definition, gwf_dis_aggregate_definitions)
     case ('DISU')
@@ -154,6 +159,8 @@ contains
       call set_block_pointer(input_definition, gwf_nam_block_definitions)
     case ('CHD')
       call set_block_pointer(input_definition, gwf_chd_block_definitions)
+    case ('CSUB')
+      call set_block_pointer(input_definition, gwf_csub_block_definitions)
     case ('DIS')
       call set_block_pointer(input_definition, gwf_dis_block_definitions)
     case ('DISU')
@@ -199,6 +206,8 @@ contains
       multi_package = gwf_nam_multi_package
     case ('CHD')
       multi_package = gwf_chd_multi_package
+    case ('CSUB')
+      multi_package = gwf_csub_multi_package
     case ('DIS')
       multi_package = gwf_dis_multi_package
     case ('DISU')
@@ -247,6 +256,8 @@ contains
       call set_subpkg_pointer(subpackages, gwf_nam_subpackages)
     case ('CHD')
       call set_subpkg_pointer(subpackages, gwf_chd_subpackages)
+    case ('CSUB')
+      call set_subpkg_pointer(subpackages, gwf_csub_subpackages)
     case ('DIS')
       call set_subpkg_pointer(subpackages, gwf_dis_subpackages)
     case ('DISU')
@@ -292,6 +303,8 @@ contains
     case ('NAM')
       integrated = .true.
     case ('CHD')
+      integrated = .true.
+    case ('CSUB')
       integrated = .true.
     case ('DIS')
       integrated = .true.

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -27,19 +27,15 @@ module GwfCsubModule
   use NumericalPackageModule, only: NumericalPackageType
   use ObserveModule, only: ObserveType
   use ObsModule, only: ObsType, obs_cr
-  use BlockParserModule, only: BlockParserType
-  use TimeSeriesLinkModule, only: TimeSeriesLinkType, &
-                                  GetTimeSeriesLinkFromList
   use GeomUtilModule, only: get_node
   use InputOutputModule, only: extract_idnum_or_bndname
   use BaseDisModule, only: DisBaseType
   use SimModule, only: count_errors, store_error, store_error_unit, &
-                       store_warning
+                       store_warning, store_error_filename
   use SimVariablesModule, only: errmsg, warnmsg
   use SortModule, only: qsort, selectn
+  use BlockParserModule, only: BlockParserType
   !
-  use TimeSeriesLinkModule, only: TimeSeriesLinkType
-  use TimeSeriesManagerModule, only: TimeSeriesManagerType, tsmanager_cr
   use ListModule, only: ListType
   use TableModule, only: TableType, table_cr
   !
@@ -216,9 +212,6 @@ module GwfCsubModule
     integer(I4B), dimension(:), pointer, contiguous :: nodelistsig0 => null() !< vector of reduced node numbers
     real(DP), dimension(:), pointer, contiguous :: sig0 => null() !< array of package specific boundary numbers
     !
-    ! -- timeseries
-    type(TimeSeriesManagerType), pointer :: TsManager => null() !< time series manager
-    !
     ! -- observation data
     integer(I4B), pointer :: inobspkg => null() !< unit number for obs package
     type(ObsType), pointer :: obs => null() !< observation package
@@ -230,7 +223,8 @@ module GwfCsubModule
 
   contains
     procedure :: define_listlabel
-    procedure :: read_options
+    procedure :: source_options
+    procedure :: log_options
     procedure :: csub_ar
     procedure :: csub_da
     procedure :: csub_rp
@@ -243,10 +237,11 @@ module GwfCsubModule
     procedure :: csub_save_model_flows
     procedure :: csub_ot_dv
     procedure :: csub_fp
-    procedure :: read_dimensions => csub_read_dimensions
+    procedure :: source_dimensions => csub_source_dimensions
     procedure, private :: csub_allocate_scalars
     procedure, private :: csub_allocate_arrays
-    procedure, private :: csub_read_packagedata
+    procedure, private :: csub_source_griddata
+    procedure, private :: csub_source_packagedata
     !
     ! -- helper methods
     procedure, private :: csub_calc_void_ratio
@@ -321,10 +316,12 @@ contains
   !!  Create a new CSUB object
   !!
   !<
-  subroutine csub_cr(csubobj, name_model, istounit, stoPckName, inunit, iout)
+  subroutine csub_cr(csubobj, name_model, mempath, istounit, stoPckName, inunit, &
+                     iout)
     ! -- dummy variables
     type(GwfCsubType), pointer :: csubobj !< pointer to default package type
     character(len=*), intent(in) :: name_model !< model name
+    character(len=*), intent(in) :: mempath !< input context mem path
     integer(I4B), intent(in) :: inunit !< unit number of csub input file
     integer(I4B), intent(in) :: istounit !< unit number of storage package
     character(len=*), intent(in) :: stoPckName !< name of the storage package
@@ -335,7 +332,7 @@ contains
     allocate (csubobj)
 
     ! -- create name and memory path
-    call csubobj%set_names(1, name_model, 'CSUB', 'CSUB')
+    call csubobj%set_names(1, name_model, 'CSUB', 'CSUB', mempath)
     !
     ! -- Allocate scalars
     call csubobj%csub_allocate_scalars()
@@ -347,9 +344,6 @@ contains
     csubobj%istounit = istounit
     csubobj%inunit = inunit
     csubobj%iout = iout
-    !
-    ! -- Initialize block parser
-    call csubobj%parser%Initialize(csubobj%inunit, csubobj%iout)
   end subroutine csub_cr
 
   !> @ brief Allocate and read method for package
@@ -367,19 +361,8 @@ contains
     class(DisBaseType), pointer, intent(in) :: dis !< model discretization
     integer(I4B), dimension(:), pointer, contiguous :: ibound !< model ibound array
     ! -- local variables
-    logical(LGP) :: isfound, endOfBlock
-    character(len=:), allocatable :: line
-    character(len=LINELENGTH) :: keyword
     character(len=20) :: cellid
-    integer(I4B) :: iske
-    integer(I4B) :: istheta
-    integer(I4B) :: isgm
-    integer(I4B) :: isgs
     integer(I4B) :: idelay
-    integer(I4B) :: ierr
-    integer(I4B) :: lloc
-    integer(I4B) :: istart
-    integer(I4B) :: istop
     integer(I4B) :: ib
     integer(I4B) :: node
     integer(I4B) :: istoerr
@@ -392,109 +375,37 @@ contains
     ! -- format
     character(len=*), parameter :: fmtcsub = &
       "(1x,/1x,'CSUB -- COMPACTION PACKAGE, VERSION 1, 12/15/2019', &
-     &' INPUT READ FROM UNIT ', i0, //)"
+     &' INPUT READ FROM MEMPATH: ', A, /)"
     !
     ! --print a message identifying the csub package.
-    write (this%iout, fmtcsub) this%inunit
+    write (this%iout, fmtcsub) this%input_mempath
     !
     ! -- store pointers to arguments that were passed in
     this%dis => dis
     this%ibound => ibound
     !
-    ! -- Create time series managers
-    call tsmanager_cr(this%TsManager, this%iout)
-    !
     ! -- create obs package
     call obs_cr(this%obs, this%inobspkg)
     !
-    ! -- Read csub options
-    call this%read_options()
+    ! -- source csub options
+    call this%source_options()
     !
-    ! -- Now that time series will have been read, need to call the df
-    !    routine to define the manager
-    call this%tsmanager%tsmanager_df()
-    !
-    ! -- Read the csub dimensions
-    call this%read_dimensions()
+    ! -- source the csub dimensions
+    call this%source_dimensions()
     !
     ! - observation data
     call this%obs%obs_ar()
     !
     ! -- terminate if errors dimensions block data
     if (count_errors() > 0) then
-      call this%parser%StoreErrorUnit()
+      call store_error_filename(this%input_fname)
     end if
 
     ! -- Allocate arrays in
     call this%csub_allocate_arrays()
     !
-    ! -- initialize local variables
-    iske = 0
-    istheta = 0
-    isgm = 0
-    isgs = 0
-    !
-    ! -- read griddata block
-    call this%parser%GetBlock('GRIDDATA', isfound, ierr)
-    if (isfound) then
-      do
-        call this%parser%GetNextLine(endOfBlock)
-        if (endOfBlock) exit
-        call this%parser%GetStringCaps(keyword)
-        call this%parser%GetRemainingLine(line)
-        lloc = 1
-        select case (keyword)
-        case ('CG_SKE_CR')
-          call this%dis%read_grid_array(line, lloc, istart, istop, &
-                                        this%iout, this%parser%iuactive, &
-                                        this%cg_ske_cr, 'CG_SKE_CR')
-          iske = 1
-        case ('CG_THETA')
-          call this%dis%read_grid_array(line, lloc, istart, istop, &
-                                        this%iout, this%parser%iuactive, &
-                                        this%cg_thetaini, 'CG_THETA')
-          istheta = 1
-        case ('SGM')
-          call this%dis%read_grid_array(line, lloc, istart, istop, &
-                                        this%iout, this%parser%iuactive, &
-                                        this%sgm, 'SGM')
-          isgm = 1
-        case ('SGS')
-          call this%dis%read_grid_array(line, lloc, istart, istop, &
-                                        this%iout, this%parser%iuactive, &
-                                        this%sgs, 'SGS')
-          isgs = 1
-        case default
-          write (errmsg, '(a,1x,a,a)') &
-            "Unknown GRIDDATA tag '", trim(keyword), "'."
-          call store_error(errmsg)
-        end select
-      end do
-    else
-      call store_error('Required GRIDDATA block not found.')
-    end if
-    !
-    ! -- determine if cg_ske and cg_theta have been specified
-    if (iske == 0) then
-      write (errmsg, '(a)') 'CG_SKE GRIDDATA must be specified.'
-      call store_error(errmsg)
-    end if
-    if (istheta == 0) then
-      write (errmsg, '(a)') 'CG_THETA GRIDDATA must be specified.'
-      call store_error(errmsg)
-    end if
-    !
-    ! -- determine if sgm and sgs have been specified, if not assign default values
-    if (isgm == 0) then
-      do node = 1, this%dis%nodes
-        this%sgm(node) = 1.7D0
-      end do
-    end if
-    if (isgs == 0) then
-      do node = 1, this%dis%nodes
-        this%sgs(node) = 2.0D0
-      end do
-    end if
+    ! -- source griddata
+    call this%csub_source_griddata()
     !
     ! -- evaluate the coarse-grained material properties and if
     !    non-zero specific storage values are specified in the
@@ -536,9 +447,9 @@ contains
       call store_error(errmsg)
     end if
     !
-    ! -- read interbed data
+    ! -- source interbed data
     if (this%ninterbeds > 0) then
-      call this%csub_read_packagedata()
+      call this%csub_source_packagedata()
     end if
     !
     ! setup package convergence tables
@@ -578,7 +489,7 @@ contains
     !
     ! -- terminate if errors griddata, packagedata blocks, TDIS, or STO data
     if (count_errors() > 0) then
-      call this%parser%StoreErrorUnit()
+      call store_error_filename(this%input_fname)
     end if
     !
     ! -- set current coarse-grained thickness (cg_thick) and
@@ -592,35 +503,181 @@ contains
     end if
   end subroutine csub_ar
 
-  !> @ brief Read options for package
+  !> @ brief Source options for package
   !!
   !!  Read options block for CSUB package.
   !!
   !<
-  subroutine read_options(this)
+  subroutine source_options(this)
     ! -- modules
     use ConstantsModule, only: MAXCHARLEN, DZERO, MNORMAL
     use MemoryManagerModule, only: mem_reallocate
+    use MemoryManagerExtModule, only: mem_set_value
     use OpenSpecModule, only: access, form
     use InputOutputModule, only: getunit, urdaux, openfile
+    use GwfCsubInputModule, only: GwfCsubParamFoundType
+    use SourceCommonModule, only: filein_fname
     ! -- dummy variables
     class(GwfCsubType), intent(inout) :: this
     ! -- local variables
-    character(len=LINELENGTH) :: keyword
-    character(len=:), allocatable :: line
-    character(len=MAXCHARLEN) :: fname
-    character(len=LENAUXNAME), dimension(:), allocatable :: caux
-    logical(LGP) :: isfound
-    logical(LGP) :: endOfBlock
-    integer(I4B) :: n
-    integer(I4B) :: lloc
-    integer(I4B) :: istart
-    integer(I4B) :: istop
-    integer(I4B) :: ierr
+    integer(I4B), pointer :: ibs
     integer(I4B) :: inobs
-    integer(I4B) :: ibrg
-    integer(I4B) :: ieslag
-    integer(I4B) :: isetgamma
+    character(len=LINELENGTH) :: csv_interbed, csv_coarse
+    character(len=LINELENGTH) :: cmp_fn, ecmp_fn, iecmp_fn, ibcmp_fn, cmpcoarse_fn
+    character(len=LINELENGTH) :: zdisp_fn, pkg_converge_fn
+    type(GwfCsubParamFoundType) :: found
+    logical(LGP) :: warn_estress_lag = .false.
+
+    ! -- allocate and initialize variables
+    allocate (ibs)
+    ibs = 0
+
+    ! -- update defaults from input context
+    call mem_set_value(this%inamedbound, 'BOUNDNAMES', this%input_mempath, &
+                       found%boundnames)
+    call mem_set_value(this%iprpak, 'PRINT_INPUT', this%input_mempath, &
+                       found%print_input)
+    call mem_set_value(this%ipakcb, 'SAVE_FLOWS', this%input_mempath, &
+                       found%save_flows)
+    call mem_set_value(this%gammaw, 'GAMMAW', this%input_mempath, found%gammaw)
+    call mem_set_value(this%beta, 'BETA', this%input_mempath, found%beta)
+    call mem_set_value(this%ipch, 'HEAD_BASED', this%input_mempath, &
+                       found%head_based)
+    call mem_set_value(this%ipch, 'PRECON_HEAD', this%input_mempath, &
+                       found%precon_head)
+    call mem_set_value(this%ndelaycells, 'NDELAYCELLS', this%input_mempath, &
+                       found%ndelaycells)
+    call mem_set_value(this%istoragec, 'ICOMPRESS', this%input_mempath, &
+                       found%icompress)
+    call mem_set_value(this%iupdatematprop, 'MATPROP', this%input_mempath, &
+                       found%matprop)
+    call mem_set_value(this%icellf, 'CELL_FRACTION', this%input_mempath, &
+                       found%cell_fraction)
+    call mem_set_value(ibs, 'INTERBED_STATE', this%input_mempath, &
+                       found%interbed_state)
+    call mem_set_value(this%ispecified_pcs, 'PRECON_STRESS', this%input_mempath, &
+                       found%precon_stress)
+    call mem_set_value(this%ispecified_dbh, 'DELAY_HEAD', this%input_mempath, &
+                       found%delay_head)
+    call mem_set_value(this%ieslag, 'STRESS_LAG', this%input_mempath, &
+                       found%stress_lag)
+    call mem_set_value(csv_interbed, 'INTERBEDSTRAINFN', this%input_mempath, &
+                       found%interbedstrainfn)
+    call mem_set_value(csv_coarse, 'COARSESTRAINFN', this%input_mempath, &
+                       found%coarsestrainfn)
+    call mem_set_value(cmp_fn, 'CMPFN', this%input_mempath, found%cmpfn)
+    call mem_set_value(ecmp_fn, 'ELASTICCMPFN', this%input_mempath, &
+                       found%elasticcmpfn)
+    call mem_set_value(iecmp_fn, 'INELASTICCMPFN', this%input_mempath, &
+                       found%inelasticcmpfn)
+    call mem_set_value(ibcmp_fn, 'INTERBEDCMPFN', this%input_mempath, &
+                       found%interbedcmpfn)
+    call mem_set_value(cmpcoarse_fn, 'CMPCOARSEFN', this%input_mempath, &
+                       found%cmpcoarsefn)
+    call mem_set_value(zdisp_fn, 'ZDISPFN', this%input_mempath, found%zdispfn)
+    call mem_set_value(pkg_converge_fn, 'PKGCONVERGEFN', this%input_mempath, &
+                       found%pkgconvergefn)
+
+    ! -- enforce 0 or 1 OBS6_FILENAME entries in option block
+    if (filein_fname(this%obs%inputFilename, 'OBS6_FILENAME', &
+                     this%input_mempath, this%input_fname)) then
+      this%obs%active = .true.
+      inobs = GetUnit()
+      call openfile(inobs, this%iout, this%obs%inputFilename, 'OBS')
+      this%obs%inUnitObs = inobs
+      this%inobspkg = inobs
+      call this%obs%obs_df(this%iout, this%packName, this%filtyp, this%dis)
+      call this%csub_df_obs()
+    end if
+
+    ! -- update input dependent internal state
+    if (found%save_flows) this%ipakcb = -1
+    if (found%head_based) then
+      this%lhead_based = .TRUE.
+      if (this%ieslag /= 0) then
+        this%ieslag = 0
+        warn_estress_lag = .true.
+      end if
+    end if
+    if (found%icompress) this%istoragec = 0
+    if (found%interbed_state) then
+      this%ispecified_pcs = 1
+      this%ispecified_dbh = 1
+    end if
+    if (found%gammaw .or. found%beta) then
+      this%brg = this%gammaw * this%beta
+    end if
+
+    ! fileout options
+    if (found%interbedstrainfn) then
+      this%istrainib = getunit()
+      call openfile(this%istrainib, this%iout, csv_interbed, 'CSV_OUTPUT', &
+                    filstat_opt='REPLACE', mode_opt=MNORMAL)
+    end if
+    if (found%coarsestrainfn) then
+      this%istrainsk = getunit()
+      call openfile(this%istrainsk, this%iout, csv_coarse, 'CSV_OUTPUT', &
+                    filstat_opt='REPLACE', mode_opt=MNORMAL)
+    end if
+    if (found%cmpfn) then
+      this%ioutcomp = getunit()
+      call openfile(this%ioutcomp, this%iout, cmp_fn, 'DATA(BINARY)', &
+                    form, access, 'REPLACE', mode_opt=MNORMAL)
+    end if
+    if (found%elasticcmpfn) then
+      this%ioutcompe = getunit()
+      call openfile(this%ioutcompe, this%iout, ecmp_fn, &
+                    'DATA(BINARY)', form, access, 'REPLACE', &
+                    mode_opt=MNORMAL)
+    end if
+    if (found%inelasticcmpfn) then
+      this%ioutcompi = getunit()
+      call openfile(this%ioutcompi, this%iout, iecmp_fn, &
+                    'DATA(BINARY)', form, access, 'REPLACE', &
+                    mode_opt=MNORMAL)
+    end if
+    if (found%interbedcmpfn) then
+      this%ioutcompib = getunit()
+      call openfile(this%ioutcompib, this%iout, ibcmp_fn, &
+                    'DATA(BINARY)', form, access, 'REPLACE', &
+                    mode_opt=MNORMAL)
+    end if
+    if (found%cmpcoarsefn) then
+      this%ioutcomps = getunit()
+      call openfile(this%ioutcomps, this%iout, cmpcoarse_fn, &
+                    'DATA(BINARY)', form, access, 'REPLACE', &
+                    mode_opt=MNORMAL)
+    end if
+    if (found%zdispfn) then
+      this%ioutzdisp = getunit()
+      call openfile(this%ioutzdisp, this%iout, zdisp_fn, &
+                    'DATA(BINARY)', form, access, 'REPLACE', &
+                    mode_opt=MNORMAL)
+    end if
+    if (found%pkgconvergefn) then
+      this%ipakcsv = getunit()
+      call openfile(this%ipakcsv, this%iout, pkg_converge_fn, 'CSV', &
+                    filstat_opt='REPLACE', mode_opt=MNORMAL)
+    end if
+
+    ! -- log user options
+    call this%log_options(warn_estress_lag)
+
+    ! -- cleanup
+    deallocate (ibs)
+  end subroutine source_options
+
+  !> @ brief log options for package
+  !!
+  !!  log options block for CSUB package.
+  !!
+  !<
+  subroutine log_options(this, warn_estress_lag)
+    ! -- modules
+    ! -- dummy variables
+    class(GwfCsubType), intent(inout) :: this
+    logical(LGP), intent(in) :: warn_estress_lag
+    ! -- local variables
     ! -- formats
     character(len=*), parameter :: fmtts = &
       &"(4x,'TIME-SERIES DATA WILL BE READ FROM FILE: ',a)"
@@ -641,290 +698,6 @@ contains
     character(len=*), parameter :: fmtfileout = &
       "(4x,'CSUB ',1x,a,1x,' WILL BE SAVED TO FILE: ',a,/4x,&
       &'OPENED ON UNIT: ',I7)"
-    !
-    ! -- initialize variables
-    ibrg = 0
-    ieslag = 0
-    isetgamma = 0
-    !
-    ! -- get options block
-    call this%parser%GetBlock('OPTIONS', isfound, ierr, blockRequired=.false., &
-                              supportOpenClose=.true.)
-    !
-    ! -- parse options block if detected
-    if (isfound) then
-      write (this%iout, '(1x,a)') 'PROCESSING CSUB OPTIONS'
-      do
-        call this%parser%GetNextLine(endOfBlock)
-        if (endOfBlock) then
-          exit
-        end if
-        call this%parser%GetStringCaps(keyword)
-        select case (keyword)
-        case ('AUX', 'AUXILIARY')
-          call this%parser%GetRemainingLine(line)
-          lloc = 1
-          call urdaux(this%naux, this%parser%iuactive, this%iout, lloc, &
-                      istart, istop, caux, line, this%packName)
-          call mem_reallocate(this%auxname, LENAUXNAME, this%naux, &
-                              'AUXNAME', this%memoryPath)
-          do n = 1, this%naux
-            this%auxname(n) = caux(n)
-          end do
-          deallocate (caux)
-        case ('SAVE_FLOWS')
-          this%ipakcb = -1
-          write (this%iout, fmtflow2)
-        case ('PRINT_INPUT')
-          this%iprpak = 1
-          write (this%iout, '(4x,a)') &
-            'LISTS OF '//trim(adjustl(this%packName))//' CELLS WILL BE PRINTED.'
-        case ('PRINT_FLOWS')
-          this%iprflow = 1
-          write (this%iout, '(4x,a)') trim(adjustl(this%packName))// &
-            ' FLOWS WILL BE PRINTED TO LISTING FILE.'
-        case ('BOUNDNAMES')
-          this%inamedbound = 1
-          write (this%iout, '(4x,a)') trim(adjustl(this%packName))// &
-            ' BOUNDARIES HAVE NAMES IN LAST COLUMN.' ! user specified boundnames
-        case ('TS6')
-          call this%parser%GetStringCaps(keyword)
-          if (trim(adjustl(keyword)) /= 'FILEIN') then
-            errmsg = 'TS6 keyword must be followed by "FILEIN" '// &
-                     'then by filename.'
-            call store_error(errmsg)
-            call this%parser%StoreErrorUnit()
-          end if
-          call this%parser%GetString(fname)
-          write (this%iout, fmtts) trim(fname)
-          call this%TsManager%add_tsfile(fname, this%inunit)
-        case ('OBS6')
-          call this%parser%GetStringCaps(keyword)
-          if (trim(adjustl(keyword)) /= 'FILEIN') then
-            errmsg = 'OBS6 keyword must be followed by "FILEIN" '// &
-                     'then by filename.'
-            call store_error(errmsg)
-          end if
-          if (this%obs%active) then
-            errmsg = 'Multiple OBS6 keywords detected in OPTIONS block. '// &
-                     'Only one OBS6 entry allowed for a package.'
-            call store_error(errmsg)
-          end if
-          this%obs%active = .true.
-          call this%parser%GetString(this%obs%inputFilename)
-          inobs = GetUnit()
-          call openfile(inobs, this%iout, this%obs%inputFilename, 'OBS')
-          this%obs%inUnitObs = inobs
-          this%inobspkg = inobs
-
-          call this%obs%obs_df(this%iout, this%packName, this%filtyp, this%dis)
-          call this%csub_df_obs()
-          !
-          ! -- CSUB specific options
-        case ('GAMMAW')
-          this%gammaw = this%parser%GetDouble()
-          ibrg = 1
-        case ('BETA')
-          this%beta = this%parser%GetDouble()
-          ibrg = 1
-        case ('HEAD_BASED')
-          this%ipch = 1
-          this%lhead_based = .TRUE.
-        case ('INITIAL_PRECONSOLIDATION_HEAD')
-          this%ipch = 1
-        case ('NDELAYCELLS')
-          this%ndelaycells = this%parser%GetInteger()
-          !
-          ! -- compression indices (CR amd CC) will be specified instead of
-          !    storage coefficients (SSE and SSV)
-        case ('COMPRESSION_INDICES')
-          this%istoragec = 0
-          !
-          ! -- variable thickness and void ratio
-        case ('UPDATE_MATERIAL_PROPERTIES')
-          this%iupdatematprop = 1
-          !
-          ! -- cell fraction will be specified instead of interbed thickness
-        case ('CELL_FRACTION')
-          this%icellf = 1
-          !
-          ! -- specified initial pcs and delay bed heads
-        case ('SPECIFIED_INITIAL_INTERBED_STATE')
-          this%ispecified_pcs = 1
-          this%ispecified_dbh = 1
-          !
-          ! -- specified initial pcs
-        case ('SPECIFIED_INITIAL_PRECONSOLIDATION_STRESS')
-          this%ispecified_pcs = 1
-          !
-          ! -- specified initial delay bed heads
-        case ('SPECIFIED_INITIAL_DELAY_HEAD')
-          this%ispecified_dbh = 1
-          !
-          ! -- lag the effective stress used to calculate storage properties
-        case ('EFFECTIVE_STRESS_LAG')
-          ieslag = 1
-          !
-          ! -- strain table options
-        case ('STRAIN_CSV_INTERBED')
-          call this%parser%GetStringCaps(keyword)
-          if (keyword == 'FILEOUT') then
-            call this%parser%GetString(fname)
-            this%istrainib = getunit()
-            call openfile(this%istrainib, this%iout, fname, 'CSV_OUTPUT', &
-                          filstat_opt='REPLACE', mode_opt=MNORMAL)
-            write (this%iout, fmtfileout) &
-              'INTERBED STRAIN CSV', fname, this%istrainib
-          else
-            errmsg = 'Optional STRAIN_CSV_INTERBED keyword must be '// &
-                     'followed by FILEOUT.'
-            call store_error(errmsg)
-          end if
-        case ('STRAIN_CSV_COARSE')
-          call this%parser%GetStringCaps(keyword)
-          if (keyword == 'FILEOUT') then
-            call this%parser%GetString(fname)
-            this%istrainsk = getunit()
-            call openfile(this%istrainsk, this%iout, fname, 'CSV_OUTPUT', &
-                          filstat_opt='REPLACE', mode_opt=MNORMAL)
-            write (this%iout, fmtfileout) &
-              'COARSE STRAIN CSV', fname, this%istrainsk
-          else
-            errmsg = 'Optional STRAIN_CSV_COARSE keyword must be '// &
-                     'followed by fileout.'
-            call store_error(errmsg)
-          end if
-          !
-          ! -- compaction output
-        case ('COMPACTION')
-          call this%parser%GetStringCaps(keyword)
-          if (keyword == 'FILEOUT') then
-            call this%parser%GetString(fname)
-            this%ioutcomp = getunit()
-            call openfile(this%ioutcomp, this%iout, fname, 'DATA(BINARY)', &
-                          form, access, 'REPLACE', mode_opt=MNORMAL)
-            write (this%iout, fmtfileout) &
-              'COMPACTION', fname, this%ioutcomp
-          else
-            errmsg = 'Optional COMPACTION keyword must be '// &
-                     'followed by FILEOUT.'
-            call store_error(errmsg)
-          end if
-        case ('COMPACTION_INELASTIC')
-          call this%parser%GetStringCaps(keyword)
-          if (keyword == 'FILEOUT') then
-            call this%parser%GetString(fname)
-            this%ioutcompi = getunit()
-            call openfile(this%ioutcompi, this%iout, fname, &
-                          'DATA(BINARY)', form, access, 'REPLACE', &
-                          mode_opt=MNORMAL)
-            write (this%iout, fmtfileout) &
-              'COMPACTION_INELASTIC', fname, this%ioutcompi
-          else
-            errmsg = 'Optional COMPACTION_INELASTIC keyword must be '// &
-                     'followed by fileout.'
-            call store_error(errmsg)
-          end if
-        case ('COMPACTION_ELASTIC')
-          call this%parser%GetStringCaps(keyword)
-          if (keyword == 'FILEOUT') then
-            call this%parser%GetString(fname)
-            this%ioutcompe = getunit()
-            call openfile(this%ioutcompe, this%iout, fname, &
-                          'DATA(BINARY)', form, access, 'REPLACE', &
-                          mode_opt=MNORMAL)
-            write (this%iout, fmtfileout) &
-              'COMPACTION_ELASTIC', fname, this%ioutcompe
-          else
-            errmsg = 'Optional COMPACTION_ELASTIC keyword must be '// &
-                     'followed by FILEOUT.'
-            call store_error(errmsg)
-          end if
-        case ('COMPACTION_INTERBED')
-          call this%parser%GetStringCaps(keyword)
-          if (keyword == 'FILEOUT') then
-            call this%parser%GetString(fname)
-            this%ioutcompib = getunit()
-            call openfile(this%ioutcompib, this%iout, fname, &
-                          'DATA(BINARY)', form, access, 'REPLACE', &
-                          mode_opt=MNORMAL)
-            write (this%iout, fmtfileout) &
-              'COMPACTION_INTERBED', fname, this%ioutcompib
-          else
-            errmsg = 'Optional COMPACTION_INTERBED keyword must be '// &
-                     'followed by FILEOUT.'
-            call store_error(errmsg)
-          end if
-        case ('COMPACTION_COARSE')
-          call this%parser%GetStringCaps(keyword)
-          if (keyword == 'FILEOUT') then
-            call this%parser%GetString(fname)
-            this%ioutcomps = getunit()
-            call openfile(this%ioutcomps, this%iout, fname, &
-                          'DATA(BINARY)', form, access, 'REPLACE', &
-                          mode_opt=MNORMAL)
-            write (this%iout, fmtfileout) &
-              'COMPACTION_COARSE', fname, this%ioutcomps
-          else
-            errmsg = 'Optional COMPACTION_COARSE keyword must be '// &
-                     'followed by FILEOUT.'
-            call store_error(errmsg)
-          end if
-          !
-          ! -- zdisplacement output
-        case ('ZDISPLACEMENT')
-          call this%parser%GetStringCaps(keyword)
-          if (keyword == 'FILEOUT') then
-            call this%parser%GetString(fname)
-            this%ioutzdisp = getunit()
-            call openfile(this%ioutzdisp, this%iout, fname, &
-                          'DATA(BINARY)', form, access, 'REPLACE', &
-                          mode_opt=MNORMAL)
-            write (this%iout, fmtfileout) &
-              'ZDISPLACEMENT', fname, this%ioutzdisp
-          else
-            errmsg = 'Optional ZDISPLACEMENT keyword must be '// &
-                     'followed by FILEOUT.'
-            call store_error(errmsg)
-          end if
-          ! -- package convergence
-        case ('PACKAGE_CONVERGENCE')
-          call this%parser%GetStringCaps(keyword)
-          if (keyword == 'FILEOUT') then
-            call this%parser%GetString(fname)
-            this%ipakcsv = getunit()
-            call openfile(this%ipakcsv, this%iout, fname, 'CSV', &
-                          filstat_opt='REPLACE', mode_opt=MNORMAL)
-            write (this%iout, fmtfileout) &
-              'PACKAGE_CONVERGENCE', fname, this%ipakcsv
-          else
-            call store_error('Optional PACKAGE_CONVERGENCE keyword must be '// &
-                             'followed by FILEOUT.')
-          end if
-          !
-          ! -- right now these are options that are only available in the
-          !    development version and are not included in the documentation.
-          !    These options are only available when IDEVELOPMODE in
-          !    constants module is set to 1
-        case ('DEV_NO_FINAL_CHECK')
-          call this%parser%DevOpt()
-          this%iconvchk = 0
-          write (this%iout, '(4x,a)') &
-            'A FINAL CONVERGENCE CHECK OF THE CHANGE IN DELAY INTERBED '// &
-            'HEADS AND FLOWS WILL NOT BE MADE'
-
-          !
-          ! default case
-        case default
-          write (errmsg, '(a,3(1x,a),a)') &
-            'Unknown', trim(adjustl(this%packName)), "option '", &
-            trim(keyword), "'."
-          call store_error(errmsg)
-        end select
-      end do
-      write (this%iout, '(1x,a)') &
-        'END OF '//trim(adjustl(this%packName))//' OPTIONS'
-    end if
     !
     ! -- write messages for options
     write (this%iout, '(//2(1X,A))') trim(adjustl(this%packName)), &
@@ -993,9 +766,8 @@ contains
         'OF RELATIVE TO INITIAL GWF HEADS'
     end if
     !
-    ! -- process effective_stress_lag, if effective stress formulation
     if (this%lhead_based .EQV. .FALSE.) then
-      if (ieslag /= 0) then
+      if (this%ieslag /= 0) then
         write (this%iout, '(4x,a,1(/,6x,a))') &
           'SPECIFIC STORAGE VALUES WILL BE CALCULATED USING THE EFFECTIVE', &
           'STRESS FROM THE PREVIOUS TIME STEP'
@@ -1004,100 +776,63 @@ contains
           'SPECIFIC STORAGE VALUES WILL BE CALCULATED USING THE CURRENT', &
           'EFFECTIVE STRESS'
       end if
-    else
-      if (ieslag /= 0) then
-        ieslag = 0
-        write (this%iout, '(4x,a,2(/,6x,a))') &
-          'EFFECTIVE_STRESS_LAG HAS BEEN SPECIFIED BUT HAS NO EFFECT WHEN', &
-          'USING THE HEAD-BASED FORMULATION (HEAD_BASED HAS BEEN SPECIFIED', &
-          'IN THE OPTIONS BLOCK)'
-      end if
+    else if (warn_estress_lag) then
+      write (this%iout, '(4x,a,2(/,6x,a))') &
+        'EFFECTIVE_STRESS_LAG HAS BEEN SPECIFIED BUT HAS NO EFFECT WHEN', &
+        'USING THE HEAD-BASED FORMULATION (HEAD_BASED HAS BEEN SPECIFIED', &
+        'IN THE OPTIONS BLOCK)'
     end if
-    this%ieslag = ieslag
     !
-    ! -- recalculate BRG if necessary and output
-    !    water compressibility values
-    if (ibrg /= 0) then
-      this%brg = this%gammaw * this%beta
-    end if
     write (this%iout, fmtoptr) 'GAMMAW        =', this%gammaw
     write (this%iout, fmtoptr) 'BETA          =', this%beta
     write (this%iout, fmtoptr) 'GAMMAW * BETA =', this%brg
-    !
-    ! -- terminate if errors encountered in reach block
-    if (count_errors() > 0) then
-      call this%parser%StoreErrorUnit()
-    end if
-  end subroutine read_options
+    write (this%iout, '((1X,A))') 'END PACKAGE SETTINGS'
+  end subroutine log_options
 
-  !> @ brief Read dimensions for package
+  !> @ brief Source dimensions for package
   !!
   !!  Read the number of interbeds and maximum number of cells with a specified
   !!  overlying geostatic stress.
   !!
   !<
-  subroutine csub_read_dimensions(this)
+  subroutine csub_source_dimensions(this)
     ! -- modules
-    use ConstantsModule, only: LINELENGTH, LENBOUNDNAME
-    use KindModule, only: I4B
+    use MemoryManagerExtModule, only: mem_set_value
+    use GwfCsubInputModule, only: GwfCsubParamFoundType
     ! -- dummy variables
     class(GwfCsubType), intent(inout) :: this
     ! -- local variables
-    character(len=LENBOUNDNAME) :: keyword
-    integer(I4B) :: ierr
-    logical(LGP) :: isfound, endOfBlock
-    ! -- format
-    !
+    type(GwfCsubParamFoundType) :: found
+
     ! -- initialize dimensions to -1
     this%ninterbeds = -1
-    !
-    ! -- get dimensions block
-    call this%parser%GetBlock('DIMENSIONS', isfound, ierr, &
-                              supportOpenClose=.true.)
-    !
-    ! -- parse dimensions block if detected
-    if (isfound) then
-      write (this%iout, '(/1x,a)') 'PROCESSING '//trim(adjustl(this%packName))// &
-        ' DIMENSIONS'
-      do
-        call this%parser%GetNextLine(endOfBlock)
-        if (endOfBlock) exit
-        call this%parser%GetStringCaps(keyword)
-        select case (keyword)
-        case ('NINTERBEDS')
-          this%ninterbeds = this%parser%GetInteger()
-          write (this%iout, '(4x,a,i0)') 'NINTERBEDS = ', this%ninterbeds
-        case ('MAXSIG0')
-          this%maxsig0 = this%parser%GetInteger()
-          write (this%iout, '(4x,a,i0)') 'MAXSIG0 = ', this%maxsig0
-        case default
-          write (errmsg, '(a,3(1x,a),a)') &
-            'Unknown', trim(this%packName), "dimension '", trim(keyword), "'."
-          call store_error(errmsg)
-        end select
-      end do
-      write (this%iout, '(1x,a)') &
-        'END OF '//trim(adjustl(this%packName))//' DIMENSIONS'
-    else
-      call store_error('Required dimensions block not found.')
-    end if
+
+    ! -- update defaults from input context
+    call mem_set_value(this%ninterbeds, 'NINTERBEDS', this%input_mempath, &
+                       found%ninterbeds)
+    call mem_set_value(this%maxsig0, 'MAXBOUND', this%input_mempath, &
+                       found%maxbound)
+
+    ! - log dimensions
+    write (this%iout, '(/1x,a)') 'PROCESSING '//trim(adjustl(this%packName))// &
+      ' DIMENSIONS'
+    write (this%iout, '(4x,a,i0)') 'NINTERBEDS = ', this%ninterbeds
+    write (this%iout, '(4x,a,i0)') 'MAXSIG0 = ', this%maxsig0
+    write (this%iout, '(1x,a)') &
+      'END OF '//trim(adjustl(this%packName))//' DIMENSIONS'
     !
     ! -- verify dimensions were set correctly
-    if (this%ninterbeds < 0) then
+    if (.not. found%ninterbeds) then
       write (errmsg, '(a)') &
-        'NINTERBEDS was not specified or was specified incorrectly.'
+        'NINTERBEDS is a required dimension.'
       call store_error(errmsg)
-    end if
-    !
-    ! -- stop if errors were encountered in the DIMENSIONS block
-    if (count_errors() > 0) then
-      call this%parser%StoreErrorUnit()
+      call store_error_filename(this%input_mempath)
     end if
 
     ! -- Call define_listlabel to construct the list label that is written
     !    when PRINT_INPUT option is used.
     call this%define_listlabel()
-  end subroutine csub_read_dimensions
+  end subroutine csub_source_dimensions
 
   !> @ brief Allocate scalars
   !!
@@ -1157,9 +892,6 @@ contains
     call mem_allocate(this%satomega, 'SATOMEGA', this%memoryPath)
     call mem_allocate(this%icellf, 'ICELLF', this%memoryPath)
     call mem_allocate(this%gwfiss0, 'GWFISS0', this%memoryPath)
-    !
-    ! -- allocate TS object
-    allocate (this%TsManager)
     !
     ! -- allocate text strings
     call mem_allocate(this%auxname, LENAUXNAME, 0, 'AUXNAME', this%memoryPath)
@@ -1227,7 +959,6 @@ contains
     integer(I4B) :: j
     integer(I4B) :: n
     integer(I4B) :: iblen
-    integer(I4B) :: ilen
     integer(I4B) :: naux
     !
     ! -- grid based data
@@ -1353,13 +1084,9 @@ contains
     end if
     !
     ! -- allocate the nodelist and bound arrays
-    if (this%maxsig0 > 0) then
-      ilen = this%maxsig0
-    else
-      ilen = 1
-    end if
-    call mem_allocate(this%nodelistsig0, ilen, 'NODELISTSIG0', this%memoryPath)
-    call mem_allocate(this%sig0, ilen, 'SIG0', this%memoryPath)
+    call mem_allocate(this%nodelistsig0, this%maxsig0, 'NODELISTSIG0', &
+                      this%memoryPath)
+    call mem_setptr(this%sig0, 'SIG0', this%input_mempath)
     !
     ! -- set pointers to gwf variables
     call mem_setptr(this%gwfiss, 'ISS', trim(this%name_model))
@@ -1382,329 +1109,280 @@ contains
       this%tcompi(n) = DZERO
       this%tcompe(n) = DZERO
     end do
-    do n = 1, max(1, this%maxsig0)
+    do n = 1, this%maxsig0
       this%nodelistsig0(n) = 0
-      this%sig0(n) = DZERO
     end do
   end subroutine csub_allocate_arrays
 
-  !> @ brief Read packagedata for package
+  !> @ brief Source griddata for package
   !!
   !!  Read delay and no-delay interbed input data for the CSUB package. Method
   !!  also validates interbed input data.
   !!
   !<
-  subroutine csub_read_packagedata(this)
+  subroutine csub_source_griddata(this)
     ! -- modules
-    use ConstantsModule, only: LINELENGTH
-    use MemoryManagerModule, only: mem_allocate, mem_setptr
+    use MemoryManagerExtModule, only: mem_set_value
+    use GwfCsubInputModule, only: GwfCsubParamFoundType
     ! -- dummy variables
     class(GwfCsubType), intent(inout) :: this
-    ! -- local variables
-    character(len=LINELENGTH) :: cellid
-    character(len=LINELENGTH) :: title
-    character(len=LINELENGTH) :: tag
-    character(len=20) :: scellid
-    character(len=10) :: text
-    character(len=LENBOUNDNAME) :: bndName
-    character(len=7) :: cdelay
-    logical(LGP) :: isfound
-    logical(LGP) :: endOfBlock
-    integer(I4B) :: ival
-    integer(I4B) :: n
-    integer(I4B) :: nn
-    integer(I4B) :: ib
-    integer(I4B) :: itmp
-    integer(I4B) :: ierr
-    integer(I4B) :: ndelaybeds
-    integer(I4B) :: idelay
-    integer(I4B) :: ntabrows
-    integer(I4B) :: ntabcols
-    real(DP) :: rval
-    real(DP) :: top
-    real(DP) :: bot
-    real(DP) :: baq
-    real(DP) :: q
-    integer, allocatable, dimension(:) :: nboundchk
+    ! -- locals
+    integer(I4B) :: node
+    type(GwfCsubParamFoundType) :: found
+    integer(I4B), dimension(:), pointer, contiguous :: map
     !
-    ! -- initialize temporary variables
-    ndelaybeds = 0
+    ! -- set map to convert user input data into reduced data
+    map => null()
+    if (this%dis%nodes < this%dis%nodesuser) map => this%dis%nodeuser
     !
-    ! -- allocate temporary arrays
-    allocate (nboundchk(this%ninterbeds))
-    do n = 1, this%ninterbeds
-      nboundchk(n) = 0
-    end do
-    !
-    call this%parser%GetBlock('PACKAGEDATA', isfound, ierr, &
-                              supportopenclose=.true.)
-    !
-    ! -- parse locations block if detected
-    if (isfound) then
-      write (this%iout, '(/1x,a)') 'PROCESSING '//trim(adjustl(this%packName))// &
-        ' PACKAGEDATA'
-      do
-        call this%parser%GetNextLine(endOfBlock)
-        if (endOfBlock) then
-          exit
-        end if
-        !
-        ! -- get interbed number
-        itmp = this%parser%GetInteger()
-        !
-        ! -- check for error condition
-        if (itmp < 1 .or. itmp > this%ninterbeds) then
-          write (errmsg, '(a,1x,i0,2(1x,a),1x,i0,a)') &
-            'Interbed number (', itmp, ') must be greater than 0 and ', &
-            'less than or equal to', this%ninterbeds, '.'
-          call store_error(errmsg)
-          cycle
-        end if
-        !
-        ! -- increment nboundchk
-        nboundchk(itmp) = nboundchk(itmp) + 1
-        !
-        ! -- read cellid
-        call this%parser%GetCellid(this%dis%ndim, cellid)
-        nn = this%dis%noder_from_cellid(cellid, &
-                                        this%parser%iuactive, this%iout)
-        n = this%dis%nodeu_from_cellid(cellid, &
-                                       this%parser%iuactive, this%iout)
-        top = this%dis%top(nn)
-        bot = this%dis%bot(nn)
-        baq = top - bot
-        !
-        ! -- determine if a valid cell location was provided
-        if (nn < 1) then
-          write (errmsg, '(a,1x,i0,a)') &
-            'Invalid cellid for packagedata entry', itmp, '.'
-          call store_error(errmsg)
-        end if
-        !
-        ! -- set nodelist and unodelist
-        this%nodelist(itmp) = nn
-        this%unodelist(itmp) = n
-        !
-        ! -- get cdelay
-        call this%parser%GetStringCaps(cdelay)
-        select case (cdelay)
-        case ('NODELAY')
-          ival = 0
-        case ('DELAY')
-          ndelaybeds = ndelaybeds + 1
-          ival = ndelaybeds
-        case default
-          write (errmsg, '(a,1x,a,1x,i0,1x,a)') &
-            'Invalid CDELAY ', trim(adjustl(cdelay)), &
-            'for packagedata entry', itmp, '.'
-          call store_error(errmsg)
-          cycle
-        end select
-        idelay = ival
-        this%idelay(itmp) = ival
-        !
-        ! -- get initial preconsolidation stress
-        this%pcs(itmp) = this%parser%GetDouble()
-        !
-        ! -- get thickness or cell fraction
-        rval = this%parser%GetDouble()
-        if (this%icellf == 0) then
-          if (rval < DZERO .or. rval > baq) then
-            write (errmsg, '(a,g0,2(a,1x),g0,1x,a,1x,i0,a)') &
-              'THICK (', rval, ') MUST BE greater than or equal to 0 ', &
-              'and less than or equal to than', baq, &
-              'for packagedata entry', itmp, '.'
-            call store_error(errmsg)
-          end if
-        else
-          if (rval < DZERO .or. rval > DONE) then
-            write (errmsg, '(a,1x,a,1x,i0,a)') &
-              'FRAC MUST BE greater than 0 and less than or equal to 1', &
-              'for packagedata entry', itmp, '.'
-            call store_error(errmsg)
-          end if
-          rval = rval * baq
-        end if
-        this%thickini(itmp) = rval
-        if (this%iupdatematprop /= 0) then
-          this%thick(itmp) = rval
-        end if
-        !
-        ! -- get rnb
-        rval = this%parser%GetDouble()
-        if (idelay > 0) then
-          if (rval < DONE) then
-            write (errmsg, '(a,g0,a,1x,a,1x,i0,a)') &
-              'RNB (', rval, ') must be greater than or equal to 1', &
-              'for packagedata entry', itmp, '.'
-            call store_error(errmsg)
-          end if
-        else
-          rval = DONE
-        end if
-        this%rnb(itmp) = rval
-        !
-        ! -- get skv or ci
-        rval = this%parser%GetDouble()
-        if (rval < DZERO) then
-          write (errmsg, '(2(a,1x),i0,a)') &
-            '(SKV,CI) must be greater than or equal to 0', &
-            'for packagedata entry', itmp, '.'
-          call store_error(errmsg)
-        end if
-        this%ci(itmp) = rval
-        !
-        ! -- get ske or rci
-        rval = this%parser%GetDouble()
-        if (rval < DZERO) then
-          write (errmsg, '(2(a,1x),i0,a)') &
-            '(SKE,RCI) must be greater than or equal to 0', &
-            'for packagedata entry', itmp, '.'
-          call store_error(errmsg)
-        end if
-        this%rci(itmp) = rval
-        !
-        ! -- set ielastic
-        if (this%ci(itmp) == this%rci(itmp)) then
-          this%ielastic(itmp) = 1
-        else
-          this%ielastic(itmp) = 0
-        end if
-        !
-        ! -- get porosity
-        rval = this%parser%GetDouble()
-        this%thetaini(itmp) = rval
-        if (this%iupdatematprop /= 0) then
-          this%theta(itmp) = rval
-        end if
-        if (rval <= DZERO .or. rval > DONE) then
-          write (errmsg, '(a,1x,a,1x,i0,a)') &
-            'THETA must be greater than 0 and less than or equal to 1', &
-            'for packagedata entry', itmp, '.'
-          call store_error(errmsg)
-        end if
-        !
-        ! -- get kv
-        rval = this%parser%GetDouble()
-        if (idelay > 0) then
-          if (rval <= 0.0) then
-            write (errmsg, '(a,1x,i0,a)') &
-              'KV must be greater than 0 for packagedata entry', itmp, '.'
-            call store_error(errmsg)
-          end if
-        end if
-        this%kv(itmp) = rval
-        !
-        ! -- get h0
-        rval = this%parser%GetDouble()
-        this%h0(itmp) = rval
-        !
-        ! -- get bound names
-        if (this%inamedbound /= 0) then
-          call this%parser%GetStringCaps(bndName)
-          if (len_trim(bndName) < 1) then
-            write (errmsg, '(a,1x,i0,a)') &
-              'BOUNDNAME must be specified for packagedata entry', itmp, '.'
-            call store_error(errmsg)
-          else
-            this%boundname(itmp) = bndName
-          end if
-        end if
-      end do
+    ! -- update defaults from input context
+    call mem_set_value(this%cg_ske_cr, 'CG_SKE_CR', this%input_mempath, &
+                       map, found%cg_ske_cr)
+    call mem_set_value(this%cg_thetaini, 'CG_THETA', this%input_mempath, &
+                       map, found%cg_theta)
+    call mem_set_value(this%sgm, 'SGM', this%input_mempath, map, found%sgm)
+    call mem_set_value(this%sgs, 'SGS', this%input_mempath, map, found%sgs)
 
-      write (this%iout, '(1x,a)') &
-        'END OF '//trim(adjustl(this%packName))//' PACKAGEDATA'
+    ! -- cg_ske and cg_theta are required input params
+    if (.not. found%cg_ske_cr) then
+      call store_error('CG_SKE GRIDDATA must be specified.')
+      call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- write summary of interbed data
-    if (this%iprpak == 1) then
-      ! -- set title
-      title = trim(adjustl(this%packName))//' PACKAGE INTERBED DATA'
-      !
-      ! -- determine the number of columns and rows
-      ntabrows = this%ninterbeds
-      ntabcols = 11
-      if (this%inamedbound /= 0) then
-        ntabcols = ntabcols + 1
-      end if
-      !
-      ! -- setup table
-      call table_cr(this%inputtab, this%packName, title)
-      call this%inputtab%table_df(ntabrows, ntabcols, this%iout)
-      !
-      ! add columns
-      tag = 'INTERBED'
-      call this%inputtab%initialize_column(tag, 10, alignment=TABLEFT)
-      tag = 'CELLID'
-      call this%inputtab%initialize_column(tag, 20, alignment=TABCENTER)
-      tag = 'CDELAY'
-      call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
-      tag = 'PCS'
-      call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
-      tag = 'THICK'
-      call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
-      tag = 'RNB'
-      call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
-      tag = 'SSV_CC'
-      call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
-      tag = 'SSV_CR'
-      call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
-      tag = 'THETA'
-      call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
-      tag = 'KV'
-      call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
-      tag = 'H0'
-      call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
-      if (this%inamedbound /= 0) then
-        tag = 'BOUNDNAME'
-        call this%inputtab%initialize_column(tag, LENBOUNDNAME, &
-                                             alignment=TABLEFT)
-      end if
-      !
-      ! -- write the data
-      do ib = 1, this%ninterbeds
-        call this%dis%noder_to_string(this%nodelist(ib), scellid)
-        if (this%idelay(ib) == 0) then
-          text = 'NODELAY'
-        else
-          text = 'DELAY'
-        end if
-        call this%inputtab%add_term(ib)
-        call this%inputtab%add_term(scellid)
-        call this%inputtab%add_term(text)
-        call this%inputtab%add_term(this%pcs(ib))
-        call this%inputtab%add_term(this%thickini(ib))
-        call this%inputtab%add_term(this%rnb(ib))
-        call this%inputtab%add_term(this%ci(ib))
-        call this%inputtab%add_term(this%rci(ib))
-        call this%inputtab%add_term(this%thetaini(ib))
-        if (this%idelay(ib) == 0) then
-          call this%inputtab%add_term('-')
-          call this%inputtab%add_term('-')
-        else
-          call this%inputtab%add_term(this%kv(ib))
-          call this%inputtab%add_term(this%h0(ib))
-        end if
-        if (this%inamedbound /= 0) then
-          call this%inputtab%add_term(this%boundname(ib))
-        end if
+    if (.not. found%cg_theta) then
+      call store_error('CG_THETA GRIDDATA must be specified.')
+      call store_error_filename(this%input_fname)
+    end if
+
+    ! -- if sgm and sgs have not been specified assign default values
+    if (.not. found%sgm) then
+      do node = 1, this%dis%nodes
+        this%sgm(node) = 1.7D0
       end do
     end if
+    if (.not. found%sgs) then
+      do node = 1, this%dis%nodes
+        this%sgs(node) = 2.0D0
+      end do
+    end if
+  end subroutine csub_source_griddata
+
+  !> @ brief source packagedata for package
+  !!
+  !!  Read delay and no-delay interbed input data for the CSUB package. Method
+  !!  also validates interbed input data.
+  !!
+  !<
+  subroutine csub_source_packagedata(this)
+    ! -- modules
+    use MemoryManagerModule, only: mem_setptr, mem_allocate
+    use MemoryManagerExtModule, only: mem_set_value
+    use CharacterStringModule, only: CharacterStringType
+    ! -- dummy variables
+    class(GwfCsubType), intent(inout) :: this
+    integer(I4B), dimension(:), pointer, contiguous :: icsubno
+    integer(I4B), dimension(:, :), pointer, contiguous :: cellid_pkgdata
+    integer(I4B), dimension(:), pointer :: cellid
+    type(CharacterStringType), dimension(:), pointer, &
+      contiguous :: cdelay
+    type(CharacterStringType), dimension(:), pointer, &
+      contiguous :: boundname
+    real(DP), dimension(:), pointer, contiguous :: pcs, thick_frac, rnb
+    real(DP), dimension(:), pointer, contiguous :: ssv_cc, sse_cr, theta, kv, h0
+    character(len=LINELENGTH) :: cdelaystr
+    character(len=LENBOUNDNAME) :: bndname
+    real(DP) :: top, botm, baq, q, thick, rval
+    integer(I4B) :: idelay, ndelaybeds, csubno
+    integer(I4B) :: ib, ierr, n, nodeu, noder
+    character(len=LINELENGTH) :: nodestr
     !
-    ! -- Check to make sure that every interbed is specified and that no
-    !    interbed is specified more than once.
-    do ib = 1, this%ninterbeds
-      if (nboundchk(ib) == 0) then
-        write (errmsg, '(a,1x,i0,a)') &
-          'Information for interbed', ib, 'not specified in packagedata block.'
+    ! -- set input context pointers
+    call mem_setptr(icsubno, 'ICSUBNO', this%input_mempath)
+    call mem_setptr(cellid_pkgdata, 'CELLID_PKGDATA', this%input_mempath)
+    call mem_setptr(cdelay, 'CDELAY', this%input_mempath)
+    call mem_setptr(pcs, 'PCS0', this%input_mempath)
+    call mem_setptr(thick_frac, 'THICK_FRAC', this%input_mempath)
+    call mem_setptr(rnb, 'RNB', this%input_mempath)
+    call mem_setptr(ssv_cc, 'SSV_CC', this%input_mempath)
+    call mem_setptr(sse_cr, 'SSE_CR', this%input_mempath)
+    call mem_setptr(theta, 'THETA', this%input_mempath)
+    call mem_setptr(kv, 'KV', this%input_mempath)
+    call mem_setptr(h0, 'H0', this%input_mempath)
+    call mem_setptr(boundname, 'BOUNDNAME', this%input_mempath)
+
+    ! initialize ndelaybeds
+    ndelaybeds = 0
+
+    ! -- update state
+    do n = 1, size(icsubno)
+
+      ! -- set cubno
+      csubno = icsubno(n)
+
+      ! -- check csubno
+      if (csubno < 1 .or. csubno > this%ninterbeds) then
+        write (errmsg, '(a,1x,i0,2(1x,a),1x,i0,a)') &
+          'Interbed number (', csubno, ') must be greater than 0 and ', &
+          'less than or equal to', this%ninterbeds, '.'
         call store_error(errmsg)
-      else if (nboundchk(ib) > 1) then
-        write (errmsg, '(2(a,1x,i0),a)') &
-          'Information specified', nboundchk(ib), 'times for interbed', ib, '.'
+        cycle
+      end if
+
+      ! -- set cellid
+      cellid => cellid_pkgdata(:, n)
+
+      ! -- set node user
+      if (this%dis%ndim == 1) then
+        nodeu = cellid(1)
+      elseif (this%dis%ndim == 2) then
+        nodeu = get_node(cellid(1), 1, cellid(2), &
+                         this%dis%mshape(1), 1, &
+                         this%dis%mshape(2))
+      else
+        nodeu = get_node(cellid(1), cellid(2), cellid(3), &
+                         this%dis%mshape(1), &
+                         this%dis%mshape(2), &
+                         this%dis%mshape(3))
+      end if
+
+      ! -- set node reduced
+      noder = this%dis%get_nodenumber(nodeu, 0)
+      if (noder <= 0) then
+        call this%dis%nodeu_to_string(nodeu, nodestr)
+        write (errmsg, *) &
+          ' Cell is outside active grid domain: '// &
+          trim(adjustl(nodestr))
         call store_error(errmsg)
       end if
+
+      ! -- update nodelists
+      this%nodelist(csubno) = noder
+      this%unodelist(csubno) = nodeu
+
+      ! -- set top, botm, baq
+      top = this%dis%top(noder)
+      botm = this%dis%bot(noder)
+      baq = top - botm
+
+      ! -- set cdelay
+      cdelaystr = cdelay(n)
+      select case (cdelaystr)
+      case ('NODELAY')
+        idelay = 0
+      case ('DELAY')
+        ndelaybeds = ndelaybeds + 1
+        idelay = ndelaybeds
+      case default
+        write (errmsg, '(a,1x,a,1x,i0,1x,a)') &
+          'Invalid CDELAY ', trim(adjustl(cdelaystr)), &
+          'for packagedata entry', csubno, '.'
+        call store_error(errmsg)
+        cycle
+      end select
+      this%idelay(csubno) = idelay
+
+      ! -- set initial preconsolidation stress
+      this%pcs(csubno) = pcs(n)
+
+      ! -- set thickness
+      if (this%icellf == 0) then
+        if (thick_frac(n) < DZERO .or. thick_frac(n) > baq) then
+          write (errmsg, '(a,g0,2(a,1x),g0,1x,a,1x,i0,a)') &
+            'THICK (', thick_frac(n), ') MUST BE greater than or equal to 0 ', &
+            'and less than or equal to than', baq, &
+            'for packagedata entry', csubno, '.'
+          call store_error(errmsg)
+        end if
+        thick = thick_frac(n)
+      else
+        if (thick_frac(n) < DZERO .or. thick_frac(n) > DONE) then
+          write (errmsg, '(a,1x,a,1x,i0,a)') &
+            'FRAC MUST BE greater than 0 and less than or equal to 1', &
+            'for packagedata entry', csubno, '.'
+          call store_error(errmsg)
+        end if
+        thick = thick_frac(n) * baq
+      end if
+      this%thickini(csubno) = thick
+      if (this%iupdatematprop /= 0) then
+        this%thick(csubno) = thick
+      end if
+
+      ! -- set rnb
+      if (idelay > 0) then
+        this%rnb(csubno) = rnb(n)
+        if (rnb(n) < DONE) then
+          write (errmsg, '(a,g0,a,1x,a,1x,i0,a)') &
+            'RNB (', rnb(n), ') must be greater than or equal to 1', &
+            'for packagedata entry', csubno, '.'
+          call store_error(errmsg)
+        end if
+      else
+        this%rnb(csubno) = DONE
+      end if
+
+      ! -- set skv or ci
+      if (ssv_cc(n) < DZERO) then
+        write (errmsg, '(2(a,1x),i0,a)') &
+          '(SKV,CI) must be greater than or equal to 0', &
+          'for packagedata entry', csubno, '.'
+        call store_error(errmsg)
+      end if
+      this%ci(csubno) = ssv_cc(n)
+
+      ! -- set ske or rci
+      if (sse_cr(n) < DZERO) then
+        write (errmsg, '(2(a,1x),i0,a)') &
+          '(SKE,RCI) must be greater than or equal to 0', &
+          'for packagedata entry', csubno, '.'
+        call store_error(errmsg)
+      end if
+      this%rci(csubno) = sse_cr(n)
+
+      ! -- set ielastic
+      if (this%ci(csubno) == this%rci(csubno)) then
+        this%ielastic(csubno) = 1
+      else
+        this%ielastic(csubno) = 0
+      end if
+
+      ! -- set porosity
+      if (theta(n) <= DZERO .or. theta(n) > DONE) then
+        write (errmsg, '(a,1x,a,1x,i0,a)') &
+          'THETA must be greater than 0 and less than or equal to 1', &
+          'for packagedata entry', csubno, '.'
+        call store_error(errmsg)
+      end if
+      this%thetaini(csubno) = theta(n)
+      if (this%iupdatematprop /= 0) then
+        this%theta(csubno) = theta(n)
+      end if
+
+      ! -- set kv
+      if (idelay > 0) then
+        if (kv(n) <= 0.0) then
+          write (errmsg, '(a,1x,i0,a)') &
+            'KV must be greater than 0 for packagedata entry', csubno, '.'
+          call store_error(errmsg)
+        end if
+      end if
+      this%kv(csubno) = kv(n)
+
+      ! -- set h0
+      this%h0(csubno) = h0(n)
+
+      ! -- set bound name
+      if (this%inamedbound /= 0) then
+        bndname = boundname(n)
+        if (len_trim(bndname) < 1) then
+          write (errmsg, '(a,1x,i0,a)') &
+            'BOUNDNAME must be specified for packagedata entry', csubno, '.'
+          call store_error(errmsg)
+        else
+          this%boundname(csubno) = bndname
+        end if
+      end if
     end do
-    deallocate (nboundchk)
+
     !
     ! -- set the number of delay interbeds
     this%ndelaybeds = ndelaybeds
@@ -1713,6 +1391,7 @@ contains
     if (ndelaybeds > 0) then
       !
       ! -- reallocate and initialize delay interbed arrays
+      ierr = 0
       if (ierr == 0) then
         call mem_allocate(this%idb_nconv_count, 2, &
                           'IDB_NCONV_COUNT', trim(this%memoryPath))
@@ -1840,7 +1519,7 @@ contains
         call store_error(errmsg)
       end if
     end if
-  end subroutine csub_read_packagedata
+  end subroutine csub_source_packagedata
 
   !> @ brief Final processing for package
   !!
@@ -2457,16 +2136,11 @@ contains
     ! -- deallocate methods on objects
     if (this%inunit > 0) then
       call this%obs%obs_da()
-      call this%TsManager%da()
       !
       ! -- deallocate and nullify observations
       deallocate (this%obs)
       nullify (this%obs)
     end if
-    !
-    ! -- deallocate TsManager
-    deallocate (this%TsManager)
-    nullify (this%TsManager)
 
     !
     ! -- deallocate parent
@@ -2482,151 +2156,97 @@ contains
   !<
   subroutine csub_rp(this)
     ! -- modules
+    use TdisModule, only: kper
     use ConstantsModule, only: LINELENGTH
-    use TdisModule, only: kper, nper
-    use TimeSeriesManagerModule, only: read_value_or_time_series_adv
+    use MemoryManagerModule, only: mem_setptr
+    use MemoryManagerExtModule, only: mem_set_value
     ! -- dummy variables
     class(GwfCsubType), intent(inout) :: this
     ! -- local variables
-    character(len=LINELENGTH) :: line
-    character(len=LINELENGTH) :: title
-    character(len=LINELENGTH) :: text
-    character(len=20) :: cellid
-    logical(LGP) :: isfound
-    logical(LGP) :: endOfBlock
-    integer(I4B) :: jj
-    integer(I4B) :: ierr
-    integer(I4B) :: node
-    integer(I4B) :: nlist
-    real(DP), pointer :: bndElem => null()
+    integer(I4B), dimension(:, :), pointer, contiguous :: cellids
+    integer(I4B), dimension(:), pointer, contiguous :: cellid
+    integer(I4B), pointer :: iper
+    integer(I4B) :: n, nodeu, noder
+    character(len=LINELENGTH) :: nodestr
+    character(len=LINELENGTH) :: title, text
+    character(len=20) :: cellstr
+    logical(LGP) :: found
     ! -- formats
-    character(len=*), parameter :: fmtblkerr = &
-      &"('Looking for BEGIN PERIOD iper.  Found ',a,' instead.')"
     character(len=*), parameter :: fmtlsp = &
       &"(1X,/1X,'REUSING ',a,'S FROM LAST STRESS PERIOD')"
-    !
-    ! -- return if data is not read from file
-    if (this%inunit == 0) return
-    !
-    ! -- get stress period data
-    if (this%ionper < kper) then
-      !
-      ! -- get period block
-      call this%parser%GetBlock('PERIOD', isfound, ierr, &
-                                supportOpenClose=.true., &
-                                blockRequired=.false.)
-      if (isfound) then
-        !
-        ! -- read ionper and check for increasing period numbers
-        call this%read_check_ionper()
+
+    call mem_setptr(iper, 'IPER', this%input_mempath)
+    if (iper /= kper) then
+      call this%csub_rp_obs()
+      return
+    end if
+
+    call mem_setptr(cellids, 'CELLID', this%input_mempath)
+    call mem_set_value(this%nbound, 'NBOUND', this%input_mempath, &
+                       found)
+
+    ! -- setup table for period data
+    if (this%iprpak /= 0) then
+      ! -- reset the input table object
+      title = 'CSUB'//' PACKAGE ('// &
+              trim(adjustl(this%packName))//') DATA FOR PERIOD'
+      write (title, '(a,1x,i6)') trim(adjustl(title)), kper
+      call table_cr(this%inputtab, this%packName, title)
+      call this%inputtab%table_df(1, 2, this%iout, finalize=.FALSE.)
+      text = 'CELLID'
+      call this%inputtab%initialize_column(text, 20)
+      text = 'SIG0'
+      call this%inputtab%initialize_column(text, 15, alignment=TABLEFT)
+    end if
+
+    ! -- update nodelist
+    do n = 1, this%nbound
+
+      ! -- set cellid
+      cellid => cellids(:, n)
+
+      ! -- set user node number
+      if (this%dis%ndim == 1) then
+        nodeu = cellid(1)
+      elseif (this%dis%ndim == 2) then
+        nodeu = get_node(cellid(1), 1, cellid(2), &
+                         this%dis%mshape(1), 1, &
+                         this%dis%mshape(2))
       else
-        !
-        ! -- PERIOD block not found
-        if (ierr < 0) then
-          ! -- End of file found; data applies for remainder of simulation.
-          this%ionper = nper + 1
-        else
-          ! -- Found invalid block
-          call this%parser%GetCurrentLine(line)
-          write (errmsg, fmtblkerr) adjustl(trim(line))
-          call store_error(errmsg)
-        end if
+        nodeu = get_node(cellid(1), cellid(2), cellid(3), &
+                         this%dis%mshape(1), &
+                         this%dis%mshape(2), &
+                         this%dis%mshape(3))
       end if
+
+      ! -- set noder
+      noder = this%dis%get_nodenumber(nodeu, 0)
+      if (noder <= 0) then
+        call this%dis%nodeu_to_string(nodeu, nodestr)
+        write (errmsg, *) &
+          ' Cell is outside active grid domain: '// &
+          trim(adjustl(nodestr))
+        call store_error(errmsg)
+      end if
+
+      this%nodelistsig0(n) = noder
+
+      ! -- write line to table
+      if (this%iprpak /= 0) then
+        call this%dis%noder_to_string(noder, cellstr)
+        call this%inputtab%add_term(cellstr)
+        call this%inputtab%add_term(this%sig0(n))
+      end if
+    end do
+    !
+    ! -- finalize the table
+    if (this%iprpak /= 0) then
+      call this%inputtab%finalize_table()
     end if
     !
-    ! -- read data if ionper == kper
-    if (this%ionper == kper) then
-      !
-      ! -- setup table for period data
-      if (this%iprpak /= 0) then
-        !
-        ! -- reset the input table object
-        title = 'CSUB'//' PACKAGE ('// &
-                trim(adjustl(this%packName))//') DATA FOR PERIOD'
-        write (title, '(a,1x,i6)') trim(adjustl(title)), kper
-        call table_cr(this%inputtab, this%packName, title)
-        call this%inputtab%table_df(1, 2, this%iout, finalize=.FALSE.)
-        text = 'CELLID'
-        call this%inputtab%initialize_column(text, 20)
-        text = 'SIG0'
-        call this%inputtab%initialize_column(text, 15, alignment=TABLEFT)
-      end if
-      !
-      ! -- initialize nlist
-      nlist = 0
-      !
-      ! -- Remove all time-series links associated with this package.
-      call this%TsManager%Reset(this%packName)
-      !
-      ! -- read data
-      readdata: do
-        call this%parser%GetNextLine(endOfBlock)
-        !
-        ! -- test for end of block
-        if (endOfBlock) then
-          exit readdata
-        end if
-        !
-        ! -- increment counter
-        nlist = nlist + 1
-        !
-        ! -- check for error condition with nlist
-        if (nlist > this%maxsig0) then
-          write (errmsg, '(a,i0,a,i0,a)') &
-            'The number of stress period entries (', nlist, &
-            ') exceeds the maximum number of stress period entries (', &
-            this%maxsig0, ').'
-          call store_error(errmsg)
-          exit readdata
-        end if
-        !
-        ! -- get cell i
-        call this%parser%GetCellid(this%dis%ndim, cellid)
-        node = this%dis%noder_from_cellid(cellid, &
-                                          this%parser%iuactive, this%iout)
-        !
-        !
-        if (node < 1) then
-          write (errmsg, '(a,2(1x,a))') &
-            'CELLID', cellid, 'is not in the active model domain.'
-          call store_error(errmsg)
-          cycle readdata
-        end if
-        this%nodelistsig0(nlist) = node
-        !
-        ! -- get sig0
-        call this%parser%GetString(text)
-        jj = 1 ! For 'SIG0'
-        bndElem => this%sig0(nlist)
-        call read_value_or_time_series_adv(text, nlist, jj, bndElem, &
-                                           this%packName, 'BND', &
-                                           this%tsManager, this%iprpak, &
-                                           'SIG0')
-        !
-        ! -- write line to table
-        if (this%iprpak /= 0) then
-          call this%dis%noder_to_string(node, cellid)
-          call this%inputtab%add_term(cellid)
-          call this%inputtab%add_term(bndElem)
-        end if
-      end do readdata
-      !
-      ! -- set nbound
-      this%nbound = nlist
-      !
-      ! -- finalize the table
-      if (this%iprpak /= 0) then
-        call this%inputtab%finalize_table()
-      end if
-      !
-      ! -- reuse data from last stress period
-    else
-      write (this%iout, fmtlsp) trim(this%filtyp)
-    end if
-    !
-    ! -- terminate if errors encountered in reach block
+    ! -- terminate if errors encountered
     if (count_errors() > 0) then
-      call this%parser%StoreErrorUnit()
+      call store_error_filename(this%input_fname)
     end if
     !
     ! -- read observations
@@ -2744,9 +2364,6 @@ contains
     ! -- set gwfiss0
     this%gwfiss0 = this%gwfiss
     !
-    ! -- Advance the time series managers
-    call this%TsManager%ad()
-    !
     ! -- For each observation, push simulated value and corresponding
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
@@ -2862,7 +2479,7 @@ contains
     !
     ! -- terminate if errors encountered when updating material properties
     if (count_errors() > 0) then
-      call this%parser%StoreErrorUnit()
+      call store_error_filename(this%input_fname)
     end if
   end subroutine csub_fc
 
@@ -3505,7 +3122,7 @@ contains
     ! -- terminate if errors encountered when updating material properties
     if (this%iupdatematprop /= 0) then
       if (count_errors() > 0) then
-        call this%parser%StoreErrorUnit()
+        call store_error_filename(this%input_fname)
       end if
     end if
   end subroutine csub_cq
@@ -4099,7 +3716,7 @@ contains
         'adding/modifying stress boundaries to prevent water-levels from', &
         'exceeding the top of the model.'
       call store_error(errmsg)
-      call this%parser%StoreErrorUnit()
+      call store_error_filename(this%input_fname)
     end if
   end subroutine csub_cg_chk_stress
 
@@ -4670,7 +4287,7 @@ contains
     !
     ! -- terminate if any initialization errors have been detected
     if (count_errors() > 0) then
-      call this%parser%StoreErrorUnit()
+      call store_error_filename(this%input_fname)
     end if
     !
     ! -- set initialized
@@ -5677,7 +5294,7 @@ contains
     !
     ! -- terminate if the aquifer head is below the top of delay interbeds
     if (count_errors() > 0) then
-      call this%parser%StoreErrorUnit()
+      call store_error_filename(this%input_fname)
     end if
     !
     ! -- solve for delay bed heads
@@ -7159,7 +6776,7 @@ contains
       !
       ! -- write summary of package error messages
       if (count_errors() > 0) then
-        call this%parser%StoreErrorUnit()
+        call store_error_filename(this%input_fname)
       end if
     end if
   end subroutine csub_bd_obs

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -1190,7 +1190,7 @@ contains
     character(len=LENBOUNDNAME) :: bndname
     real(DP) :: top, botm, baq, q, thick, rval
     integer(I4B) :: idelay, ndelaybeds, csubno
-    integer(I4B) :: ib, ierr, n, nodeu, noder
+    integer(I4B) :: ib, n, nodeu, noder
     character(len=LINELENGTH) :: nodestr
 
     ! -- set input context pointers
@@ -1388,121 +1388,118 @@ contains
     if (ndelaybeds > 0) then
       !
       ! -- reallocate and initialize delay interbed arrays
-      ierr = 0
-      if (ierr == 0) then
-        call mem_allocate(this%idb_nconv_count, 2, &
-                          'IDB_NCONV_COUNT', trim(this%memoryPath))
-        call mem_allocate(this%idbconvert, this%ndelaycells, ndelaybeds, &
-                          'IDBCONVERT', trim(this%memoryPath))
-        call mem_allocate(this%dbdhmax, ndelaybeds, &
-                          'DBDHMAX', trim(this%memoryPath))
-        call mem_allocate(this%dbz, this%ndelaycells, ndelaybeds, &
-                          'DBZ', trim(this%memoryPath))
-        call mem_allocate(this%dbrelz, this%ndelaycells, ndelaybeds, &
-                          'DBRELZ', trim(this%memoryPath))
-        call mem_allocate(this%dbh, this%ndelaycells, ndelaybeds, &
-                          'DBH', trim(this%memoryPath))
-        call mem_allocate(this%dbh0, this%ndelaycells, ndelaybeds, &
-                          'DBH0', trim(this%memoryPath))
-        call mem_allocate(this%dbgeo, this%ndelaycells, ndelaybeds, &
-                          'DBGEO', trim(this%memoryPath))
-        call mem_allocate(this%dbes, this%ndelaycells, ndelaybeds, &
-                          'DBES', trim(this%memoryPath))
-        call mem_allocate(this%dbes0, this%ndelaycells, ndelaybeds, &
-                          'DBES0', trim(this%memoryPath))
-        call mem_allocate(this%dbpcs, this%ndelaycells, ndelaybeds, &
-                          'DBPCS', trim(this%memoryPath))
-        call mem_allocate(this%dbflowtop, ndelaybeds, &
-                          'DBFLOWTOP', trim(this%memoryPath))
-        call mem_allocate(this%dbflowbot, ndelaybeds, &
-                          'DBFLOWBOT', trim(this%memoryPath))
-        call mem_allocate(this%dbdzini, this%ndelaycells, ndelaybeds, &
-                          'DBDZINI', trim(this%memoryPath))
-        call mem_allocate(this%dbthetaini, this%ndelaycells, ndelaybeds, &
-                          'DBTHETAINI', trim(this%memoryPath))
-        call mem_allocate(this%dbcomp, this%ndelaycells, ndelaybeds, &
-                          'DBCOMP', trim(this%memoryPath))
-        call mem_allocate(this%dbtcomp, this%ndelaycells, ndelaybeds, &
-                          'DBTCOMP', trim(this%memoryPath))
-        !
-        ! -- allocate delay bed arrays
-        if (this%iupdatematprop == 0) then
-          call mem_setptr(this%dbdz, 'DBDZINI', trim(this%memoryPath))
-          call mem_setptr(this%dbdz0, 'DBDZINI', trim(this%memoryPath))
-          call mem_setptr(this%dbtheta, 'DBTHETAINI', trim(this%memoryPath))
-          call mem_setptr(this%dbtheta0, 'DBTHETAINI', trim(this%memoryPath))
-        else
-          call mem_allocate(this%dbdz, this%ndelaycells, ndelaybeds, &
-                            'DBDZ', trim(this%memoryPath))
-          call mem_allocate(this%dbdz0, this%ndelaycells, ndelaybeds, &
-                            'DBDZ0', trim(this%memoryPath))
-          call mem_allocate(this%dbtheta, this%ndelaycells, ndelaybeds, &
-                            'DBTHETA', trim(this%memoryPath))
-          call mem_allocate(this%dbtheta0, this%ndelaycells, ndelaybeds, &
-                            'DBTHETA0', trim(this%memoryPath))
+      call mem_allocate(this%idb_nconv_count, 2, &
+                        'IDB_NCONV_COUNT', trim(this%memoryPath))
+      call mem_allocate(this%idbconvert, this%ndelaycells, ndelaybeds, &
+                        'IDBCONVERT', trim(this%memoryPath))
+      call mem_allocate(this%dbdhmax, ndelaybeds, &
+                        'DBDHMAX', trim(this%memoryPath))
+      call mem_allocate(this%dbz, this%ndelaycells, ndelaybeds, &
+                        'DBZ', trim(this%memoryPath))
+      call mem_allocate(this%dbrelz, this%ndelaycells, ndelaybeds, &
+                        'DBRELZ', trim(this%memoryPath))
+      call mem_allocate(this%dbh, this%ndelaycells, ndelaybeds, &
+                        'DBH', trim(this%memoryPath))
+      call mem_allocate(this%dbh0, this%ndelaycells, ndelaybeds, &
+                        'DBH0', trim(this%memoryPath))
+      call mem_allocate(this%dbgeo, this%ndelaycells, ndelaybeds, &
+                        'DBGEO', trim(this%memoryPath))
+      call mem_allocate(this%dbes, this%ndelaycells, ndelaybeds, &
+                        'DBES', trim(this%memoryPath))
+      call mem_allocate(this%dbes0, this%ndelaycells, ndelaybeds, &
+                        'DBES0', trim(this%memoryPath))
+      call mem_allocate(this%dbpcs, this%ndelaycells, ndelaybeds, &
+                        'DBPCS', trim(this%memoryPath))
+      call mem_allocate(this%dbflowtop, ndelaybeds, &
+                        'DBFLOWTOP', trim(this%memoryPath))
+      call mem_allocate(this%dbflowbot, ndelaybeds, &
+                        'DBFLOWBOT', trim(this%memoryPath))
+      call mem_allocate(this%dbdzini, this%ndelaycells, ndelaybeds, &
+                        'DBDZINI', trim(this%memoryPath))
+      call mem_allocate(this%dbthetaini, this%ndelaycells, ndelaybeds, &
+                        'DBTHETAINI', trim(this%memoryPath))
+      call mem_allocate(this%dbcomp, this%ndelaycells, ndelaybeds, &
+                        'DBCOMP', trim(this%memoryPath))
+      call mem_allocate(this%dbtcomp, this%ndelaycells, ndelaybeds, &
+                        'DBTCOMP', trim(this%memoryPath))
+      !
+      ! -- allocate delay bed arrays
+      if (this%iupdatematprop == 0) then
+        call mem_setptr(this%dbdz, 'DBDZINI', trim(this%memoryPath))
+        call mem_setptr(this%dbdz0, 'DBDZINI', trim(this%memoryPath))
+        call mem_setptr(this%dbtheta, 'DBTHETAINI', trim(this%memoryPath))
+        call mem_setptr(this%dbtheta0, 'DBTHETAINI', trim(this%memoryPath))
+      else
+        call mem_allocate(this%dbdz, this%ndelaycells, ndelaybeds, &
+                          'DBDZ', trim(this%memoryPath))
+        call mem_allocate(this%dbdz0, this%ndelaycells, ndelaybeds, &
+                          'DBDZ0', trim(this%memoryPath))
+        call mem_allocate(this%dbtheta, this%ndelaycells, ndelaybeds, &
+                          'DBTHETA', trim(this%memoryPath))
+        call mem_allocate(this%dbtheta0, this%ndelaycells, ndelaybeds, &
+                          'DBTHETA0', trim(this%memoryPath))
+      end if
+      !
+      ! -- allocate delay interbed solution arrays
+      call mem_allocate(this%dbal, this%ndelaycells, &
+                        'DBAL', trim(this%memoryPath))
+      call mem_allocate(this%dbad, this%ndelaycells, &
+                        'DBAD', trim(this%memoryPath))
+      call mem_allocate(this%dbau, this%ndelaycells, &
+                        'DBAU', trim(this%memoryPath))
+      call mem_allocate(this%dbrhs, this%ndelaycells, &
+                        'DBRHS', trim(this%memoryPath))
+      call mem_allocate(this%dbdh, this%ndelaycells, &
+                        'DBDH', trim(this%memoryPath))
+      call mem_allocate(this%dbaw, this%ndelaycells, &
+                        'DBAW', trim(this%memoryPath))
+      !
+      ! -- initialize delay bed counters
+      do n = 1, 2
+        this%idb_nconv_count(n) = 0
+      end do
+      !
+      ! -- initialize delay bed storage
+      do ib = 1, this%ninterbeds
+        idelay = this%idelay(ib)
+        if (idelay == 0) then
+          cycle
         end if
         !
-        ! -- allocate delay interbed solution arrays
-        call mem_allocate(this%dbal, this%ndelaycells, &
-                          'DBAL', trim(this%memoryPath))
-        call mem_allocate(this%dbad, this%ndelaycells, &
-                          'DBAD', trim(this%memoryPath))
-        call mem_allocate(this%dbau, this%ndelaycells, &
-                          'DBAU', trim(this%memoryPath))
-        call mem_allocate(this%dbrhs, this%ndelaycells, &
-                          'DBRHS', trim(this%memoryPath))
-        call mem_allocate(this%dbdh, this%ndelaycells, &
-                          'DBDH', trim(this%memoryPath))
-        call mem_allocate(this%dbaw, this%ndelaycells, &
-                          'DBAW', trim(this%memoryPath))
-        !
-        ! -- initialize delay bed counters
-        do n = 1, 2
-          this%idb_nconv_count(n) = 0
-        end do
-        !
-        ! -- initialize delay bed storage
-        do ib = 1, this%ninterbeds
-          idelay = this%idelay(ib)
-          if (idelay == 0) then
-            cycle
-          end if
-          !
-          ! -- initialize delay interbed variables
-          do n = 1, this%ndelaycells
-            rval = this%thickini(ib) / real(this%ndelaycells, DP)
-            this%dbdzini(n, idelay) = rval
-            this%dbh(n, idelay) = this%h0(ib)
-            this%dbh0(n, idelay) = this%h0(ib)
-            this%dbthetaini(n, idelay) = this%thetaini(ib)
-            this%dbgeo(n, idelay) = DZERO
-            this%dbes(n, idelay) = DZERO
-            this%dbes0(n, idelay) = DZERO
-            this%dbpcs(n, idelay) = this%pcs(ib)
-            this%dbcomp(n, idelay) = DZERO
-            this%dbtcomp(n, idelay) = DZERO
-            if (this%iupdatematprop /= 0) then
-              this%dbdz(n, idelay) = this%dbdzini(n, idelay)
-              this%dbdz0(n, idelay) = this%dbdzini(n, idelay)
-              this%dbtheta(n, idelay) = this%theta(ib)
-              this%dbtheta0(n, idelay) = this%theta(ib)
-            end if
-          end do
-          !
-          ! -- initialize elevation of delay bed cells
-          call this%csub_delay_init_zcell(ib)
-        end do
-        !
-        ! -- initialize delay bed solution arrays
+        ! -- initialize delay interbed variables
         do n = 1, this%ndelaycells
-          this%dbal(n) = DZERO
-          this%dbad(n) = DZERO
-          this%dbau(n) = DZERO
-          this%dbrhs(n) = DZERO
-          this%dbdh(n) = DZERO
-          this%dbaw(n) = DZERO
+          rval = this%thickini(ib) / real(this%ndelaycells, DP)
+          this%dbdzini(n, idelay) = rval
+          this%dbh(n, idelay) = this%h0(ib)
+          this%dbh0(n, idelay) = this%h0(ib)
+          this%dbthetaini(n, idelay) = this%thetaini(ib)
+          this%dbgeo(n, idelay) = DZERO
+          this%dbes(n, idelay) = DZERO
+          this%dbes0(n, idelay) = DZERO
+          this%dbpcs(n, idelay) = this%pcs(ib)
+          this%dbcomp(n, idelay) = DZERO
+          this%dbtcomp(n, idelay) = DZERO
+          if (this%iupdatematprop /= 0) then
+            this%dbdz(n, idelay) = this%dbdzini(n, idelay)
+            this%dbdz0(n, idelay) = this%dbdzini(n, idelay)
+            this%dbtheta(n, idelay) = this%theta(ib)
+            this%dbtheta0(n, idelay) = this%theta(ib)
+          end if
         end do
-      end if
+        !
+        ! -- initialize elevation of delay bed cells
+        call this%csub_delay_init_zcell(ib)
+      end do
+      !
+      ! -- initialize delay bed solution arrays
+      do n = 1, this%ndelaycells
+        this%dbal(n) = DZERO
+        this%dbad(n) = DZERO
+        this%dbau(n) = DZERO
+        this%dbrhs(n) = DZERO
+        this%dbdh(n) = DZERO
+        this%dbaw(n) = DZERO
+      end do
     end if
     !
     ! -- check that ndelaycells is odd when using

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -503,7 +503,7 @@ contains
 
   !> @ brief Source options for package
   !!
-  !!  Read options block for CSUB package.
+  !!  Source options for CSUB package.
   !!
   !<
   subroutine source_options(this)
@@ -950,7 +950,7 @@ contains
   !<
   subroutine csub_allocate_arrays(this)
     ! -- modules
-    use MemoryManagerModule, only: mem_allocate, mem_setptr
+    use MemoryManagerModule, only: mem_allocate, mem_setptr, mem_checkin
     ! -- dummy variables
     class(GwfCsubType), intent(inout) :: this
     ! -- local variables
@@ -1068,7 +1068,7 @@ contains
       call mem_allocate(this%theta0, iblen, 'THETA0', trim(this%memoryPath))
     end if
     !
-    ! -- delay bed storage - allocated in csub_read_packagedata
+    ! -- delay bed storage - allocated in csub_source_packagedata
     !    after number of delay beds is defined
     !
     ! -- allocate boundname
@@ -1084,7 +1084,11 @@ contains
     ! -- allocate the nodelist and bound arrays
     call mem_allocate(this%nodelistsig0, this%maxsig0, 'NODELISTSIG0', &
                       this%memoryPath)
+
+    ! -- set sig0 input context pointer
     call mem_setptr(this%sig0, 'SIG0', this%input_mempath)
+    call mem_checkin(this%sig0, 'SIG0', this%memoryPath, &
+                     'SIG0', this%input_mempath)
     !
     ! -- set pointers to gwf variables
     call mem_setptr(this%gwfiss, 'ISS', trim(this%name_model))
@@ -1113,10 +1117,6 @@ contains
   end subroutine csub_allocate_arrays
 
   !> @ brief Source griddata for package
-  !!
-  !!  Read delay and no-delay interbed input data for the CSUB package. Method
-  !!  also validates interbed input data.
-  !!
   !<
   subroutine csub_source_griddata(this)
     ! -- modules
@@ -1191,7 +1191,6 @@ contains
     real(DP) :: top, botm, baq, q, thick, rval
     integer(I4B) :: idelay, ndelaybeds, csubno
     integer(I4B) :: ib, n, nodeu, noder
-    character(len=LINELENGTH) :: nodestr
 
     ! -- set input context pointers
     call mem_setptr(icsubno, 'ICSUBNO', this%input_mempath)
@@ -1243,13 +1242,9 @@ contains
       end if
 
       ! -- set node reduced
-      noder = this%dis%get_nodenumber(nodeu, 0)
+      noder = this%dis%get_nodenumber(nodeu, 1)
       if (noder <= 0) then
-        call this%dis%nodeu_to_string(nodeu, nodestr)
-        write (errmsg, *) &
-          ' Cell is outside active grid domain: '// &
-          trim(adjustl(nodestr))
-        call store_error(errmsg)
+        cycle
       end if
 
       ! -- update nodelists
@@ -2052,7 +2047,7 @@ contains
       !
       ! -- period data
       call mem_deallocate(this%nodelistsig0)
-      call mem_deallocate(this%sig0)
+      call mem_deallocate(this%sig0, 'SIG0', this%memoryPath)
       !
       ! -- pointers to gwf variables
       nullify (this%gwfiss)
@@ -2161,7 +2156,6 @@ contains
     integer(I4B), dimension(:), pointer, contiguous :: cellid
     integer(I4B), pointer :: iper
     integer(I4B) :: n, nodeu, noder
-    character(len=LINELENGTH) :: nodestr
     character(len=LINELENGTH) :: title, text
     character(len=20) :: cellstr
     logical(LGP) :: found
@@ -2171,6 +2165,7 @@ contains
 
     call mem_setptr(iper, 'IPER', this%input_mempath)
     if (iper /= kper) then
+      write (this%iout, fmtlsp) trim(this%filtyp)
       call this%csub_rp_obs()
       return
     end if
@@ -2214,13 +2209,9 @@ contains
       end if
 
       ! -- set noder
-      noder = this%dis%get_nodenumber(nodeu, 0)
+      noder = this%dis%get_nodenumber(nodeu, 1)
       if (noder <= 0) then
-        call this%dis%nodeu_to_string(nodeu, nodestr)
-        write (errmsg, *) &
-          ' Cell is outside active grid domain: '// &
-          trim(adjustl(nodestr))
-        call store_error(errmsg)
+        cycle
       end if
 
       this%nodelistsig0(n) = noder
@@ -2233,14 +2224,14 @@ contains
       end if
     end do
     !
-    ! -- finalize the table
-    if (this%iprpak /= 0) then
-      call this%inputtab%finalize_table()
-    end if
-    !
     ! -- terminate if errors encountered
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
+    end if
+    !
+    ! -- finalize the table
+    if (this%iprpak /= 0) then
+      call this%inputtab%finalize_table()
     end if
     !
     ! -- read observations

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -30,13 +30,11 @@ module GwfCsubModule
   use GeomUtilModule, only: get_node
   use InputOutputModule, only: extract_idnum_or_bndname
   use BaseDisModule, only: DisBaseType
-  use SimModule, only: count_errors, store_error, store_error_unit, &
-                       store_warning, store_error_filename
+  use SimModule, only: count_errors, store_error, store_warning, &
+                       store_error_filename
   use SimVariablesModule, only: errmsg, warnmsg
-  use SortModule, only: qsort, selectn
-  use BlockParserModule, only: BlockParserType
+  use SortModule, only: selectn
   !
-  use ListModule, only: ListType
   use TableModule, only: TableType, table_cr
   !
   use IMSLinearMisc, only: ims_misc_thomas
@@ -820,7 +818,7 @@ contains
     write (this%iout, '(4x,a,i0)') 'MAXSIG0 = ', this%maxsig0
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%packName))//' DIMENSIONS'
-    !
+
     ! -- verify dimensions were set correctly
     if (.not. found%ninterbeds) then
       write (errmsg, '(a)') &
@@ -1130,11 +1128,11 @@ contains
     integer(I4B) :: node
     type(GwfCsubParamFoundType) :: found
     integer(I4B), dimension(:), pointer, contiguous :: map
-    !
+
     ! -- set map to convert user input data into reduced data
     map => null()
     if (this%dis%nodes < this%dis%nodesuser) map => this%dis%nodeuser
-    !
+
     ! -- update defaults from input context
     call mem_set_value(this%cg_ske_cr, 'CG_SKE_CR', this%input_mempath, &
                        map, found%cg_ske_cr)
@@ -1194,7 +1192,7 @@ contains
     integer(I4B) :: idelay, ndelaybeds, csubno
     integer(I4B) :: ib, ierr, n, nodeu, noder
     character(len=LINELENGTH) :: nodestr
-    !
+
     ! -- set input context pointers
     call mem_setptr(icsubno, 'ICSUBNO', this%input_mempath)
     call mem_setptr(cellid_pkgdata, 'CELLID_PKGDATA', this%input_mempath)
@@ -1309,13 +1307,13 @@ contains
 
       ! -- set rnb
       if (idelay > 0) then
-        this%rnb(csubno) = rnb(n)
         if (rnb(n) < DONE) then
           write (errmsg, '(a,g0,a,1x,a,1x,i0,a)') &
             'RNB (', rnb(n), ') must be greater than or equal to 1', &
             'for packagedata entry', csubno, '.'
           call store_error(errmsg)
         end if
+        this%rnb(csubno) = rnb(n)
       else
         this%rnb(csubno) = DONE
       end if
@@ -1377,9 +1375,8 @@ contains
           write (errmsg, '(a,1x,i0,a)') &
             'BOUNDNAME must be specified for packagedata entry', csubno, '.'
           call store_error(errmsg)
-        else
-          this%boundname(csubno) = bndname
         end if
+        this%boundname(csubno) = bndname
       end if
     end do
 
@@ -6943,7 +6940,7 @@ contains
       !
       ! -- evaluate if there are any observation errors
       if (count_errors() > 0) then
-        call store_error_unit(this%inunit)
+        call store_error_filename(this%input_fname)
       end if
     end if
   end subroutine csub_rp_obs

--- a/src/Model/GroundWaterFlow/gwf.f90
+++ b/src/Model/GroundWaterFlow/gwf.f90
@@ -107,7 +107,7 @@ module GwfModule
   character(len=LENPACKAGETYPE), dimension(GWF_NBASEPKG) :: GWF_BASEPKG
   data GWF_BASEPKG/'DIS6 ', 'DISV6', 'DISU6', '     ', '     ', & !  5
                   &'NPF6 ', 'BUY6 ', 'VSC6 ', 'GNC6 ', '     ', & ! 10
-                  &'HFB6 ', 'STO6 ', 'IC6  ', '     ', '     ', & ! 15
+                  &'HFB6 ', 'STO6 ', 'IC6  ', 'CSUB6', '     ', & ! 15
                   &'MVR6 ', 'OC6  ', 'OBS6 ', '     ', '     ', & ! 20
                   &30*'     '/ ! 50
 
@@ -119,7 +119,7 @@ module GwfModule
   integer(I4B), parameter :: GWF_NMULTIPKG = 50
   character(len=LENPACKAGETYPE), dimension(GWF_NMULTIPKG) :: GWF_MULTIPKG
   data GWF_MULTIPKG/'WEL6 ', 'DRN6 ', 'RIV6 ', 'GHB6 ', '     ', & !  5
-                   &'RCH6 ', 'EVT6 ', 'CHD6 ', 'CSUB6', '     ', & ! 10
+                   &'RCH6 ', 'EVT6 ', 'CHD6 ', '     ', '     ', & ! 10
                    &'MAW6 ', 'SFR6 ', 'LAK6 ', 'UZF6 ', 'API6 ', & ! 15
                    &35*'     '/ ! 50
 
@@ -1440,6 +1440,7 @@ contains
     character(len=LENMEMPATH) :: mempathnpf = ''
     character(len=LENMEMPATH) :: mempathic = ''
     character(len=LENMEMPATH) :: mempathsto = ''
+    character(len=LENMEMPATH) :: mempathcsub = ''
     !
     ! -- set input model memory path
     model_mempath = create_mem_path(component=this%name, context=idm_context)
@@ -1484,7 +1485,8 @@ contains
         this%insto = 1
         mempathsto = mempath
       case ('CSUB6')
-        this%incsub = inunit
+        this%incsub = 1
+        mempathcsub = mempath
       case ('IC6')
         this%inic = 1
         mempathic = mempath
@@ -1512,8 +1514,8 @@ contains
     call gnc_cr(this%gnc, this%name, this%ingnc, this%iout)
     call hfb_cr(this%hfb, this%name, this%inhfb, this%iout)
     call sto_cr(this%sto, this%name, mempathsto, this%insto, this%iout)
-    call csub_cr(this%csub, this%name, this%insto, this%sto%packName, &
-                 this%incsub, this%iout)
+    call csub_cr(this%csub, this%name, mempathcsub, this%insto, &
+                 this%sto%packName, this%incsub, this%iout)
     call ic_cr(this%ic, this%name, mempathic, this%inic, this%iout, this%dis)
     call mvr_cr(this%mvr, this%name, this%inmvr, this%iout, this%dis)
     call oc_cr(this%oc, this%name, this%inoc, this%iout)

--- a/src/Utilities/Idm/BoundInputContext.f90
+++ b/src/Utilities/Idm/BoundInputContext.f90
@@ -95,9 +95,16 @@ contains
     use MemoryManagerExtModule, only: mem_set_value
     class(BoundInputContextType) :: this
     logical(LGP) :: found
+    integer(I4B) :: nauxsz
 
     ! set pointers to defined scalars
-    call mem_setptr(this%naux, 'NAUX', this%mf6_input%mempath)
+    call get_isize('NAUX', this%mf6_input%mempath, nauxsz)
+    if (nauxsz > -1) then
+      call mem_setptr(this%naux, 'NAUX', this%mf6_input%mempath)
+    else
+      allocate (this%naux)
+      this%naux = 0
+    end if
 
     ! allocate memory managed scalars
     call mem_allocate(this%nbound, 'NBOUND', this%mf6_input%mempath)
@@ -151,6 +158,7 @@ contains
     class(BoundInputContextType) :: this
     integer(I4B), dimension(:, :), pointer, contiguous :: cellid
     integer(I4B), dimension(:), pointer, contiguous :: nodeulist
+    integer(I4B) :: varsz
 
     ! set auxname_cst and iauxmultcol
     if (this%naux > 0) then
@@ -171,10 +179,20 @@ contains
     end if
 
     ! set pointer to BOUNDNAME
-    call mem_setptr(this%boundname_cst, 'BOUNDNAME', this%mf6_input%mempath)
+    call get_isize('BOUNDNAME', this%mf6_input%mempath, varsz)
+    if (varsz > -1) then
+      call mem_setptr(this%boundname_cst, 'BOUNDNAME', this%mf6_input%mempath)
+    else
+      allocate (this%boundname_cst(0))
+    end if
 
     ! set pointer to AUXVAR
-    call mem_setptr(this%auxvar, 'AUXVAR', this%mf6_input%mempath)
+    call get_isize('AUXVAR', this%mf6_input%mempath, varsz)
+    if (varsz > -1) then
+      call mem_setptr(this%auxvar, 'AUXVAR', this%mf6_input%mempath)
+    else
+      allocate (this%auxvar(0, 0))
+    end if
   end subroutine allocate_arrays
 
   subroutine list_params_create(this, params, nparam, input_name)

--- a/src/meson.build
+++ b/src/meson.build
@@ -58,6 +58,7 @@ modflow_sources = files(
     'Idm' / 'gwe-icidm.f90',
     'Idm' / 'gwe-namidm.f90',
     'Idm' / 'gwf-chdidm.f90',
+    'Idm' / 'gwf-csubidm.f90',
     'Idm' / 'gwf-disidm.f90',
     'Idm' / 'gwf-disuidm.f90',
     'Idm' / 'gwf-disvidm.f90',

--- a/utils/idmloader/dfns.txt
+++ b/utils/idmloader/dfns.txt
@@ -2,6 +2,7 @@ sim-nam.dfn
 sim-tdis.dfn
 gwf-nam.dfn
 gwf-chd.dfn
+gwf-csub.dfn
 gwf-dis.dfn
 gwf-disu.dfn
 gwf-disv.dfn


### PR DESCRIPTION
Update GWF-CSUB to integrate with IDM for input. Note CSUB6 was moved from the GWF multi-package list to the base package list with the assumption that only a single CSUB6 package can be configured per model.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Added doxygen comments to new and modified procedures
- [X] Updated meson files, makefiles, and Visual Studio project files for new source files
- [X] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [X] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
