### PR TITLE
refactor(readarraygrid): make dimension optional

### DIFF
--- a/autotest/test_gwf_disv_uzf.py
+++ b/autotest/test_gwf_disv_uzf.py
@@ -173,9 +173,7 @@ def get_model(ws, name, array_input=False):
 
     # general-head boundary
     if array_input:
-        ghb = flopy.mf6.ModflowGwfghbg(
-            gwf, print_flows=True, bhead=abhead, cond=acond
-        )
+        ghb = flopy.mf6.ModflowGwfghbg(gwf, print_flows=True, bhead=abhead, cond=acond)
     else:
         ghb = flopy.mf6.ModflowGwfghb(gwf, print_flows=True, stress_period_data=ghb_spd)
 

--- a/autotest/test_gwf_disv_uzf.py
+++ b/autotest/test_gwf_disv_uzf.py
@@ -174,7 +174,7 @@ def get_model(ws, name, array_input=False):
     # general-head boundary
     if array_input:
         ghb = flopy.mf6.ModflowGwfghbg(
-            gwf, print_flows=True, maxbound=20, bhead=abhead, cond=acond
+            gwf, print_flows=True, bhead=abhead, cond=acond
         )
     else:
         ghb = flopy.mf6.ModflowGwfghb(gwf, print_flows=True, stress_period_data=ghb_spd)

--- a/autotest/test_gwf_uzf01.py
+++ b/autotest/test_gwf_uzf01.py
@@ -112,7 +112,6 @@ def get_model(ws, name, array_input=False):
             gwf,
             print_input=True,
             print_flows=True,
-            maxbound=1,
             bhead=bhead,
             cond=cond,
             save_flows=False,

--- a/autotest/test_gwf_vsc01.py
+++ b/autotest/test_gwf_vsc01.py
@@ -145,7 +145,6 @@ def get_model(idx, ws, array_input=False):
             temp[0][0, i, ncol - 1] = initial_temperature
         flopy.mf6.ModflowGwfghbg(
             gwf,
-            maxbound=nrow,
             pname="GHB-1",
             auxiliary="temperature",
             bhead=bhead,

--- a/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
@@ -124,7 +124,7 @@ block dimensions
 name maxbound
 type integer
 reader urword
-optional false
+optional true
 longname maximum number of general-head boundaries in any stress period
 description REPLACE maxbound {'{#1}': 'general-head boundary'}
 

--- a/src/Idm/gwf-ghbgidm.f90
+++ b/src/Idm/gwf-ghbgidm.f90
@@ -265,7 +265,7 @@ module GwfGhbgInputModule
     'INTEGER', & ! type
     '', & ! shape
     'maximum number of general-head boundaries in any stress period', & ! longname
-    .true., & ! required
+    .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -379,7 +379,7 @@ module GwfGhbgInputModule
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .false., & ! aggregate
     .false. & ! block_variable
     ), &

--- a/src/Model/GroundWaterFlow/gwf-ghb.f90
+++ b/src/Model/GroundWaterFlow/gwf-ghb.f90
@@ -211,6 +211,7 @@ contains
     ! -- check stress period data
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node == 0) cycle
       bt = this%dis%bot(node)
       ! -- accumulate errors
       if (this%bhead(i) < bt .and. this%icelltype(node) /= 0) then
@@ -252,6 +253,7 @@ contains
     ! -- Calculate hcof and rhs for each ghb entry
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node == 0) cycle
       if (this%ibound(node) .le. 0) then
         this%hcof(i) = DZERO
         this%rhs(i) = DZERO
