### PR TITLE
feat(idm): generalize layer array input for base stress packages

### DIFF
--- a/src/Model/GroundWaterFlow/gwf-evt.f90
+++ b/src/Model/GroundWaterFlow/gwf-evt.f90
@@ -26,7 +26,6 @@ module EvtModule
     ! -- logicals
     logical, pointer, private :: segsdefined
     logical, pointer, private :: fixed_cell
-    logical, pointer, private :: read_as_arrays
     logical, pointer, private :: surfratespecified
     ! -- integers
     integer(I4B), pointer, private :: nseg => null() !< number of ET segments
@@ -115,14 +114,12 @@ contains
     ! -- allocate internal members
     allocate (this%segsdefined)
     allocate (this%fixed_cell)
-    allocate (this%read_as_arrays)
     allocate (this%surfratespecified)
     !
     ! -- Set values
     this%nseg = 1
     this%segsdefined = .true.
     this%fixed_cell = .false.
-    this%read_as_arrays = .false.
     this%surfratespecified = .false.
   end subroutine evt_allocate_scalars
 
@@ -153,7 +150,7 @@ contains
                      'DEPTH', this%input_mempath)
     !
     ! -- set list input segment descriptors
-    if (.not. this%read_as_arrays) then
+    if (.not. this%readasarrays) then
       if (this%nseg > 1) then
         !
         ! -- set pxdp and petm input context pointers
@@ -188,7 +185,6 @@ contains
     class(EvtType), intent(inout) :: this
     ! -- local
     logical(LGP) :: found_fixed_cell = .false.
-    logical(LGP) :: found_readasarrays = .false.
     logical(LGP) :: found_surfratespec = .false.
     !
     ! -- source common bound options
@@ -197,40 +193,27 @@ contains
     ! -- update defaults with idm sourced values
     call mem_set_value(this%fixed_cell, 'FIXED_CELL', &
                        this%input_mempath, found_fixed_cell)
-    call mem_set_value(this%read_as_arrays, 'READASARRAYS', &
-                       this%input_mempath, found_readasarrays)
     call mem_set_value(this%surfratespecified, 'SURFRATESPEC', &
                        this%input_mempath, found_surfratespec)
     !
-    if (found_readasarrays) then
-      if (this%dis%supports_layers()) then
-        this%text = texta
-      else
-        errmsg = 'READASARRAYS option is not compatible with selected'// &
-                 ' discretization type.'
-        call store_error(errmsg)
-        call store_error_filename(this%input_fname)
-      end if
-    end if
-    !
-    if (found_readasarrays .and. found_surfratespec) then
-      if (this%read_as_arrays) then
+    if (this%readasarrays) then
+      if (found_surfratespec) then
         errmsg = 'READASARRAYS option is not compatible with the'// &
                  ' SURF_RATE_SPECIFIED option.'
         call store_error(errmsg)
         call store_error_filename(this%input_fname)
       end if
+      !
+      this%text = texta
     end if
     !
     ! -- log evt specific options
-    call this%evt_log_options(found_fixed_cell, found_readasarrays, &
-                              found_surfratespec)
+    call this%evt_log_options(found_fixed_cell, found_surfratespec)
   end subroutine evt_source_options
 
   !> @brief Source options specific to EvtType
   !<
-  subroutine evt_log_options(this, found_fixed_cell, found_readasarrays, &
-                             found_surfratespec)
+  subroutine evt_log_options(this, found_fixed_cell, found_surfratespec)
     ! -- modules
     use MemoryManagerModule, only: mem_reallocate, mem_setptr
     use MemoryManagerExtModule, only: mem_set_value
@@ -238,15 +221,12 @@ contains
     ! -- dummy
     class(EvtType), intent(inout) :: this
     logical(LGP), intent(in) :: found_fixed_cell
-    logical(LGP), intent(in) :: found_readasarrays
     logical(LGP), intent(in) :: found_surfratespec
     ! -- formats
     character(len=*), parameter :: fmtihact = &
       &"(4x, 'EVAPOTRANSPIRATION WILL BE APPLIED TO HIGHEST ACTIVE CELL.')"
     character(len=*), parameter :: fmtfixedcell = &
       &"(4x, 'EVAPOTRANSPIRATION WILL BE APPLIED TO SPECIFIED CELL.')"
-    character(len=*), parameter :: fmtreadasarrays = &
-      &"(4x, 'EVAPOTRANSPIRATION INPUT WILL BE READ AS ARRAYS.')"
     character(len=*), parameter :: fmtsrz = &
       &"(4x, 'ET RATE AT SURFACE WILL BE ZERO.')"
     character(len=*), parameter :: fmtsrs = &
@@ -258,10 +238,6 @@ contains
     !
     if (found_fixed_cell) then
       write (this%iout, fmtfixedcell)
-    end if
-    !
-    if (found_readasarrays) then
-      write (this%iout, fmtreadasarrays)
     end if
     !
     if (found_surfratespec) then
@@ -285,25 +261,13 @@ contains
     ! -- format
     character(len=*), parameter :: fmtnsegerr = &
       &"('Error: In EVT, NSEG must be > 0 but is specified as ',i0)"
-    !
-    ! Dimensions block is not required if:
-    !   (1) discretization is DIS or DISV, and
-    !   (2) READASARRAYS option has been specified.
-    if (this%read_as_arrays) then
-      this%maxbound = this%dis%get_ncpl()
-      !
-      ! -- verify dimensions were set
-      if (this%maxbound <= 0) then
-        write (errmsg, '(a)') &
-          'MAXBOUND must be an integer greater than zero.'
-        call store_error(errmsg)
-        call store_error_filename(this%input_fname)
-      end if
-      !
+
+    ! -- set maxbound
+    call this%BndExtType%source_dimensions()
+
+    if (this%readasarrays) then
+      ! -- base class call is sufficient
     else
-      !
-      ! -- source maxbound
-      call this%BndExtType%source_dimensions()
       !
       ! -- log found options
       write (this%iout, '(/1x,a)') 'PROCESSING '//trim(adjustl(this%text)) &
@@ -323,7 +287,7 @@ contains
           !
         elseif (this%nseg > 1) then
           ! NSEG>1 is supported only if readasarrays is false
-          if (this%read_as_arrays) then
+          if (this%readasarrays) then
             errmsg = 'In the EVT package, NSEG cannot be greater than 1'// &
                      ' when READASARRAYS is used.'
             call store_error(errmsg)
@@ -338,10 +302,6 @@ contains
         'END OF '//trim(adjustl(this%text))//' DIMENSIONS'
       !
     end if
-    !
-    ! -- Call define_listlabel to construct the list label that is written
-    !    when PRINT_INPUT option is used.
-    call this%define_listlabel()
   end subroutine evt_source_dimensions
 
   !> @brief Part of allocate and read
@@ -352,7 +312,7 @@ contains
     ! -- dummy
     class(EvtType), intent(inout) :: this
     !
-    if (this%read_as_arrays) then
+    if (this%readasarrays) then
       call this%default_nodelist()
     end if
     !
