### PR TITLE
feat(gwf): add drng package

### DIFF
--- a/autotest/test_gwf_mvr01.py
+++ b/autotest/test_gwf_mvr01.py
@@ -3,13 +3,13 @@ import os
 import flopy
 import numpy as np
 import pytest
-from framework import TestFramework
+from framework import DNODATA, TestFramework
 
 name = "gwf_mvr01"
 cases = [name]
 
 
-def build_models(idx, test):
+def get_model(idx, ws, array_input=False):
     # static model data
     # temporal discretization
     nper = 1
@@ -35,7 +35,7 @@ def build_models(idx, test):
 
     # build MODFLOW 6 files
     sim = flopy.mf6.MFSimulation(
-        sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
     tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
@@ -96,13 +96,28 @@ def build_models(idx, test):
     chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # drn file
-    drn6 = [
-        [(0, 1, 2), -1.0, 1.0],
-        [(0, 2, 3), -1.0, 1.0],
-    ]
-    drn = flopy.mf6.modflow.ModflowGwfdrn(
-        gwf, mover=True, stress_period_data=drn6, pname="drn-1"
-    )
+    if array_input:
+        elev = np.full((nlay, nrow, ncol), DNODATA, dtype=float)
+        cond = np.full((nlay, nrow, ncol), DNODATA, dtype=float)
+        elev[0, 1, 2] = -1.0
+        elev[0, 2, 3] = -1.0
+        cond[0, 1, 2] = 1.0
+        cond[0, 2, 3] = 1.0
+        drn = flopy.mf6.modflow.ModflowGwfdrng(
+            gwf,
+            mover=True,
+            pname="drn-1",
+            elev=elev,
+            cond=cond,
+        )
+    else:
+        drn6 = [
+            [(0, 1, 2), -1.0, 1.0],
+            [(0, 2, 3), -1.0, 1.0],
+        ]
+        drn = flopy.mf6.modflow.ModflowGwfdrn(
+            gwf, mover=True, stress_period_data=drn6, pname="drn-1"
+        )
 
     # sfr file
     packagedata = [
@@ -364,12 +379,12 @@ def build_models(idx, test):
         printrecord=[("HEAD", "LAST"), ("BUDGET", "ALL")],
     )
 
-    return sim, None
+    return sim
 
 
-def check_output(idx, test):
+def check_output(idx, ws, array_input=False):
     # mvr budget terms
-    fpth = os.path.join(test.workspace, "gwf_mvr01.mvr.bud")
+    fpth = os.path.join(ws, "gwf_mvr01.mvr.bud")
     bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
     times = bobj.get_times()
     records = bobj.get_data(totim=times[-1])
@@ -439,6 +454,28 @@ def check_output(idx, test):
     assert records[24].shape == (0,)
 
 
+def build_models(idx, test):
+    # build MODFLOW 6 files
+    ws = test.workspace
+    sim = get_model(idx, ws)
+
+    # build comparison array_input model
+    ws = os.path.join(test.workspace, "mf6")
+    mc = get_model(idx, ws, array_input=True)
+
+    return sim, mc
+
+
+def check_outputs(idx, test):
+    # check output MODFLOW 6 files
+    ws = test.workspace
+    check_output(idx, ws)
+
+    # check output comparison array_input model
+    ws = os.path.join(test.workspace, "mf6")
+    check_output(idx, ws, array_input=True)
+
+
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -446,6 +483,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=lambda t: check_output(idx, t),
+        check=lambda t: check_outputs(idx, t),
+        compare="mf6",
     )
     test.run()

--- a/autotest/test_gwt_henry_nr.py
+++ b/autotest/test_gwt_henry_nr.py
@@ -169,29 +169,41 @@ def get_model(ws, name, array_input=False):
         bheadspd = {}
         ghbcondspd = {}
         ghbauxspd = {}
+        elevspd = {}
+        drncondspd = {}
+        drnauxspd = {}
     else:
         ghbspd = {}
+        drnspd = {}
     for kper in range(nper):
         if kper == 0:
             sl = sealevel
         else:
             sl = sealevelts[kper]
         sl = np.round(sl, decimals=8)
-        drnlist = []
         if array_input:
             bhead = np.full((nlay, nrow, ncol), DNODATA, dtype=float)
             ghbcond = np.full((nlay, nrow, ncol), DNODATA, dtype=float)
             ghbconc = np.full((nlay, nrow, ncol), DNODATA, dtype=float)
             ghbdens = np.full((nlay, nrow, ncol), DNODATA, dtype=float)
