### PR TITLE
test(prt): fix flowface/stopzone/extended tracking combo test

### DIFF
--- a/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
@@ -142,9 +142,14 @@ contains
       return
     end if
 
-    ! Particle stationary, terminate it if it's the last timestep
+    ! If particle stationary and extended tracking is on, terminate here if it's
+    ! the last timestep. TODO: temporary solution, consider where to catch this?
+    ! Should we really have to special case this here? We do diverge from MP7 in
+    ! guaranteeing that every particle terminates at the end of the simulation..
+    ! ideally that would be handled at a higher scope but with extended tracking
+    ! tmax is not the end of the simulation, it's just a wildly high upper bound.
     if ((statusVX .eq. 2) .and. (statusVY .eq. 2) .and. (statusVZ .eq. 2) .and. &
-        endofsimulation) then
+        particle%iextend > 0 .and. endofsimulation) then
       call this%events%terminate(particle, status=TERM_TIMEOUT)
       return
     end if
@@ -210,6 +215,8 @@ contains
         call this%events%usertime(particle)
       end do
     end if
+
+    print *, "texit: ", texit, " tmax: ", tmax
 
     if (texit .gt. tmax) then
       ! The computed exit time is greater than the maximum time, so set

--- a/src/Solution/ParticleTracker/Particle/ParticleEvent.f90
+++ b/src/Solution/ParticleTracker/Particle/ParticleEvent.f90
@@ -33,7 +33,6 @@ module ParticleEventModule
     integer(I4B) :: code = -1 ! event code
     integer(I4B) :: kper = 0, kstp = 0 ! period and step
     real(DP) :: time = 0.0_DP ! simulation time
-    character(len=:), allocatable :: context ! optional context string
   contains
     procedure :: get_code
     procedure :: get_str

--- a/src/Solution/ParticleTracker/Particle/ParticleEvents.f90
+++ b/src/Solution/ParticleTracker/Particle/ParticleEvents.f90
@@ -51,13 +51,12 @@ contains
   end subroutine subscribe
 
   !> @brief Dispatch an event. Internal use only.
-  subroutine dispatch(this, particle, event, context)
+  subroutine dispatch(this, particle, event)
     use TdisModule, only: kper, kstp, totimc
     ! dummy
     class(ParticleEventDispatcherType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
     class(ParticleEventType), pointer, intent(inout) :: event
-    character(len=*), intent(in), optional :: context
     ! local
     integer(I4B) :: per, stp
 
@@ -82,10 +81,6 @@ contains
     event%time = particle%ttrack
     event%kper = per
     event%kstp = stp
-    if (present(context)) then
-      allocate (character(len=len(context)) :: event%context)
-      event%context = context
-    end if
 
     call this%consumer%handle_event(particle, event)
     deallocate (event)
@@ -99,33 +94,30 @@ contains
   end subroutine destroy
 
   !> @brief Particle is released.
-  subroutine release(this, particle, context)
+  subroutine release(this, particle)
     class(ParticleEventDispatcherType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
-    character(len=*), intent(in), optional :: context
     class(ParticleEventType), pointer :: event
 
     allocate (ReleaseEventType :: event)
-    call this%dispatch(particle, event, context)
+    call this%dispatch(particle, event)
   end subroutine release
 
   !> @brief Particle exits a cell.
-  subroutine cellexit(this, particle, context)
+  subroutine cellexit(this, particle)
     class(ParticleEventDispatcherType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
-    character(len=*), intent(in), optional :: context
     class(ParticleEventType), pointer :: event
 
     allocate (CellExitEventType :: event)
-    call this%dispatch(particle, event, context)
+    call this%dispatch(particle, event)
   end subroutine cellexit
 
   !> @brief Particle terminates.
-  subroutine terminate(this, particle, status, context)
+  subroutine terminate(this, particle, status)
     class(ParticleEventDispatcherType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
     integer(I4B), intent(in), optional :: status
-    character(len=*), intent(in), optional :: context
     class(ParticleEventType), pointer :: event
 
     particle%advancing = .false.
@@ -134,40 +126,37 @@ contains
     end if
 
     allocate (TerminationEventType :: event)
-    call this%dispatch(particle, event, context)
+    call this%dispatch(particle, event)
   end subroutine terminate
 
   !> @brief Time step ends.
-  subroutine timestep(this, particle, context)
+  subroutine timestep(this, particle)
     class(ParticleEventDispatcherType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
-    character(len=*), intent(in), optional :: context
     class(ParticleEventType), pointer :: event
 
     allocate (TimeStepEventType :: event)
-    call this%dispatch(particle, event, context)
+    call this%dispatch(particle, event)
   end subroutine timestep
 
   !> @brief Particle leaves a weak sink.
-  subroutine weaksink(this, particle, context)
+  subroutine weaksink(this, particle)
     class(ParticleEventDispatcherType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
-    character(len=*), intent(in), optional :: context
     class(ParticleEventType), pointer :: event
 
     allocate (WeakSinkEventType :: event)
-    call this%dispatch(particle, event, context)
+    call this%dispatch(particle, event)
   end subroutine weaksink
 
   !> @brief User-defined tracking time occurs.
-  subroutine usertime(this, particle, context)
+  subroutine usertime(this, particle)
     class(ParticleEventDispatcherType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
-    character(len=*), intent(in), optional :: context
     class(ParticleEventType), pointer :: event
 
     allocate (UserTimeEventType :: event)
-    call this%dispatch(particle, event, context)
+    call this%dispatch(particle, event)
   end subroutine usertime
 
 end module ParticleEventsModule

--- a/src/Solution/ParticleTracker/Particle/ParticleTrackOutput.f90
+++ b/src/Solution/ParticleTracker/Particle/ParticleTrackOutput.f90
@@ -277,11 +277,13 @@ contains
       ' in (Layer: ', particle%ilay, &
       '  Cell: ', particle%icu, &
       '  Zone: ', particle%izone, &
-      ') at (Time ', particle%ttrack, &
-      '  Period ', event%kper, &
-      '  Timestep ', event%kstp, &
-      ') with (Status: ', particle%istatus, &
-      '  Context: ', trim(adjustl(event%context)), ')'
+      ') at (X: ', particle%x, &
+      '  Y: ', particle%y, &
+      '  Z: ', particle%z, &
+      '  Time: ', particle%ttrack, &
+      '  Period: ', event%kper, &
+      '  Timestep: ', event%kstp, &
+      ') with (Status: ', particle%istatus, ')'
   end subroutine log_event
 
   !> @brief Handle a particle event.


### PR DESCRIPTION
Fix the `test_prt_iflowface_istopzone.py` autotest configuration to make sure PRT and MP7 are consuming identical flows and running with identical configurations (there were several differences). With this, endpoints now agree. Still some slightly different results with extended tracking on, but the differences seem small enough to chalk up to compiler toolchain and/or optimization flags. This makes me fairly confident we can close #2358.

But this does point to the fact that it's not easy to a) convert an MP7 simulation to an identical PRT simulation or b) verify that they are identically configured after doing so, without running them and comparing results. We need to consider how to improve flopy in this area.

Also, fix the fix introduced in #2369 for termination in cells with zero flow under extended tracking. It should only apply if extended tracking is on. This deserves more consideration (can we avoid special casing terminations like this at the subcell level, while guaranteeing that tracking time is accurately reported?) in followup.

Also, remove the context string on the new particle event type introduced recently. YAGNI

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Closed issue #2358
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Removed checklist items not relevant to this pull request