@@ -381,9 +341,11 @@ contains
       call this%check_pxdp()
     end if
     !
-    ! -- Write the list to iout if requested
-    if (.not. this%read_as_arrays) then
-      if (this%iprpak /= 0) then
+    if (this%iprpak /= 0) then
+      if (this%readasarrays) then
+        ! no-op
+      else
+        ! -- Write the list to iout
         call this%write_list()
       end if
     end if
@@ -655,7 +617,7 @@ contains
     call mem_deallocate(this%rate, 'RATE', this%memoryPath)
     call mem_deallocate(this%depth, 'DEPTH', this%memoryPath)
     !
-    if (.not. this%read_as_arrays) then
+    if (.not. this%readasarrays) then
       if (this%nseg > 1) then
         call mem_deallocate(this%pxdp, 'PXDP', this%memoryPath)
         call mem_deallocate(this%petm, 'PETM', this%memoryPath)
@@ -670,7 +632,6 @@ contains
     call mem_deallocate(this%nseg)
     deallocate (this%segsdefined)
     deallocate (this%fixed_cell)
-    deallocate (this%read_as_arrays)
     deallocate (this%surfratespecified)
     !
     ! -- Deallocate parent package

--- a/src/Model/GroundWaterFlow/gwf-evt.f90
+++ b/src/Model/GroundWaterFlow/gwf-evt.f90
@@ -52,7 +52,6 @@ module EvtModule
     procedure :: bnd_da => evt_da
     procedure :: define_listlabel => evt_define_listlabel
     procedure :: bound_value => evt_bound_value
-    procedure, private :: default_nodelist
     procedure, private :: check_pxdp
     ! -- for observations
     procedure, public :: bnd_obs_supported => evt_obs_supported
@@ -356,6 +355,10 @@ contains
     if (this%read_as_arrays) then
       call this%default_nodelist()
     end if
+    !
+    ! -- if fixed_cell option not set, then need to store nodelist
+    !    in the nodesontop array
+    if (.not. this%fixed_cell) call this%set_nodesontop()
   end subroutine evt_read_initial_attr
 
   !> @brief Read and Prepare
@@ -724,50 +727,6 @@ contains
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
   end subroutine evt_define_listlabel
-
-  !> @brief Assign default nodelist when READASARRAYS is specified.
-  !!
-  !! Equivalent to reading IEVT as CONSTANT 1
-  !<
-  subroutine default_nodelist(this)
-    ! -- modules
-    use SimModule, only: store_error
-    use ConstantsModule, only: LINELENGTH
-    ! -- dummy
-    class(EvtType) :: this
-    ! -- local
-    integer(I4B) :: il, ir, ic, ncol, nrow, nlay, nodeu, noder, ipos
-    !
-    ! -- set variables
-    if (this%dis%ndim == 3) then
-      nlay = this%dis%mshape(1)
-      nrow = this%dis%mshape(2)
-      ncol = this%dis%mshape(3)
-    elseif (this%dis%ndim == 2) then
-      nlay = this%dis%mshape(1)
-      nrow = 1
-      ncol = this%dis%mshape(2)
-    end if
-    !
-    ! -- Populate nodelist
-    ipos = 1
-    il = 1
-    do ir = 1, nrow
-      do ic = 1, ncol
-        nodeu = get_node(il, ir, ic, nlay, nrow, ncol)
-        noder = this%dis%get_nodenumber(nodeu, 0)
-        this%nodelist(ipos) = noder
-        ipos = ipos + 1
-      end do
-    end do
-    !
-    ! -- assign nbound.
-    this%nbound = ipos - 1
-    !
-    ! -- if fixed_cell option not set, then need to store nodelist
-    !    in the nodesontop array
-    if (.not. this%fixed_cell) call this%set_nodesontop()
-  end subroutine default_nodelist
 
   ! -- Procedures related to observations
 

--- a/src/Model/GroundWaterFlow/gwf-evt.f90
+++ b/src/Model/GroundWaterFlow/gwf-evt.f90
@@ -370,27 +370,19 @@ contains
     !
     if (this%iper /= kper) return
     !
-    if (this%read_as_arrays) then
-      !
-      ! -- update nodelist based on IEVT input
-      call nodelist_update(this%nodelist, this%nbound, this%maxbound, &
-                           this%dis, this%input_mempath)
-      !
-    else
-      !
-      ! -- process the input list arrays
-      call this%BndExtType%bnd_rp()
-      !
-      ! -- ensure pxdp is monotonically increasing
-      if (this%nseg > 1) then
-        call this%check_pxdp()
-      end if
-      !
-      ! -- Write the list to iout if requested
+    ! -- process the input list arrays
+    call this%BndExtType%bnd_rp()
+    !
+    ! -- ensure pxdp is monotonically increasing
+    if (this%nseg > 1) then
+      call this%check_pxdp()
+    end if
+    !
+    ! -- Write the list to iout if requested
+    if (.not. this%read_as_arrays) then
       if (this%iprpak /= 0) then
         call this%write_list()
       end if
-      !
     end if
     !
     ! -- copy nodelist to nodesontop if not fixed cell
@@ -866,47 +858,6 @@ contains
       !
     end select
   end function evt_bound_value
-
-  !> @brief Update the nodelist based on IEVT input
-  !!
-  !! This is a module scoped routine to check for IEVT input. If array input
-  !! was provided, INIEVT and IEVT will be allocated in the input context.
-  !! If the read state variable INIEVT is set to 1 during this period update,
-  !! IEVT input was read and is used here to update the nodelist.
-  !<
-  subroutine nodelist_update(nodelist, nbound, maxbound, &
-                             dis, input_mempath)
-    ! -- modules
-    use MemoryManagerModule, only: mem_setptr
-    use BaseDisModule, only: DisBaseType
-    ! -- dummy
-    integer(I4B), dimension(:), contiguous, &
-      pointer, intent(inout) :: nodelist
-    class(DisBaseType), pointer, intent(in) :: dis
-    character(len=*), intent(in) :: input_mempath
-    integer(I4B), intent(inout) :: nbound
-    integer(I4B), intent(in) :: maxbound
-    ! -- format
-    character(len=24) :: aname = '     LAYER OR NODE INDEX'
-    ! -- local
-    integer(I4B), dimension(:), contiguous, pointer :: ievt => null()
-    integer(I4B), pointer :: inievt => NULL()
-    !
-    ! -- set pointer to input context INIEVT
-    call mem_setptr(inievt, 'INIEVT', input_mempath)
-    !
-    ! -- check INIEVT read state
-    if (inievt == 1) then
-      ! -- ievt was read this period
-      !
-      ! -- set pointer to input context IEVT
-      call mem_setptr(ievt, 'IEVT', input_mempath)
-      !
-      ! -- update nodelist
-      call dis%nlarray_to_nodelist(ievt, nodelist, &
-                                   maxbound, nbound, aname)
-    end if
-  end subroutine nodelist_update
 
 end module EvtModule
 

--- a/src/Model/GroundWaterFlow/gwf-rch.f90
+++ b/src/Model/GroundWaterFlow/gwf-rch.f90
@@ -45,7 +45,6 @@ module RchModule
     procedure :: set_nodesontop
     procedure :: define_listlabel => rch_define_listlabel
     procedure :: bound_value => rch_bound_value