+            elev = np.full((nlay, nrow, ncol), DNODATA, dtype=float)
+            drncond = np.full((nlay, nrow, ncol), DNODATA, dtype=float)
+            drnconc = np.full((nlay, nrow, ncol), DNODATA, dtype=float)
         else:
             ghblist = []
+            drnlist = []
         ghbbnd = 0
         drnbnd = 0
         for k, i, j in zip(kidx, iidx, jidx):
             zcell = zcellcenters[k, i, j]
             cond = 864.0 * (delz * delc) / (0.5 * delr)
             if zcell > sl:
-                drnlist.append([(k, i, j), zcell, 864.0, 0.0])
+                if array_input:
+                    elev[k, i, j] = zcell
+                    drncond[k, i, j] = 864.0
+                    drnconc[k, i, j] = 0.0
+                else:
+                    drnlist.append([(k, i, j), zcell, 864.0, 0.0])
                 drnbnd += 1
             else:
                 if array_input:
@@ -210,18 +222,37 @@ def get_model(ws, name, array_input=False):
             else:
                 ghbspd[kper] = ghblist
         if drnbnd > 0:
-            drnspd[kper] = drnlist
+            if array_input:
+                elevspd[kper] = elev
+                drncondspd[kper] = drncond
+                drnauxspd[kper] = [drnconc]
+            else:
+                drnspd[kper] = drnlist
 
     # drn
-    drn1 = flopy.mf6.ModflowGwfdrn(
-        gwf,
-        stress_period_data=drnspd,
-        print_input=True,
-        print_flows=True,
-        save_flows=False,
-        pname="DRN-1",
-        auxiliary="CONCENTRATION",
-    )
+    if array_input:
+        drn1 = flopy.mf6.ModflowGwfdrng(
+            gwf,
+            print_input=True,
+            print_flows=True,
+            save_flows=False,
+            maxbound=11,
+            pname="DRN-1",
+            auxiliary=["CONCENTRATION"],
+            elev=elevspd,
+            cond=drncondspd,
+            aux=drnauxspd,
+        )
+    else:
+        drn1 = flopy.mf6.ModflowGwfdrn(
+            gwf,
+            stress_period_data=drnspd,
+            print_input=True,
+            print_flows=True,
+            save_flows=False,
+            pname="DRN-1",
+            auxiliary="CONCENTRATION",
+        )
 
     # ghb / ghbg
     if array_input:

--- a/autotest/test_netcdf_gwt_henry_nr.py
+++ b/autotest/test_netcdf_gwt_henry_nr.py
@@ -39,6 +39,7 @@ def build_models(idx, test, export):
     # mc.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwf = mc.gwf[0]
     gwf.get_package("GHB-1").export_array_netcdf = True
+    gwf.get_package("DRN-1").export_array_netcdf = True
 
     name = "gwf_" + cases[idx]
 
@@ -89,7 +90,7 @@ def check_output(idx, test, export):
         f.write(f"  NPF6  {name}.npf  npf\n")
         f.write(f"  STO6  {name}.sto  sto\n")
         f.write(f"  BUY6  {name}.buy  buy\n")
-        f.write(f"  DRN6  {name}.drn  drn-1\n")
+        f.write(f"  DRN6  {name}.drng  drn-1\n")
         f.write(f"  GHB6  {name}.ghbg  ghb-1\n")
         f.write(f"  WEL6  {name}.wel  wel-1\n")
         f.write(f"  OC6  {name}.oc  oc\n")
@@ -112,6 +113,32 @@ def check_output(idx, test, export):
             f.write("  concentration NETCDF\n")
             f.write("  density NETCDF\n")
             f.write(f"END period {i + 1}\n\n")
