### PR TITLE
chore(test_gwf_sfr_reorder.py): cleanup deprecation warning

### DIFF
--- a/autotest/test_gwf_sfr_reorder.py
+++ b/autotest/test_gwf_sfr_reorder.py
@@ -97,7 +97,7 @@ def build_model(idx, ws):
             nconn += 1
         rp = [
             irch,
-            "none",
+            (-1, -1, -1),
             rlen,
             rwid,
             slope,


### PR DESCRIPTION
Running test_gwf_sfr_reorder.py was printing deprecation warnings leftover from version 6.4.x.  Making subtle change that uses the current approach for having no connections between an SFR reach and underlying cell to shutoff the deprecation warning.

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