-    procedure, private :: default_nodelist
     ! -- for observations
     procedure, public :: bnd_obs_supported => rch_obs_supported
     procedure, public :: bnd_df_obs => rch_df_obs
@@ -240,6 +239,10 @@ contains
     if (this%read_as_arrays) then
       call this%default_nodelist()
     end if
+    !
+    ! -- if fixed_cell option not set, then need to store nodelist
+    !    in the nodesontop array
+    if (.not. this%fixed_cell) call this%set_nodesontop()
   end subroutine rch_read_initial_attr
 
   !> @brief Read and Prepare
@@ -416,47 +419,6 @@ contains
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
   end subroutine rch_define_listlabel
-
-  !> @brief Assign default nodelist when READASARRAYS is specified.
-  !!
-  !! Equivalent to reading IRCH as CONSTANT 1
-  !<
-  subroutine default_nodelist(this)
-    ! -- dummy
-    class(RchType) :: this
-    ! -- local
-    integer(I4B) :: il, ir, ic, ncol, nrow, nlay, nodeu, noder, ipos
-    !
-    ! -- set variables
-    if (this%dis%ndim == 3) then
-      nlay = this%dis%mshape(1)
-      nrow = this%dis%mshape(2)
-      ncol = this%dis%mshape(3)
-    elseif (this%dis%ndim == 2) then
-      nlay = this%dis%mshape(1)
-      nrow = 1
-      ncol = this%dis%mshape(2)
-    end if
-    !
-    ! -- Populate nodelist
-    ipos = 1
-    il = 1
-    do ir = 1, nrow
-      do ic = 1, ncol
-        nodeu = get_node(il, ir, ic, nlay, nrow, ncol)
-        noder = this%dis%get_nodenumber(nodeu, 0)
-        this%nodelist(ipos) = noder
-        ipos = ipos + 1
-      end do
-    end do
-    !
-    ! -- Assign nbound
-    this%nbound = ipos - 1
-    !
-    ! -- if fixed_cell option not set, then need to store nodelist
-    !    in the nodesontop array
-    if (.not. this%fixed_cell) call this%set_nodesontop()
-  end subroutine default_nodelist
 
   ! -- Procedures related to observations
 

--- a/src/Model/GroundWaterFlow/gwf-rch.f90
+++ b/src/Model/GroundWaterFlow/gwf-rch.f90
@@ -28,14 +28,12 @@ module RchModule
     real(DP), dimension(:), pointer, contiguous :: recharge => null() !< boundary recharge array
     integer(I4B), dimension(:), pointer, contiguous :: nodesontop => NULL() ! User provided cell numbers; nodelist is cells where recharge is applied)
     logical, pointer, private :: fixed_cell
-    logical, pointer, private :: read_as_arrays
 
   contains
 
     procedure :: rch_allocate_scalars
     procedure :: allocate_arrays => rch_allocate_arrays
     procedure :: source_options => rch_source_options
-    procedure :: source_dimensions => rch_source_dimensions
     procedure :: log_rch_options
     procedure :: read_initial_attr => rch_read_initial_attr
     procedure :: bnd_rp => rch_rp
@@ -103,11 +101,9 @@ contains
     !
     ! -- allocate internal members
     allocate (this%fixed_cell)
-    allocate (this%read_as_arrays)
     !
     ! -- Set values
     this%fixed_cell = .false.
-    this%read_as_arrays = .false.
   end subroutine rch_allocate_scalars
 
   !> @brief Allocate package arrays
@@ -141,7 +137,6 @@ contains
     class(RchType), intent(inout) :: this
     ! -- local
     logical(LGP) :: found_fixed_cell = .false.
-    logical(LGP) :: found_readasarrays = .false.
     !
     ! -- source common bound options
     call this%BndExtType%source_options()
@@ -149,37 +144,25 @@ contains
     ! -- update defaults with idm sourced values
     call mem_set_value(this%fixed_cell, 'FIXED_CELL', this%input_mempath, &
                        found_fixed_cell)
-    call mem_set_value(this%read_as_arrays, 'READASARRAYS', this%input_mempath, &
-                       found_readasarrays)
     !
-    if (found_readasarrays) then
-      if (this%dis%supports_layers()) then
-        this%text = texta
-      else
-        errmsg = 'READASARRAYS option is not compatible with selected'// &
-                 ' discretization type.'
-        call store_error(errmsg)
-        call store_error_filename(this%input_fname)
-      end if
+    if (this%readasarrays) then
+      this%text = texta
     end if
     !
     ! -- log rch params
-    call this%log_rch_options(found_fixed_cell, found_readasarrays)
+    call this%log_rch_options(found_fixed_cell)
   end subroutine rch_source_options
 
   !> @brief Log options specific to RchType
   !<
-  subroutine log_rch_options(this, found_fixed_cell, found_readasarrays)
+  subroutine log_rch_options(this, found_fixed_cell)
     implicit none
     ! -- dummy
     class(RchType), intent(inout) :: this
     logical(LGP), intent(in) :: found_fixed_cell
-    logical(LGP), intent(in) :: found_readasarrays
     ! -- formats
     character(len=*), parameter :: fmtfixedcell = &
       &"(4x, 'RECHARGE WILL BE APPLIED TO SPECIFIED CELL.')"
-    character(len=*), parameter :: fmtreadasarrays = &
-      &"(4x, 'RECHARGE INPUT WILL BE READ AS ARRAY(S).')"
     !
     ! -- log found options
     write (this%iout, '(/1x,a)') 'PROCESSING '//trim(adjustl(this%text)) &
@@ -189,46 +172,10 @@ contains
       write (this%iout, fmtfixedcell)
     end if
     !
-    if (found_readasarrays) then
-      write (this%iout, fmtreadasarrays)
-    end if
-    !
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
   end subroutine log_rch_options
-
-  !> @brief Source the dimensions for this package
-  !!
-  !! Dimensions block is not required if:
-  !!   (1) discretization is DIS or DISV, and
-  !!   (2) READASARRAYS option has been specified.
-  !<
-  subroutine rch_source_dimensions(this)
-    ! -- dummy
-    class(RchType), intent(inout) :: this
-    !
-    if (this%read_as_arrays) then
-      this%maxbound = this%dis%get_ncpl()
-      !
-      ! -- verify dimensions were set
-      if (this%maxbound <= 0) then
-        write (errmsg, '(a)') &
-          'MAXBOUND must be an integer greater than zero.'
-        call store_error(errmsg)
-        call store_error_filename(this%input_fname)
-      end if
-      !
-    else
-      !
-      ! -- source maxbound
-      call this%BndExtType%source_dimensions()
-    end if
-    !
-    ! -- Call define_listlabel to construct the list label that is written
-    !    when PRINT_INPUT option is used.
-    call this%define_listlabel()
-  end subroutine rch_source_dimensions
 
   !> @brief Part of allocate and read
   !<