+
+    with open(ws / f"{name}.drng", "w") as f:
+        f.write("BEGIN options\n")
+        f.write("  READARRAYGRID\n")
+        f.write("  auxiliary  CONCENTRATION\n")
+        f.write("  PRINT_INPUT\n")
+        f.write("  PRINT_FLOWS\n")
+        f.write("END options\n\n")
+        f.write("BEGIN dimensions\n")
+        f.write("  MAXBOUND  11\n")
+        f.write("END dimensions\n\n")
+        for i in range(1001):
+            kper = i + 1
+            if (
+                (kper > 44 and kper < 83)
+                or (kper > 294 and kper < 333)
+                or (kper > 544 and kper < 583)
+                or (kper > 794 and kper < 833)
+            ):
+                pass
+            else:
+                f.write(f"BEGIN period {i + 1}\n")
+                f.write("  elev NETCDF\n")
+                f.write("  cond NETCDF\n")
+                f.write("  concentration NETCDF\n")
+                f.write(f"END period {i + 1}\n\n")
 
     success, buff = flopy.run_model(
         test.targets["mf6"],

--- a/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
@@ -1,0 +1,197 @@
+# --------------------- gwf drng options ---------------------
+# flopy multi-package
+# package-type stress-package
+
+block options
+name readarraygrid
+type keyword
+reader urword
+optional false
+longname use array-based grid input
+description indicates that array-based grid input will be used for the drain package.  This keyword must be specified to use array-based grid input.  When READARRAYGRID is specified, values must be provided for every cell within a model grid, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. No data cells should contain the value DNODATA (3.0E+30). 
+default_value True
+
+block options
+name auxiliary
+type string
+shape (naux)
+reader urword
+optional true
+longname keyword to specify aux variables
+description REPLACE auxnames {'{#1}': 'Groundwater Flow'}
+
+block options
+name auxmultname
+type string
+shape
+reader urword
+optional true
+longname name of auxiliary variable for multiplier
+description REPLACE auxmultname {'{#1}': 'drain conductance'}
+
+block options
+name auxdepthname
+type string
+shape
+reader urword
+optional true
+longname name of auxiliary variable for drainage depth
+description name of a variable listed in AUXILIARY that defines the depth at which drainage discharge will be scaled. If a positive value is specified for the AUXDEPTHNAME AUXILIARY variable, then ELEV is the elevation at which the drain starts to discharge and ELEV + DDRN (assuming DDRN is the AUXDEPTHNAME variable) is the elevation when the drain conductance (COND) scaling factor is 1. If a negative drainage depth value is specified for DDRN, then ELEV + DDRN is the elevation at which the drain starts to discharge and ELEV is the elevation when the conductance (COND) scaling factor is 1. A linear- or cubic-scaling is used to scale the drain conductance (COND) when the Standard or Newton-Raphson Formulation is used, respectively.  This discharge scaling option is described in more detail in Chapter 3 of the Supplemental Technical Information.
+
+block options
+name print_input
+type keyword
+reader urword
+optional true
+longname print input to listing file
+description REPLACE print_input {'{#1}': 'drain'}
+mf6internal iprpak
+
+block options
+name print_flows
+type keyword
+reader urword
+optional true
+longname print calculated flows to listing file
+description REPLACE print_flows {'{#1}': 'drain'}
+mf6internal iprflow
+
+block options
+name save_flows
+type keyword
+reader urword
+optional true
+longname save DRNG flows to budget file
+description REPLACE save_flows {'{#1}': 'drain'}
+mf6internal ipakcb
+
+block options
+name obs_filerecord
+type record obs6 filein obs6_filename
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name obs6
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname obs keyword
+description keyword to specify that record corresponds to an observations file.
+
+block options
+name filein
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an input filename is expected next.
+
+block options
+name obs6_filename
+type string
+preserve_case true
+in_record true
+tagged false
+reader urword
+optional false
+longname obs6 input filename
+description REPLACE obs6_filename {'{#1}': 'Drain'}
+
+block options
+name mover
+type keyword
+tagged true
+reader urword
+optional true
+longname
+description REPLACE mover {'{#1}': 'Drain'}
+
+block options
+name export_array_netcdf
+type keyword
+reader urword
+optional true
+mf6internal export_nc
+longname export array variables to netcdf output files.
+description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+extended true
+
+# dev options
+block options
+name dev_cubic_scaling
+type keyword
+reader urword
+optional true
+longname cubic-scaling
+description cubic-scaling is used to scale the drain conductance
+mf6internal icubicsfac
+
+# --------------------- gwf drng dimensions ---------------------
+
+block dimensions
+name maxbound
+type integer
+reader urword
+optional true
+longname maximum number of drain cells in any stress period
+description REPLACE maxbound {'{#1}': 'drains'}
+
+# --------------------- gwf drng period ---------------------
+
+block period
+name iper
+type integer
+block_variable True
+in_record true
+tagged false
+shape
+valid
+reader urword
+optional false
+longname stress period number
+description REPLACE iper {}
+
+block period
+name elev
+type double precision
+shape (nodes)
+reader readarray
+layered true
+netcdf true
+longname drain elevation
+description is the elevation of the drain.
+default_value 3.e30
+
+block period
+name cond
+type double precision
+shape (nodes)
+reader readarray
+layered true
+netcdf true
+longname drain conductance
+description is the hydraulic conductance of the interface between the aquifer and the drain.
+default_value 3.e30
+
+block period
+name aux
+type double precision
+shape (nodes)
+reader readarray
+layered true
+netcdf true
+optional true
+longname drain auxiliary variable iaux
+description is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the drain array will be multiplied by this array.
+mf6internal auxvar

--- a/make/makefile
+++ b/make/makefile
@@ -23,6 +23,7 @@ SOURCEDIR16=../src/Model/OverlandFlow
 SOURCEDIR17=../src/Model/ParticleTracking
 SOURCEDIR18=../src/Model/SurfaceWaterFlow
 SOURCEDIR19=../src/Model/TransportModel
+<<<<<<< HEAD
 SOURCEDIR20=../src/Model/TransportModel/InterpolationScheme
 SOURCEDIR21=../src/Solution
 SOURCEDIR22=../src/Solution/LinearMethods
@@ -35,6 +36,20 @@ SOURCEDIR28=../src/Timing
 SOURCEDIR29=../src/Utilities
 SOURCEDIR30=../src/Utilities/ArrayRead
 SOURCEDIR31=../src/Utilities/Export
+=======
+SOURCEDIR20=../src/Solution
+SOURCEDIR21=../src/Solution/LinearMethods
+SOURCEDIR22=../src/Solution/PETSc
+SOURCEDIR23=../src/Solution/ParticleTracker
+SOURCEDIR24=../src/Solution/ParticleTracker/Domain
+SOURCEDIR25=../src/Solution/ParticleTracker/Method
+SOURCEDIR26=../src/Solution/ParticleTracker/Particle
+SOURCEDIR27=../src/Timing
+SOURCEDIR28=../src/Utilities
+SOURCEDIR29=../src/Utilities/ArrayRead
+SOURCEDIR30=../src/Utilities/Export
+SOURCEDIR31=../src/Utilities/Export/tmp
+>>>>>>> ef73b153d8 (rebuild makefiles)
 SOURCEDIR32=../src/Utilities/Idm
 SOURCEDIR33=../src/Utilities/Idm/mf6blockfile
 SOURCEDIR34=../src/Utilities/Idm/netcdf
@@ -185,6 +200,7 @@ $(OBJDIR)/gwf-ghbgidm.o \
 $(OBJDIR)/gwf-evtidm.o \
 $(OBJDIR)/gwf-evtaidm.o \
 $(OBJDIR)/gwf-drnidm.o \
+$(OBJDIR)/gwf-drngidm.o \
 $(OBJDIR)/gwf-disvidm.o \
 $(OBJDIR)/gwf-disuidm.o \
 $(OBJDIR)/gwf-disidm.o \

--- a/make/makefile
+++ b/make/makefile
@@ -23,7 +23,6 @@ SOURCEDIR16=../src/Model/OverlandFlow
 SOURCEDIR17=../src/Model/ParticleTracking
 SOURCEDIR18=../src/Model/SurfaceWaterFlow
 SOURCEDIR19=../src/Model/TransportModel
-<<<<<<< HEAD
 SOURCEDIR20=../src/Model/TransportModel/InterpolationScheme
 SOURCEDIR21=../src/Solution
 SOURCEDIR22=../src/Solution/LinearMethods
@@ -36,36 +35,23 @@ SOURCEDIR28=../src/Timing
 SOURCEDIR29=../src/Utilities
 SOURCEDIR30=../src/Utilities/ArrayRead
 SOURCEDIR31=../src/Utilities/Export
-=======
-SOURCEDIR20=../src/Solution
-SOURCEDIR21=../src/Solution/LinearMethods
-SOURCEDIR22=../src/Solution/PETSc
-SOURCEDIR23=../src/Solution/ParticleTracker
-SOURCEDIR24=../src/Solution/ParticleTracker/Domain
-SOURCEDIR25=../src/Solution/ParticleTracker/Method
-SOURCEDIR26=../src/Solution/ParticleTracker/Particle
-SOURCEDIR27=../src/Timing
-SOURCEDIR28=../src/Utilities
-SOURCEDIR29=../src/Utilities/ArrayRead
-SOURCEDIR30=../src/Utilities/Export
-SOURCEDIR31=../src/Utilities/Export/tmp
->>>>>>> ef73b153d8 (rebuild makefiles)
-SOURCEDIR32=../src/Utilities/Idm
-SOURCEDIR33=../src/Utilities/Idm/mf6blockfile
-SOURCEDIR34=../src/Utilities/Idm/netcdf
-SOURCEDIR35=../src/Utilities/Libraries
-SOURCEDIR36=../src/Utilities/Libraries/blas
-SOURCEDIR37=../src/Utilities/Libraries/daglib
-SOURCEDIR38=../src/Utilities/Libraries/rcm
-SOURCEDIR39=../src/Utilities/Libraries/sparsekit
-SOURCEDIR40=../src/Utilities/Libraries/sparskit2
-SOURCEDIR41=../src/Utilities/Matrix
-SOURCEDIR42=../src/Utilities/Memory
-SOURCEDIR43=../src/Utilities/Observation
-SOURCEDIR44=../src/Utilities/OutputControl
-SOURCEDIR45=../src/Utilities/Performance
-SOURCEDIR46=../src/Utilities/TimeSeries
-SOURCEDIR47=../src/Utilities/Vector
+SOURCEDIR32=../src/Utilities/Export/tmp
+SOURCEDIR33=../src/Utilities/Idm
+SOURCEDIR34=../src/Utilities/Idm/mf6blockfile
+SOURCEDIR35=../src/Utilities/Idm/netcdf
+SOURCEDIR36=../src/Utilities/Libraries
+SOURCEDIR37=../src/Utilities/Libraries/blas
+SOURCEDIR38=../src/Utilities/Libraries/daglib
+SOURCEDIR39=../src/Utilities/Libraries/rcm
+SOURCEDIR40=../src/Utilities/Libraries/sparsekit
+SOURCEDIR41=../src/Utilities/Libraries/sparskit2
+SOURCEDIR42=../src/Utilities/Matrix
+SOURCEDIR43=../src/Utilities/Memory
+SOURCEDIR44=../src/Utilities/Observation
+SOURCEDIR45=../src/Utilities/OutputControl
+SOURCEDIR46=../src/Utilities/Performance
+SOURCEDIR47=../src/Utilities/TimeSeries
+SOURCEDIR48=../src/Utilities/Vector
 
 VPATH = \
 ${SOURCEDIR1} \
@@ -114,7 +100,8 @@ ${SOURCEDIR43} \
 ${SOURCEDIR44} \
 ${SOURCEDIR45} \
 ${SOURCEDIR46} \
-${SOURCEDIR47} 
+${SOURCEDIR47} \
+${SOURCEDIR48} 
 
 .SUFFIXES: .f90 .F90 .o
 

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -173,6 +173,7 @@
 		<File RelativePath="..\src\Idm\gwf-disuidm.f90"/>
 		<File RelativePath="..\src\Idm\gwf-disvidm.f90"/>
 		<File RelativePath="..\src\Idm\gwf-drnidm.f90"/>
+		<File RelativePath="..\src\Idm\gwf-drngidm.f90"/>
 		<File RelativePath="..\src\Idm\gwf-evtaidm.f90"/>
 		<File RelativePath="..\src\Idm\gwf-evtidm.f90"/>
 		<File RelativePath="..\src\Idm\gwf-ghbgidm.f90"/>

--- a/src/Idm/gwf-drngidm.f90
+++ b/src/Idm/gwf-drngidm.f90
@@ -1,0 +1,434 @@
+! ** Do Not Modify! MODFLOW 6 system generated file. **
+module GwfDrngInputModule
+  use ConstantsModule, only: LENVARNAME
+  use InputDefinitionModule, only: InputParamDefinitionType, &
+                                   InputBlockDefinitionType
+  private
+  public gwf_drng_param_definitions
+  public gwf_drng_aggregate_definitions
+  public gwf_drng_block_definitions
+  public GwfDrngParamFoundType
+  public gwf_drng_multi_package
+  public gwf_drng_subpackages
+
+  type GwfDrngParamFoundType
+    logical :: readarraygrid = .false.
+    logical :: auxiliary = .false.
+    logical :: auxmultname = .false.
+    logical :: auxdepthname = .false.
+    logical :: iprpak = .false.
+    logical :: iprflow = .false.
+    logical :: ipakcb = .false.
+    logical :: obs_filerecord = .false.
+    logical :: obs6 = .false.
+    logical :: filein = .false.
+    logical :: obs6_filename = .false.
+    logical :: mover = .false.
+    logical :: export_nc = .false.
+    logical :: icubicsfac = .false.
+    logical :: maxbound = .false.
+    logical :: elev = .false.
+    logical :: cond = .false.
+    logical :: auxvar = .false.
+  end type GwfDrngParamFoundType
+
+  logical :: gwf_drng_multi_package = .true.
+
+  character(len=16), parameter :: &
+    gwf_drng_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_readarraygrid = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'READARRAYGRID', & ! tag name
+    'READARRAYGRID', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'use array-based grid input', & ! longname
+    .true., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_auxiliary = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'AUXILIARY', & ! tag name
+    'AUXILIARY', & ! fortran variable
+    'STRING', & ! type
+    'NAUX', & ! shape
+    'keyword to specify aux variables', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_auxmultname = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'AUXMULTNAME', & ! tag name
+    'AUXMULTNAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'name of auxiliary variable for multiplier', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_auxdepthname = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'AUXDEPTHNAME', & ! tag name
+    'AUXDEPTHNAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'name of auxiliary variable for drainage depth', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_iprpak = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'PRINT_INPUT', & ! tag name
+    'IPRPAK', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'print input to listing file', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_iprflow = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'PRINT_FLOWS', & ! tag name
+    'IPRFLOW', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'print calculated flows to listing file', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_ipakcb = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'SAVE_FLOWS', & ! tag name
+    'IPAKCB', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'save DRNG flows to budget file', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_obs_filerecord = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'OBS_FILERECORD', & ! tag name
+    'OBS_FILERECORD', & ! fortran variable
+    'RECORD OBS6 FILEIN OBS6_FILENAME', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_obs6 = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'OBS6', & ! tag name
+    'OBS6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'obs keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_filein = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEIN', & ! tag name
+    'FILEIN', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_obs6_filename = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'OBS6_FILENAME', & ! tag name
+    'OBS6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'obs6 input filename', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_mover = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'MOVER', & ! tag name
+    'MOVER', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_export_nc = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'EXPORT_ARRAY_NETCDF', & ! tag name
+    'EXPORT_NC', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'export array variables to netcdf output files.', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_icubicsfac = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'OPTIONS', & ! block
+    'DEV_CUBIC_SCALING', & ! tag name
+    'ICUBICSFAC', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'cubic-scaling', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_maxbound = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'DIMENSIONS', & ! block
+    'MAXBOUND', & ! tag name
+    'MAXBOUND', & ! fortran variable
+    'INTEGER', & ! type
+    '', & ! shape
+    'maximum number of drain cells in any stress period', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_elev = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'PERIOD', & ! block
+    'ELEV', & ! tag name
+    'ELEV', & ! fortran variable
+    'DOUBLE1D', & ! type
+    'NODES', & ! shape
+    'drain elevation', & ! longname
+    .true., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .true., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_cond = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'PERIOD', & ! block
+    'COND', & ! tag name
+    'COND', & ! fortran variable
+    'DOUBLE1D', & ! type
+    'NODES', & ! shape
+    'drain conductance', & ! longname
+    .true., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .true., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfdrng_auxvar = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'DRNG', & ! subcomponent
+    'PERIOD', & ! block
+    'AUX', & ! tag name
+    'AUXVAR', & ! fortran variable
+    'DOUBLE2D', & ! type
+    'NAUX NODES', & ! shape
+    'drain auxiliary variable iaux', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .true., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwf_drng_param_definitions(*) = &
+    [ &
+    gwfdrng_readarraygrid, &
+    gwfdrng_auxiliary, &
+    gwfdrng_auxmultname, &
+    gwfdrng_auxdepthname, &
+    gwfdrng_iprpak, &
+    gwfdrng_iprflow, &
+    gwfdrng_ipakcb, &
+    gwfdrng_obs_filerecord, &
+    gwfdrng_obs6, &
+    gwfdrng_filein, &
+    gwfdrng_obs6_filename, &
+    gwfdrng_mover, &
+    gwfdrng_export_nc, &
+    gwfdrng_icubicsfac, &
+    gwfdrng_maxbound, &
+    gwfdrng_elev, &
+    gwfdrng_cond, &
+    gwfdrng_auxvar &
+    ]
+
+  type(InputParamDefinitionType), parameter :: &
+    gwf_drng_aggregate_definitions(*) = &
+    [ &
+    InputParamDefinitionType &
+    ( &
+    '', & ! component
+    '', & ! subcomponent
+    '', & ! block
+    '', & ! tag name
+    '', & ! fortran variable
+    '', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    ) &
+    ]
+
+  type(InputBlockDefinitionType), parameter :: &
+    gwf_drng_block_definitions(*) = &
+    [ &
+    InputBlockDefinitionType( &
+    'OPTIONS', & ! blockname
+    .true., & ! required
+    .false., & ! aggregate
+    .false. & ! block_variable
+    ), &
+    InputBlockDefinitionType( &
+    'DIMENSIONS', & ! blockname
+    .false., & ! required
+    .false., & ! aggregate
+    .false. & ! block_variable
+    ), &
+    InputBlockDefinitionType( &
+    'PERIOD', & ! blockname
+    .true., & ! required
+    .false., & ! aggregate
+    .true. & ! block_variable
+    ) &
+    ]
+
+end module GwfDrngInputModule

--- a/src/Idm/selector/IdmGwfDfnSelector.f90
+++ b/src/Idm/selector/IdmGwfDfnSelector.f90
@@ -11,6 +11,7 @@ module IdmGwfDfnSelectorModule
   use GwfDisuInputModule
   use GwfDisvInputModule
   use GwfDrnInputModule
+  use GwfDrngInputModule
   use GwfEvtInputModule
   use GwfEvtaInputModule
   use GwfGhbInputModule
@@ -69,6 +70,8 @@ contains
       call set_param_pointer(input_definition, gwf_disv_param_definitions)
     case ('DRN')
       call set_param_pointer(input_definition, gwf_drn_param_definitions)
+    case ('DRNG')
+      call set_param_pointer(input_definition, gwf_drng_param_definitions)
     case ('EVT')
       call set_param_pointer(input_definition, gwf_evt_param_definitions)
     case ('EVTA')
@@ -113,6 +116,8 @@ contains
       call set_param_pointer(input_definition, gwf_disv_aggregate_definitions)
     case ('DRN')
       call set_param_pointer(input_definition, gwf_drn_aggregate_definitions)
+    case ('DRNG')
+      call set_param_pointer(input_definition, gwf_drng_aggregate_definitions)
     case ('EVT')
       call set_param_pointer(input_definition, gwf_evt_aggregate_definitions)
     case ('EVTA')
@@ -157,6 +162,8 @@ contains
       call set_block_pointer(input_definition, gwf_disv_block_definitions)
     case ('DRN')
       call set_block_pointer(input_definition, gwf_drn_block_definitions)
+    case ('DRNG')
+      call set_block_pointer(input_definition, gwf_drng_block_definitions)
     case ('EVT')
       call set_block_pointer(input_definition, gwf_evt_block_definitions)
     case ('EVTA')
@@ -200,6 +207,8 @@ contains
       multi_package = gwf_disv_multi_package
     case ('DRN')
       multi_package = gwf_drn_multi_package
+    case ('DRNG')
+      multi_package = gwf_drng_multi_package
     case ('EVT')
       multi_package = gwf_evt_multi_package
     case ('EVTA')
@@ -246,6 +255,8 @@ contains
       call set_subpkg_pointer(subpackages, gwf_disv_subpackages)
     case ('DRN')
       call set_subpkg_pointer(subpackages, gwf_drn_subpackages)
+    case ('DRNG')
+      call set_subpkg_pointer(subpackages, gwf_drng_subpackages)
     case ('EVT')
       call set_subpkg_pointer(subpackages, gwf_evt_subpackages)
     case ('EVTA')
@@ -289,6 +300,8 @@ contains
     case ('DISV')
       integrated = .true.
     case ('DRN')
+      integrated = .true.
+    case ('DRNG')
       integrated = .true.
     case ('EVT')
       integrated = .true.

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -209,22 +209,15 @@ contains
   subroutine bndext_allocate_scalars(this)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr
-    use MemoryManagerExtModule, only: mem_set_value
-    use MemoryHelperModule, only: create_mem_path
-    use SimVariablesModule, only: idm_context
     ! -- dummy variables
     class(BndExtType) :: this !< BndExtType object
     ! -- local variables
-    character(len=LENMEMPATH) :: input_mempath
-    !
-    ! -- set memory path
-    input_mempath = create_mem_path(this%name_model, this%packName, idm_context)
     !
     ! -- allocate base BndType scalars
     call this%BndType%allocate_scalars()
     !
     ! -- set IPER pointer
-    call mem_setptr(this%iper, 'IPER', input_mempath)
+    call mem_setptr(this%iper, 'IPER', this%input_mempath)
 
     ! -- allocate internal scalars
     allocate (this%readarraygrid)
@@ -568,7 +561,7 @@ contains
     ! -- Set the nodelist
     do n = 1, this%nbound
       nodeuser = this%nodeulist(n)
-      noder = this%dis%get_nodenumber(nodeuser, 1)
+      noder = this%dis%get_nodenumber(nodeuser, 0)
       if (noder > 0) then
         this%nodelist(n) = noder
       else

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -569,7 +569,7 @@ contains
     do n = 1, this%nbound
       nodeuser = this%nodeulist(n)
       noder = this%dis%get_nodenumber(nodeuser, 1)
-      if (noder >= 0) then
+      if (noder > 0) then
         this%nodelist(n) = noder
       else
         ninactive = ninactive + 1

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -559,11 +559,11 @@ contains
   subroutine nodeu_to_nlist(this)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr
-    use ConstantsModule, only: LENVARNAME
     ! -- dummy
     class(BndExtType) :: this !< BndExtType object
-    integer(I4B) :: n, noder, nodeuser
-    character(len=LINELENGTH) :: nodestr
+    integer(I4B) :: n, noder, nodeuser, ninactive
+
+    ninactive = 0
 
     ! -- Set the nodelist
     do n = 1, this%nbound
@@ -572,20 +572,12 @@ contains
       if (noder >= 0) then
         this%nodelist(n) = noder
       else
-        call this%dis%nodeu_to_string(n, nodestr)
-        write (errmsg, *) &
-          ' Cell is outside active grid domain: '// &
-          trim(adjustl(nodestr))
-        call store_error(errmsg)
+        ninactive = ninactive + 1
       end if
     end do
-    !
-    ! -- exit if errors were found
-    if (count_errors() > 0) then
-      write (errmsg, *) count_errors(), ' errors encountered.'
-      call store_error(errmsg)
-      call store_error_filename(this%input_fname)
-    end if
+
+    ! update nbound
+    this%nbound = this%nbound - ninactive
   end subroutine nodeu_to_nlist
 
   !> @brief Update the nodelist based on layer number variable input

--- a/src/Utilities/Idm/ModflowInput.f90
+++ b/src/Utilities/Idm/ModflowInput.f90
@@ -99,7 +99,7 @@ contains
     character(len=LENPACKAGETYPE) :: sc_type
     sc_type = subcomponent_type
     select case (subcomponent_type)
-    case ('RCH', 'EVT', 'SCP', 'GHB')
+    case ('RCH', 'EVT', 'SCP', 'DRN', 'GHB')
       sc_type = read_as_arrays(filetype, filename, component_type, &
                                subcomponent_type)
     case default

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
@@ -180,13 +180,6 @@ contains
       ! reset read state
       this%param_reads(n)%invar = 0
     end do
-
-    ! explicitly reset auxvar array each period
-    do m = 1, this%bound_context%maxbound
-      do n = 1, this%bound_context%naux
-        this%bound_context%auxvar(n, m) = DZERO
-      end do
-    end do
   end subroutine reset
 
   subroutine params_alloc(this)

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
@@ -172,7 +172,7 @@ contains
   subroutine reset(this)
     use ConstantsModule, only: DNODATA
     class(GridArrayLoadType), intent(inout) :: this
-    integer(I4B) :: n, m
+    integer(I4B) :: n
 
     this%bound_context%nbound = 0
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -62,6 +62,7 @@ modflow_sources = files(
     'Idm' / 'gwf-disuidm.f90',
     'Idm' / 'gwf-disvidm.f90',
     'Idm' / 'gwf-drnidm.f90',
+    'Idm' / 'gwf-drngidm.f90',
     'Idm' / 'gwf-evtidm.f90',
     'Idm' / 'gwf-evtaidm.f90',
     'Idm' / 'gwf-ghbidm.f90',

--- a/utils/idmloader/dfns.txt
+++ b/utils/idmloader/dfns.txt
@@ -6,6 +6,7 @@ gwf-dis.dfn
 gwf-disu.dfn
 gwf-disv.dfn
 gwf-drn.dfn
+gwf-drng.dfn
 gwf-evt.dfn
 gwf-evta.dfn
 gwf-ghb.dfn


### PR DESCRIPTION
Add `READARRAYGRID` based `GWF DRNG` package

General changes to grid based package input:
  - If data is provided for inactive cells it is silently dropped instead of throwing errors.
  - auxiliary variables are NOT reset at each period as with `READASARRAYS`.  Data will persist once set unless the user provides new data.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Added new test or modified an existing test
- [X] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Added doxygen comments to new and modified procedures
- [X] Updated meson files, makefiles, and Visual Studio project files for new source files
- [X] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
