### PR TITLE
(fix) Solve some memory leaks in the PtrHastable unit tests

### DIFF
--- a/autotest/TestHashTable.f90
+++ b/autotest/TestHashTable.f90
@@ -36,6 +36,8 @@ contains
                  'wrong value for '//to_string(i))
     end do
 
+    call hash_table_da(map)
+
   end subroutine test_add_and_get_value
 
 end module TestHashTable

--- a/autotest/TestHashTable.f90
+++ b/autotest/TestHashTable.f90
@@ -23,7 +23,6 @@ contains
     type(HashTableType), pointer :: map
     integer(I4B) :: i, n
 
-    allocate (map)
     call hash_table_cr(map)
 
     n = 3

--- a/autotest/TestKeyValueList.f90
+++ b/autotest/TestKeyValueList.f90
@@ -60,6 +60,9 @@ contains
     call check(error, value2 == expected_value2)
     if (allocated(error)) return
 
+    ! - Clean up
+    call list%clear()
+
   end subroutine test_add_get_values
 
   !> @brief Test retrieving a value using a non-existing key
@@ -81,6 +84,9 @@ contains
     !- Assert
     call check(error,.not. associated(val_ptr))
     if (allocated(error)) return
+
+    ! - Clean up
+    call list%clear()
 
   end subroutine test_get_nonexisting_value
 
@@ -116,6 +122,9 @@ contains
     !- Assert
     call check(error, cnt == 3)
     if (allocated(error)) return
+
+    ! - Clean up
+    call list%clear()
 
   end subroutine test_count_items
 

--- a/autotest/TestList.f90
+++ b/autotest/TestList.f90
@@ -62,6 +62,7 @@ contains
     end select
     if (allocated(error)) return
 
+    call list%Clear()
     deallocate (list)
     deallocate (n)
   end subroutine test_add_count_get_item
@@ -102,6 +103,7 @@ contains
     call check(error, list%ContainsObject(p), "should contain n2")
     if (allocated(error)) return
 
+    call list%Clear()
     deallocate (list)
     deallocate (n1)
     deallocate (n2)
@@ -150,6 +152,7 @@ contains
     p => list%GetPreviousItem()
     call check(error, (.not. associated(p)))
 
+    call list%Clear()
     deallocate (list)
     deallocate (n1)
     deallocate (n2)
@@ -244,6 +247,7 @@ contains
     p => list%GetItem(1)
     call check(error, associated(p, n2))
 
+    call list%Clear()
     deallocate (list)
     deallocate (n1)
     deallocate (n2)

--- a/autotest/TestMemoryContainerIterator.f90
+++ b/autotest/TestMemoryContainerIterator.f90
@@ -42,8 +42,11 @@ contains
 
     !- Arrange.
     mt1%name = "TestName1"
+    mt1%path = "TestPath1"
     mt2%name = "TestName2"
+    mt2%path = "TestPath2"
     mt3%name = "TestName3"
+    mt3%path = "TestPath3"
 
     current_mt => mt1
     call memory_container%add(current_mt)
@@ -69,6 +72,9 @@ contains
     !- Assert.
     call check(error, all(iterated .eqv. .true.))
     if (allocated(error)) return
+
+    !- Clean up.
+    call memory_container%clear()
 
   end subroutine test_iterate_through_container
 

--- a/autotest/TestMemoryStore.f90
+++ b/autotest/TestMemoryStore.f90
@@ -52,6 +52,8 @@ contains
     call check(error, mt_ptr%path == path)
     if (allocated(error)) return
 
+    !- Cleanup
+    call container%clear()
   end subroutine test_add_get_values
 
   !> @brief Test retrieving a MemoryType using a non-existing name and path
@@ -74,6 +76,8 @@ contains
     call check(error,.not. associated(mt_ptr))
     if (allocated(error)) return
 
+    !- Cleanup
+    call container%clear()
   end subroutine test_get_nonexisting_value
 
 end module TestMemoryStore

--- a/autotest/TestPtrHashTable.f90
+++ b/autotest/TestPtrHashTable.f90
@@ -63,6 +63,9 @@ contains
     call check(error, value2 == expected_value2)
     if (allocated(error)) return
 
+    ! - Clean up
+    call hashtable%clear()
+
   end subroutine test_add_get_values
 
   !> @brief Test retrieving a value using a non-existing key
@@ -84,6 +87,9 @@ contains
     !- Assert
     call check(error,.not. associated(val_ptr))
     if (allocated(error)) return
+
+    ! - Clean up
+    call hashtable%clear()
 
   end subroutine test_get_nonexisting_value
 
@@ -119,6 +125,9 @@ contains
     !- Assert
     call check(error, cnt == 3)
     if (allocated(error)) return
+
+    ! - Clean up
+    call hashtable%clear()
 
   end subroutine test_count_items
 
@@ -201,6 +210,9 @@ contains
     call check(error,.not. found_item2)
     if (allocated(error)) return
 
+    ! - Clean up
+    call hashtable%clear()
+
   end subroutine test_contains_items
 
   !> @brief Test adding duplicate keys
@@ -229,6 +241,9 @@ contains
     !- Assert
     call check(error, count_warnings() == 1)
     if (allocated(error)) return
+
+    ! - Clean up
+    call hashtable%clear()
 
   end subroutine test_add_duplicate_key
 


### PR DESCRIPTION
When running `Tester` through valgrind some memoryleaks popped 
up in the (Ptr)HashTable related unit tests. The memoryleaks are all in the unit tests themself and not in the production code. 

Still it is good to have the `Tester` memory leak free to not obfuscate any real memory leaks that might pop up in the future

Checklist of items for pull request

- [ ] Replaced section above with description of pull request
- [ ] Closed issue #xxxx
- [ ] Referenced issue or pull request #xxxx
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