@@ -236,7 +183,7 @@ contains
     ! -- dummy
     class(RchType), intent(inout) :: this
     !
-    if (this%read_as_arrays) then
+    if (this%readasarrays) then
       call this%default_nodelist()
     end if
     !
@@ -263,9 +210,13 @@ contains
     ! -- copy nodelist to nodesontop if not fixed cell
     if (.not. this%fixed_cell) call this%set_nodesontop()
     !
-    ! -- Write the list to iout if requested
     if (this%iprpak /= 0) then
-      call this%write_list()
+      if (this%readasarrays) then
+        ! no-op
+      else
+        ! -- Write the list to iout
+        call this%write_list()
+      end if
     end if
   end subroutine rch_rp
 
@@ -386,7 +337,6 @@ contains
     !
     ! -- scalars
     deallocate (this%fixed_cell)
-    deallocate (this%read_as_arrays)
     !
     ! -- arrays
     if (associated(this%nodesontop)) deallocate (this%nodesontop)

--- a/src/Model/GroundWaterFlow/gwf-rch.f90
+++ b/src/Model/GroundWaterFlow/gwf-rch.f90
@@ -255,17 +255,7 @@ contains
     !
     if (this%iper /= kper) return
     !
-    if (this%read_as_arrays) then
-      !
-      ! -- update nodelist based on IRCH input
-      call nodelist_update(this%nodelist, this%nbound, this%maxbound, &
-                           this%dis, this%input_mempath)
-      !
-    else
-      !
-      call this%BndExtType%bnd_rp()
-      !
-    end if
+    call this%BndExtType%bnd_rp()
     !
     ! -- copy nodelist to nodesontop if not fixed cell
     if (.not. this%fixed_cell) call this%set_nodesontop()
@@ -524,50 +514,6 @@ contains
       call store_error_filename(this%input_fname)
     end select
   end function rch_bound_value
-
-  !> @brief Update the nodelist based on IRCH input
-  !!
-  !! This is a module scoped routine to check for IRCH
-  !! input. If array input was provided, INIRCH and IRCH
-  !! will be allocated in the input context.  If the read
-  !! state variable INIRCH is set to 1 during this period
-  !! update, IRCH input was read and is used here to update
-  !! the nodelist.
-  !!
-  !<
-  subroutine nodelist_update(nodelist, nbound, maxbound, &
-                             dis, input_mempath)
-    ! -- modules
-    use MemoryManagerModule, only: mem_setptr
-    use BaseDisModule, only: DisBaseType
-    ! -- dummy
-    integer(I4B), dimension(:), contiguous, &
-      pointer, intent(inout) :: nodelist
-    class(DisBaseType), pointer, intent(in) :: dis
-    character(len=*), intent(in) :: input_mempath
-    integer(I4B), intent(inout) :: nbound
-    integer(I4B), intent(in) :: maxbound
-    character(len=24) :: aname = '     LAYER OR NODE INDEX'
-    ! -- local
-    integer(I4B), dimension(:), contiguous, &
-      pointer :: irch => null()
-    integer(I4B), pointer :: inirch => NULL()
-    !
-    ! -- set pointer to input context INIRCH
-    call mem_setptr(inirch, 'INIRCH', input_mempath)
-    !
-    ! -- check INIRCH read state
-    if (inirch == 1) then
-      ! -- irch was read this period
-      !
-      ! -- set pointer to input context IRCH
-      call mem_setptr(irch, 'IRCH', input_mempath)
-      !
-      ! -- update nodelist
-      call dis%nlarray_to_nodelist(irch, nodelist, &
-                                   maxbound, nbound, aname)
-    end if
-  end subroutine nodelist_update
 
 end module RchModule
 

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -144,8 +144,7 @@ contains
     class(BndExtType), intent(inout) :: this !< BndExtType object
     ! -- local variables
     logical(LGP) :: found
-    integer(I4B) :: n, noder, nodeuser
-    character(len=LINELENGTH) :: nodestr
+    integer(I4B) :: n
     !
     if (this%iper /= kper) return
 

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -775,7 +775,7 @@ contains
   !> @brief Update the nodelist based on layer number variable input
   !!
   !! This is a module scoped routine to check for I<filtyp>
-  !! input. If array input was provided, INI<filtype> and I<filtyp>
+  !! input. If array input was provided, INI<filtyp> and I<filtyp>
   !! will be allocated in the input context.  If the read
   !! state variable INI<filtyp> is set to 1 during this period
   !! update, I<filtyp> input was read and is used here to update

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -46,6 +46,7 @@ module BndExtModule
     procedure :: source_dimensions
     procedure :: log_options
     procedure :: nodelist_update
+    procedure :: nodelist_update_ilay
     procedure :: check_cellid
     procedure :: write_list
     procedure :: bound_value
@@ -141,10 +142,12 @@ contains
     character(len=LINELENGTH) :: nodestr
     !
     if (this%iper /= kper) return
-    !
-    ! -- copy nbound from input context
-    call mem_set_value(this%nbound, 'NBOUND', this%input_mempath, &
-                       found)
+
+    if (.not. this%readarraylayer) then
+      ! -- copy nbound from input context
+      call mem_set_value(this%nbound, 'NBOUND', this%input_mempath, &
+                         found)
+    end if
 
     if (this%readarraygrid) then
       ! -- Set the nodelist
@@ -168,6 +171,8 @@ contains
         call store_error(errmsg)
         call store_error_filename(this%input_fname)
       end if
+    else if (this%readarraylayer) then
+      call this%nodelist_update_ilay()
     else
       !
       ! -- convert cellids to node numbers
@@ -249,15 +254,7 @@ contains
 
     ! -- update internal scalars based on user input
     call mem_set_value(this%readarraygrid, 'READARRAYGRID', input_mempath, found)
-    call mem_set_value(this%readarraylayer, 'READARRAYLAYER', &
-                       input_mempath, found)
-
-    ! -- no packages currently use READARRAYLAYER
-    if (this%readarraylayer) then
-      write (errmsg, '(a)') 'READARRAYLAYER is not currently supported.'
-      call store_error(errmsg)
-      call store_error_filename(this%input_fname)
-    end if
+    call mem_set_value(this%readarraylayer, 'READASARRAYS', input_mempath, found)
   end subroutine bndext_allocate_scalars
 
   !> @ brief Allocate package arrays
@@ -774,6 +771,49 @@ contains
     nullify (inputtab)
     deallocate (words)
   end subroutine write_list