@@ -283,6 +285,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
+      if (n == 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -196,13 +196,13 @@ contains
   !<
   subroutine block_post_process(this, iblk)
     use ConstantsModule, only: LENBOUNDNAME
-    use MemoryManagerModule, only: mem_allocate, get_isize
+    use MemoryManagerModule, only: mem_allocate
     use CharacterStringModule, only: CharacterStringType
     use SourceCommonModule, only: set_model_shape
     class(LoadMf6FileType) :: this
     integer(I4B), intent(in) :: iblk
     type(InputParamDefinitionType), pointer :: idt
-    integer(I4B) :: iparam, isize
+    integer(I4B) :: iparam
     integer(I4B), pointer :: intptr
 
     ! update state based on read tags
@@ -247,13 +247,6 @@ contains
         call set_model_shape(this%mf6_input%pkgtype, this%filename, &
                              this%mf6_input%component_mempath, &
                              this%mf6_input%mempath, this%mshape)
-      else if (this%readarraygrid) then
-        ! maxbound is optional
-        call get_isize('MAXBOUND', this%mf6_input%mempath, isize)
-        if (isize < 0) then
-          call mem_allocate(intptr, 'MAXBOUND', this%mf6_input%mempath)
-          intptr = product(this%mshape)
-        end if
       end if
     case default
     end select

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -56,6 +56,7 @@ module LoadMf6FileModule
     logical(LGP) :: ts_active !< is timeseries active
     logical(LGP) :: export !< is array export active
     logical(LGP) :: readasarrays
+    logical(LGP) :: readarraygrid
     integer(I4B) :: inamedbound
     integer(I4B) :: iauxiliary
     integer(I4B) :: iout !< inunit for list log
@@ -129,6 +130,7 @@ contains
     this%ts_active = .false.
     this%export = .false.
     this%readasarrays = .false.
+    this%readarraygrid = .false.
     this%inamedbound = 0
     this%iauxiliary = 0
     this%iout = iout
@@ -194,12 +196,13 @@ contains
   !<
   subroutine block_post_process(this, iblk)
     use ConstantsModule, only: LENBOUNDNAME
+    use MemoryManagerModule, only: mem_allocate, get_isize
     use CharacterStringModule, only: CharacterStringType
     use SourceCommonModule, only: set_model_shape
     class(LoadMf6FileType) :: this
     integer(I4B), intent(in) :: iblk
     type(InputParamDefinitionType), pointer :: idt
-    integer(I4B) :: iparam
+    integer(I4B) :: iparam, isize
     integer(I4B), pointer :: intptr
 
     ! update state based on read tags
@@ -212,6 +215,8 @@ contains
           this%inamedbound = 1
         else if (this%block_tags(iparam) == 'READASARRAYS') then
           this%readasarrays = .true.
+        else if (this%block_tags(iparam) == 'READARRAYGRID') then
+          this%readarraygrid = .true.
         else if (this%block_tags(iparam) == 'TS6') then
           this%ts_active = .true.
         else if (this%block_tags(iparam) == 'EXPORT_ARRAY_ASCII') then
@@ -242,6 +247,13 @@ contains
         call set_model_shape(this%mf6_input%pkgtype, this%filename, &
                              this%mf6_input%component_mempath, &
                              this%mf6_input%mempath, this%mshape)
+      else if (this%readarraygrid) then
+        ! maxbound is optional
+        call get_isize('MAXBOUND', this%mf6_input%mempath, isize)
+        if (isize < 0) then
+          call mem_allocate(intptr, 'MAXBOUND', this%mf6_input%mempath)
+          intptr = sum(this%mshape)
+        end if
       end if
     case default
     end select

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -196,7 +196,6 @@ contains
   !<
   subroutine block_post_process(this, iblk)
     use ConstantsModule, only: LENBOUNDNAME
-    use MemoryManagerModule, only: mem_allocate
     use CharacterStringModule, only: CharacterStringType
     use SourceCommonModule, only: set_model_shape
     class(LoadMf6FileType) :: this

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -252,7 +252,7 @@ contains
         call get_isize('MAXBOUND', this%mf6_input%mempath, isize)
         if (isize < 0) then
           call mem_allocate(intptr, 'MAXBOUND', this%mf6_input%mempath)
-          intptr = sum(this%mshape)
+          intptr = product(this%mshape)
         end if
       end if
     case default

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
@@ -58,6 +58,8 @@ contains
     type(BlockParserType), pointer, intent(inout) :: parser
     integer(I4B), intent(in) :: iout
     type(LoadMf6FileType) :: loader
+    integer(I4B) :: isize
+    integer(I4B), pointer :: maxbound
 
     ! initialize base type
     call this%DynamicPkgLoadType%init(mf6_input, component_name, &
@@ -68,6 +70,14 @@ contains
 
     ! load static input
     call loader%load(parser, mf6_input, this%nc_vars, this%input_name, iout)
+
+    ! maxbound is optional
+    call get_isize('MAXBOUND', mf6_input%mempath, isize)
+    if (isize < 0) then
+      ! set maxbound to grid nodes
+      call mem_allocate(maxbound, 'MAXBOUND', mf6_input%mempath)
+      maxbound = product(loader%mshape)
+    end if
 
     ! initialize input context memory
     call this%bound_context%create(mf6_input, &


### PR DESCRIPTION
Make `MAXBOUND` an optional dimension for `READARRAYGRID` packages:
  - mark `MAXBOUND` as optional in package dfn
  - if not provided, `MAXBOUND` is set to user grid nodes
  - documentation will be added to describe when and why to considering defining

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Added new test or modified an existing test
- [X] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Added doxygen comments to new and modified procedures
- [X] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