+
+  !> @brief Update the nodelist based on layer number variable input
+  !!
+  !! This is a module scoped routine to check for I<filtyp>
+  !! input. If array input was provided, INI<filtype> and I<filtyp>
+  !! will be allocated in the input context.  If the read
+  !! state variable INI<filtyp> is set to 1 during this period
+  !! update, I<filtyp> input was read and is used here to update
+  !! the nodelist.
+  !!
+  !<
+  subroutine nodelist_update_ilay(this)
+    ! -- modules
+    use MemoryManagerModule, only: mem_setptr
+    use ConstantsModule, only: LENVARNAME
+    ! -- dummy
+    class(BndExtType), intent(inout) :: this !< BndExtType object
+    character(len=LENVARNAME) :: ilayname, inilayname
+    character(len=24) :: aname = '     LAYER OR NODE INDEX'
+    ! -- local
+    integer(I4B), dimension(:), contiguous, &
+      pointer :: ilay => null()
+    integer(I4B), pointer :: inilay => NULL()
+    !
+    ! set ilay and read state variable names
+    ilayname = 'I'//trim(this%filtyp)
+    inilayname = 'INI'//trim(this%filtyp)
+    !
+    ! -- set pointer to input context read state variable
+    call mem_setptr(inilay, inilayname, this%input_mempath)
+    !
+    ! -- check read state
+    if (inilay == 1) then
+      ! -- ilay variable was read this period
+      !
+      ! -- set pointer to input context layer index variable
+      call mem_setptr(ilay, ilayname, this%input_mempath)
+      !
+      ! -- update nodelist
+      call this%dis%nlarray_to_nodelist(ilay, this%nodelist, this%maxbound, &
+                                        this%nbound, aname)
+    end if
+  end subroutine nodelist_update_ilay
 
   !> @ brief Return a bound value
     !!

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -45,8 +45,9 @@ module BndExtModule
     procedure :: source_options
     procedure :: source_dimensions
     procedure :: log_options
-    procedure :: nodelist_update
-    procedure :: nodelist_update_ilay
+    procedure :: cellid_to_nlist
+    procedure :: nodeu_to_nlist
+    procedure :: layarr_to_nlist
     procedure :: default_nodelist
     procedure :: check_cellid
     procedure :: write_list
@@ -155,33 +156,11 @@ contains
     end if
 
     if (this%readarraygrid) then
-      ! -- Set the nodelist
-      do n = 1, this%nbound
-        nodeuser = this%nodeulist(n)
-        noder = this%dis%get_nodenumber(nodeuser, 1)
-        if (noder >= 0) then
-          this%nodelist(n) = noder
-        else
-          call this%dis%nodeu_to_string(n, nodestr)
-          write (errmsg, *) &
-            ' Cell is outside active grid domain: '// &
-            trim(adjustl(nodestr))
-          call store_error(errmsg)
-        end if
-      end do
-      !
-      ! -- exit if errors were found
-      if (count_errors() > 0) then
-        write (errmsg, *) count_errors(), ' errors encountered.'
-        call store_error(errmsg)
-        call store_error_filename(this%input_fname)
-      end if
+      call this%nodeu_to_nlist()
     else if (this%readasarrays) then
-      call this%nodelist_update_ilay()
+      call this%layarr_to_nlist()
     else
-      !
-      ! -- convert cellids to node numbers
-      call this%nodelist_update()
+      call this%cellid_to_nlist()
       !
       ! -- update boundname string list
       if (this%inamedbound /= 0) then
@@ -515,7 +494,7 @@ contains
     !! Convert period updated cellids to node numbers.
     !!
   !<
-  subroutine nodelist_update(this)
+  subroutine cellid_to_nlist(this)
     ! -- modules
     use SimVariablesModule, only: errmsg
     ! -- dummy
@@ -571,7 +550,44 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end if
-  end subroutine nodelist_update
+  end subroutine cellid_to_nlist
+
+  !> @ brief Update package nodelist
+  !!
+  !! Convert period user nodes to reduced nodes
+  !!
+  !<
+  subroutine nodeu_to_nlist(this)
+    ! -- modules
+    use MemoryManagerModule, only: mem_setptr
+    use ConstantsModule, only: LENVARNAME
+    ! -- dummy
+    class(BndExtType) :: this !< BndExtType object
+    integer(I4B) :: n, noder, nodeuser
+    character(len=LINELENGTH) :: nodestr
+
+    ! -- Set the nodelist
+    do n = 1, this%nbound
+      nodeuser = this%nodeulist(n)
+      noder = this%dis%get_nodenumber(nodeuser, 1)
+      if (noder >= 0) then
+        this%nodelist(n) = noder
+      else
+        call this%dis%nodeu_to_string(n, nodestr)
+        write (errmsg, *) &
+          ' Cell is outside active grid domain: '// &
+          trim(adjustl(nodestr))
+        call store_error(errmsg)
+      end if
+    end do
+    !
+    ! -- exit if errors were found
+    if (count_errors() > 0) then
+      write (errmsg, *) count_errors(), ' errors encountered.'
+      call store_error(errmsg)
+      call store_error_filename(this%input_fname)
+    end if
+  end subroutine nodeu_to_nlist
 
   !> @brief Update the nodelist based on layer number variable input
   !!
@@ -583,7 +599,7 @@ contains
   !! the nodelist.
   !!
   !<
-  subroutine nodelist_update_ilay(this)
+  subroutine layarr_to_nlist(this)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr
     use ConstantsModule, only: LENVARNAME
@@ -614,7 +630,7 @@ contains
       call this%dis%nlarray_to_nodelist(ilay, this%nodelist, this%maxbound, &
                                         this%nbound, aname)
     end if
-  end subroutine nodelist_update_ilay
+  end subroutine layarr_to_nlist
 
   !> @brief Assign default nodelist when READASARRAYS is specified.
   !!

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -32,7 +32,7 @@ module BndExtModule
     ! -- scalars
     integer(I4B), pointer :: iper
     logical(LGP), pointer :: readarraygrid
-    logical(LGP), pointer :: readarraylayer
+    logical(LGP), pointer :: readasarrays
     ! -- arrays
     integer(I4B), dimension(:, :), pointer, contiguous :: cellid => null() !< input user cellid list
     integer(I4B), dimension(:), pointer, contiguous :: nodeulist => null() !< input user nodelist
@@ -128,6 +128,10 @@ contains
       call this%obs%obs_df(this%iout, this%packName, this%filtyp, this%dis)
       call this%bnd_df_obs()
     end if
+    !
+    ! -- Call define_listlabel to construct the list label that is written
+    !    when PRINT_INPUT option is used.
+    call this%define_listlabel()
   end subroutine bndext_df
 
   subroutine bndext_rp(this)
@@ -144,7 +148,7 @@ contains
     !
     if (this%iper /= kper) return
 
-    if (.not. this%readarraylayer) then
+    if (.not. this%readasarrays) then
       ! -- copy nbound from input context
       call mem_set_value(this%nbound, 'NBOUND', this%input_mempath, &
                          found)
@@ -172,7 +176,7 @@ contains
         call store_error(errmsg)
         call store_error_filename(this%input_fname)
       end if
-    else if (this%readarraylayer) then
+    else if (this%readasarrays) then
       call this%nodelist_update_ilay()
     else
       !
@@ -208,9 +212,9 @@ contains
     !
     ! -- scalars
     deallocate (this%readarraygrid)
-    deallocate (this%readarraylayer)
+    deallocate (this%readasarrays)
     nullify (this%readarraygrid)
-    nullify (this%readarraylayer)
+    nullify (this%readasarrays)
     nullify (this%iper)
     !
     ! -- deallocate
@@ -234,7 +238,6 @@ contains
     class(BndExtType) :: this !< BndExtType object
     ! -- local variables
     character(len=LENMEMPATH) :: input_mempath
-    logical(LGP) :: found
     !
     ! -- set memory path
     input_mempath = create_mem_path(this%name_model, this%packName, idm_context)
@@ -247,15 +250,11 @@ contains
 
     ! -- allocate internal scalars
     allocate (this%readarraygrid)
-    allocate (this%readarraylayer)
+    allocate (this%readasarrays)
 
     ! -- initialize internal scalars
     this%readarraygrid = .false.
-    this%readarraylayer = .false.
-
-    ! -- update internal scalars based on user input
-    call mem_set_value(this%readarraygrid, 'READARRAYGRID', input_mempath, found)
-    call mem_set_value(this%readarraylayer, 'READASARRAYS', input_mempath, found)
+    this%readasarrays = .false.
   end subroutine bndext_allocate_scalars
 
   !> @ brief Allocate package arrays
@@ -315,6 +314,7 @@ contains
     class(BndExtType), intent(inout) :: this !< BndExtType object
     ! -- local variables
     type(BndExtFoundType) :: found
+    logical(LGP) :: found_readarr
     character(len=LENAUXNAME) :: sfacauxname
     integer(I4B) :: n
     !
@@ -328,6 +328,10 @@ contains
     call mem_set_value(sfacauxname, 'AUXMULTNAME', this%input_mempath, &
                        found%auxmultname)
     call mem_set_value(this%inewton, 'INEWTON', this%input_mempath, found%inewton)
+    call mem_set_value(this%readarraygrid, 'READARRAYGRID', this%input_mempath, &
+                       found_readarr)
+    call mem_set_value(this%readasarrays, 'READASARRAYS', this%input_mempath, &
+                       found_readarr)
     !
     ! -- log found options
     call this%log_options(found, sfacauxname)
@@ -393,6 +397,15 @@ contains
       end if
     end if
     !
+    if (this%readasarrays) then
+      if (.not. this%dis%supports_layers()) then
+        errmsg = 'READASARRAYS option is not compatible with selected'// &
+                 ' discretization type.'
+        call store_error(errmsg)
+        call store_error_filename(this%input_fname)
+      end if
+    end if
+    !
     ! -- terminate if errors were detected
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
@@ -409,18 +422,24 @@ contains
     character(len=*), intent(in) :: sfacauxname
     ! -- local variables
     ! -- format
+    character(len=*), parameter :: fmtreadasarrays = &
+      &"(4x, 'PACKAGE INPUT WILL BE READ AS LAYER ARRAYS.')"
+    character(len=*), parameter :: fmtreadarraygrid = &
+      &"(4x, 'PACKAGE INPUT WILL BE READ AS GRID ARRAYS.')"
     character(len=*), parameter :: fmtflow = &
       &"(4x, 'FLOWS WILL BE SAVED TO BUDGET FILE SPECIFIED IN OUTPUT CONTROL')"
-    character(len=*), parameter :: fmttas = &
-      &"(4x, 'TIME-ARRAY SERIES DATA WILL BE READ FROM FILE: ', a)"
-    character(len=*), parameter :: fmtts = &
-      &"(4x, 'TIME-SERIES DATA WILL BE READ FROM FILE: ', a)"
-    character(len=*), parameter :: fmtnme = &
-      &"(a, i0, a)"
     !
     ! -- log found options
     write (this%iout, '(/1x,a)') 'PROCESSING '//trim(adjustl(this%text)) &
       //' BASE OPTIONS'
+    !
+    if (this%readasarrays) then
+      write (this%iout, fmtreadasarrays)
+    end if
+    !
+    if (this%readarraygrid) then
+      write (this%iout, fmtreadarraygrid)
+    end if
     !
     if (found%ipakcb) then
       write (this%iout, fmtflow)
@@ -465,19 +484,23 @@ contains
     ! -- local variables
     type(BndExtFoundType) :: found
     !
-    ! -- open dimensions logging block
-    write (this%iout, '(/1x,a)') 'PROCESSING '//trim(adjustl(this%text))// &
-      ' BASE DIMENSIONS'
-    !
-    ! -- update defaults with idm sourced values
-    call mem_set_value(this%maxbound, 'MAXBOUND', this%input_mempath, &
-                       found%maxbound)
-    !
-    write (this%iout, '(4x,a,i7)') 'MAXBOUND = ', this%maxbound
-    !
-    ! -- close logging block
-    write (this%iout, '(1x,a)') &
-      'END OF '//trim(adjustl(this%text))//' BASE DIMENSIONS'
+    if (this%readasarrays) then
+      this%maxbound = this%dis%get_ncpl()
+    else
+      ! -- open dimensions logging block
+      write (this%iout, '(/1x,a)') 'PROCESSING '//trim(adjustl(this%text))// &
+        ' BASE DIMENSIONS'
+
+      ! -- update defaults with idm sourced values
+      call mem_set_value(this%maxbound, 'MAXBOUND', this%input_mempath, &
+                         found%maxbound)
+
+      write (this%iout, '(4x,a,i7)') 'MAXBOUND = ', this%maxbound
+
+      ! -- close logging block
+      write (this%iout, '(1x,a)') &
+        'END OF '//trim(adjustl(this%text))//' BASE DIMENSIONS'
+    end if
     !
     ! -- verify dimensions were set
     if (this%maxbound <= 0) then
@@ -485,10 +508,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- Call define_listlabel to construct the list label that is written
-    !    when PRINT_INPUT option is used.
-    call this%define_listlabel()
   end subroutine source_dimensions
 
   !> @ brief Update package nodelist
@@ -607,7 +626,7 @@ contains
     ! -- local
     integer(I4B) :: il, ir, ic, ncol, nrow, nlay, nodeu, noder, ipos
     !
-    if (this%readarraylayer) then
+    if (this%readasarrays) then
       !
       ! -- set variables
       if (this%dis%ndim == 3) then

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -47,6 +47,7 @@ module BndExtModule
     procedure :: log_options
     procedure :: nodelist_update
     procedure :: nodelist_update_ilay
+    procedure :: default_nodelist
     procedure :: check_cellid
     procedure :: write_list
     procedure :: bound_value
@@ -553,6 +554,89 @@ contains
     end if
   end subroutine nodelist_update
 
+  !> @brief Update the nodelist based on layer number variable input
+  !!
+  !! This is a module scoped routine to check for I<filtyp>
+  !! input. If array input was provided, INI<filtyp> and I<filtyp>
+  !! will be allocated in the input context.  If the read
+  !! state variable INI<filtyp> is set to 1 during this period
+  !! update, I<filtyp> input was read and is used here to update
+  !! the nodelist.
+  !!
+  !<
+  subroutine nodelist_update_ilay(this)
+    ! -- modules
+    use MemoryManagerModule, only: mem_setptr
+    use ConstantsModule, only: LENVARNAME
+    ! -- dummy
+    class(BndExtType) :: this !< BndExtType object
+    character(len=LENVARNAME) :: ilayname, inilayname
+    character(len=24) :: aname = '     LAYER OR NODE INDEX'
+    ! -- local
+    integer(I4B), dimension(:), contiguous, &
+      pointer :: ilay => null()
+    integer(I4B), pointer :: inilay => NULL()
+    !
+    ! set ilay and read state variable names
+    ilayname = 'I'//trim(this%filtyp)
+    inilayname = 'INI'//trim(this%filtyp)
+    !
+    ! -- set pointer to input context read state variable
+    call mem_setptr(inilay, inilayname, this%input_mempath)
+    !
+    ! -- check read state
+    if (inilay == 1) then
+      ! -- ilay variable was read this period
+      !
+      ! -- set pointer to input context layer index variable
+      call mem_setptr(ilay, ilayname, this%input_mempath)
+      !
+      ! -- update nodelist
+      call this%dis%nlarray_to_nodelist(ilay, this%nodelist, this%maxbound, &
+                                        this%nbound, aname)
+    end if
+  end subroutine nodelist_update_ilay
+
+  !> @brief Assign default nodelist when READASARRAYS is specified.
+  !!
+  !! Equivalent to reading layer number array as CONSTANT 1
+  !<
+  subroutine default_nodelist(this)
+    ! -- dummy
+    class(BndExtType) :: this
+    ! -- local
+    integer(I4B) :: il, ir, ic, ncol, nrow, nlay, nodeu, noder, ipos
+    !
+    if (this%readarraylayer) then
+      !
+      ! -- set variables
+      if (this%dis%ndim == 3) then
+        nlay = this%dis%mshape(1)
+        nrow = this%dis%mshape(2)
+        ncol = this%dis%mshape(3)
+      elseif (this%dis%ndim == 2) then
+        nlay = this%dis%mshape(1)
+        nrow = 1
+        ncol = this%dis%mshape(2)
+      end if
+      !
+      ! -- Populate nodelist
+      ipos = 1
+      il = 1
+      do ir = 1, nrow
+        do ic = 1, ncol
+          nodeu = get_node(il, ir, ic, nlay, nrow, ncol)
+          noder = this%dis%get_nodenumber(nodeu, 0)
+          this%nodelist(ipos) = noder
+          ipos = ipos + 1
+        end do
+      end do
+      !
+      ! -- Assign nbound
+      this%nbound = ipos - 1
+    end if
+  end subroutine default_nodelist
+
   !> @ brief Check for valid cellid
   !<
   subroutine check_cellid(this, ii, cellid, mshape, ndim)
@@ -771,49 +855,6 @@ contains
     nullify (inputtab)
     deallocate (words)
   end subroutine write_list
-
-  !> @brief Update the nodelist based on layer number variable input
-  !!
-  !! This is a module scoped routine to check for I<filtyp>
-  !! input. If array input was provided, INI<filtyp> and I<filtyp>
-  !! will be allocated in the input context.  If the read
-  !! state variable INI<filtyp> is set to 1 during this period
-  !! update, I<filtyp> input was read and is used here to update
-  !! the nodelist.
-  !!
-  !<
-  subroutine nodelist_update_ilay(this)
-    ! -- modules
-    use MemoryManagerModule, only: mem_setptr
-    use ConstantsModule, only: LENVARNAME
-    ! -- dummy
-    class(BndExtType), intent(inout) :: this !< BndExtType object
-    character(len=LENVARNAME) :: ilayname, inilayname
-    character(len=24) :: aname = '     LAYER OR NODE INDEX'
-    ! -- local
-    integer(I4B), dimension(:), contiguous, &
-      pointer :: ilay => null()
-    integer(I4B), pointer :: inilay => NULL()
-    !
-    ! set ilay and read state variable names
-    ilayname = 'I'//trim(this%filtyp)
-    inilayname = 'INI'//trim(this%filtyp)
-    !
-    ! -- set pointer to input context read state variable
-    call mem_setptr(inilay, inilayname, this%input_mempath)
-    !
-    ! -- check read state
-    if (inilay == 1) then
-      ! -- ilay variable was read this period
-      !
-      ! -- set pointer to input context layer index variable
-      call mem_setptr(ilay, ilayname, this%input_mempath)
-      !
-      ! -- update nodelist
-      call this%dis%nlarray_to_nodelist(ilay, this%nodelist, this%maxbound, &
-                                        this%nbound, aname)
-    end if
-  end subroutine nodelist_update_ilay
 
   !> @ brief Return a bound value
     !!

--- a/src/Model/SurfaceWaterFlow/swf-evp.f90
+++ b/src/Model/SurfaceWaterFlow/swf-evp.f90
@@ -61,7 +61,7 @@ module SwfEvpModule
     procedure :: bnd_da => evp_da
     procedure :: define_listlabel => evp_define_listlabel
     procedure :: bound_value => evp_bound_value
-    procedure, private :: default_nodelist
+    procedure :: default_nodelist
     procedure, private :: reach_length_pointer
     procedure, private :: get_qevp
     procedure, private :: get_evap_reduce_mult

--- a/src/Model/SurfaceWaterFlow/swf-pcp.f90
+++ b/src/Model/SurfaceWaterFlow/swf-pcp.f90
@@ -56,7 +56,7 @@ module SwfPcpModule
     procedure :: bnd_da => pcp_da
     procedure :: define_listlabel => pcp_define_listlabel
     procedure :: bound_value => pcp_bound_value
-    procedure, private :: default_nodelist
+    procedure :: default_nodelist
     procedure, private :: reach_length_pointer
     ! for observations
     procedure, public :: bnd_obs_supported => pcp_obs_supported

--- a/src/Utilities/Export/NCExportCreate.f90
+++ b/src/Utilities/Export/NCExportCreate.f90
@@ -171,7 +171,7 @@ contains
       call mem_set_value(export_arrays, 'EXPORT_NC', &
                          dynamic_pkg%mf6_input%mempath, found)
 
-      readasarrays = (dynamic_pkg%readarraylayer .or. dynamic_pkg%readarraygrid)
+      readasarrays = (dynamic_pkg%readasarrays .or. dynamic_pkg%readarraygrid)
       if (export_arrays > 0 .and. readasarrays) then
         select type (dynamic_pkg)
         type is (Mf6FileDynamicPkgLoadType)

--- a/src/Utilities/Idm/BoundInputContext.f90
+++ b/src/Utilities/Idm/BoundInputContext.f90
@@ -53,6 +53,7 @@ module BoundInputContextModule
     integer(I4B), dimension(:), pointer, contiguous :: mshape => null() !< model shape
     logical(LGP) :: readasarrays !< grid or layer array input
     logical(LGP) :: readarraygrid !< array grid reader
+    logical(LGP) :: readarray
     type(DynamicPackageParamsType) :: package_params
     type(ModflowInputType) :: mf6_input !< description of input
   contains
@@ -80,6 +81,7 @@ contains
     this%mf6_input = mf6_input
     this%readarraygrid = readarraygrid
     this%readasarrays = readasarrays
+    this%readarray = readarraygrid .or. readasarrays
 
     ! create the dynamic package input context
     call this%allocate_scalars()
@@ -134,7 +136,7 @@ contains
     this%nodes = product(this%mshape)
 
     ! initialize package params object
-    call this%package_params%init(this%mf6_input, 'PERIOD', this%readasarrays, &
+    call this%package_params%init(this%mf6_input, 'PERIOD', this%readarray, &
                                   this%naux, this%inamedbound)
   end subroutine allocate_scalars
 
@@ -159,7 +161,7 @@ contains
     end if
 
     ! allocate cellid if this is not list input
-    if (this%readasarrays) then
+    if (this%readarray) then
       call mem_allocate(cellid, 0, 0, 'CELLID', this%mf6_input%mempath)
     end if
 
@@ -368,7 +370,7 @@ contains
     end do
 
     if (allocate_params) then
-      if (this%readasarrays) then
+      if (this%readarray) then
         call this%array_params_create(params, nparam, input_name)
       else
         call this%list_params_create(params, nparam, input_name)

--- a/src/Utilities/Idm/BoundInputContext.f90
+++ b/src/Utilities/Idm/BoundInputContext.f90
@@ -52,7 +52,6 @@ module BoundInputContextModule
       contiguous :: auxvar => null() !< auxiliary variable array
     integer(I4B), dimension(:), pointer, contiguous :: mshape => null() !< model shape
     logical(LGP) :: readasarrays !< grid or layer array input
-    logical(LGP) :: readarraylayer !< array layer reader
     logical(LGP) :: readarraygrid !< array grid reader
     type(DynamicPackageParamsType) :: package_params
     type(ModflowInputType) :: mf6_input !< description of input
@@ -72,16 +71,15 @@ contains
   !> @brief create boundary input context
   !!
   !<
-  subroutine create(this, mf6_input, readarraygrid, readarraylayer)
+  subroutine create(this, mf6_input, readarraygrid, readasarrays)
     class(BoundInputContextType) :: this
     type(ModflowInputType), intent(in) :: mf6_input
     logical(LGP), intent(in) :: readarraygrid
-    logical(LGP), intent(in) :: readarraylayer
+    logical(LGP), intent(in) :: readasarrays
 
     this%mf6_input = mf6_input
     this%readarraygrid = readarraygrid
-    this%readarraylayer = readarraylayer
-    this%readasarrays = readarraygrid .or. readarraylayer
+    this%readasarrays = readasarrays
 
     ! create the dynamic package input context
     call this%allocate_scalars()

--- a/src/Utilities/Idm/InputLoadType.f90
+++ b/src/Utilities/Idm/InputLoadType.f90
@@ -82,7 +82,7 @@ module InputLoadTypeModule
     character(len=LINELENGTH) :: component_input_name !< component input name, e.g. model name file
     character(len=LINELENGTH) :: input_name !< input name, e.g. package *.chd file
     character(len=LINELENGTH), dimension(:), allocatable :: param_names !< dynamic param tagnames
-    logical(LGP) :: readarraylayer
+    logical(LGP) :: readasarrays
     logical(LGP) :: readarraygrid
     integer(I4B) :: iperblock !< index of period block on block definition list
     integer(I4B) :: iout !< inunit number for logging
@@ -356,7 +356,7 @@ contains
     this%component_name = component_name
     this%component_input_name = component_input_name
     this%input_name = input_name
-    this%readarraylayer = .false.
+    this%readasarrays = .false.
     this%readarraygrid = .false.
     this%iperblock = iperblock
     this%nparam = 0
@@ -373,7 +373,7 @@ contains
       call store_error_filename(this%input_name)
     end if
 
-    ! set readarraylayer and readarraygrid
+    ! set readasarrays and readarraygrid
     if (mf6_input%block_dfns(iperblock)%aggregate) then
       ! no-op, list based input
     else
@@ -381,8 +381,8 @@ contains
         idt => mf6_input%param_dfns(iparam)
         if (idt%blockname == 'OPTIONS') then
           select case (idt%tagname)
-          case ('READARRAYLAYER', 'READASARRAYS')
-            this%readarraylayer = .true.
+          case ('READASARRAYS')
+            this%readasarrays = .true.
           case ('READARRAYGRID')
             this%readarraygrid = .true.
           case default

--- a/src/Utilities/Idm/ModflowInput.f90
+++ b/src/Utilities/Idm/ModflowInput.f90
@@ -141,8 +141,6 @@ contains
         select case (keyword)
         case ('READASARRAYS')
           write (sc_type, '(a)') trim(subcomponent_type)//'A'
-        case ('READARRAYLAYER')
-          write (sc_type, '(a)') trim(subcomponent_type)//'L'
         case ('READARRAYGRID')
           write (sc_type, '(a)') trim(subcomponent_type)//'G'
         case default

--- a/src/Utilities/Idm/mf6blockfile/IdmMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/IdmMf6File.f90
@@ -282,16 +282,7 @@ contains
     if (this%mf6_input%subcomponent_type == 'STO') then
       allocate (sto_loader)
       this%rp_loader => sto_loader
-    else if (this%readarraylayer) then
-      select case (this%mf6_input%subcomponent_type)
-      case ('EVTA', 'RCHA')
-        ! no-op
-      case default
-        call dev_feature('Input file "'//trim(this%input_name)// &
-          '" READARRAYLAYER option is still under development, install the &
-          &nightly build or compile from source with IDEVELOPMODE = 1.', &
-        this%iout)
-      end select
+    else if (this%readasarrays) then
       allocate (arrlayer_loader)
       this%rp_loader => arrlayer_loader
     else if (this%readarraygrid) then

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
@@ -82,7 +82,7 @@ contains
     ! initialize input context memory
     call this%bound_context%create(mf6_input, &
                                    readarraygrid=.true., &
-                                   readarraylayer=.false.)
+                                   readasarrays=.false.)
 
     ! allocate user nodelist
     call mem_allocate(this%nodeulist, this%bound_context%maxbound, &

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileLayerArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileLayerArray.f90
@@ -106,7 +106,7 @@ contains
     ! initialize input context memory
     call this%bound_context%create(mf6_input, &
                                    readarraygrid=.false., &
-                                   readarraylayer=.true.)
+                                   readasarrays=.true.)
 
     ! allocate dfn params
     call this%params_alloc()

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileList.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileList.f90
@@ -100,7 +100,7 @@ contains
     ! initialize package input context
     call this%bound_context%create(mf6_input, &
                                    readarraygrid=.false., &
-                                   readarraylayer=.false.)
+                                   readasarrays=.false.)
 
     ! store in scope SA cols for list input
     call this%bound_context%bound_params(this%param_names, this%nparam, &


### PR DESCRIPTION
Make IDM based layer based array input generic.  Relevance of layer array input is determined per package.
Per package steps required for support:
  - Create READASARRAYS style dfn with optional layer number period parameter
  - Layer number parameter must be named `I<component>` e.g. `IEVT` or `IRCH`
  - Ensure package inherits from `BndExtType` and complete any package specific updates to support `READASARRAYS`- see as examples `gwf-rch.f90` and `gwf-evt.f90` in this PR. 
 
Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Added doxygen comments to new and modified procedures
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
