### PR TITLE
refactor: introduce binary file header type

### DIFF
--- a/src/Model/ModelUtilities/FlowModelInterface.f90
+++ b/src/Model/ModelUtilities/FlowModelInterface.f90
@@ -611,8 +611,8 @@ contains
     ! -- or if that record is the last one in the budget file.
     readnext = .true.
     if (kstp * kper > 1) then
-      if (this%bfr%kstp == 1) then
-        if (this%bfr%kpernext == kper + 1) then
+      if (this%bfr%header%kstp == 1) then
+        if (this%bfr%headernext%kper == kper + 1) then
           readnext = .false.
         else if (this%bfr%endoffile) then
           readnext = .false.
@@ -644,7 +644,7 @@ contains
         end if
         !
         ! -- Ensure kper is same between model and budget file
-        if (kper /= this%bfr%kper) then
+        if (kper /= this%bfr%header%kper) then
           write (errmsg, '(4x,a)') 'PERIOD NUMBER IN BUDGET FILE &
             &DOES NOT MATCH PERIOD NUMBER IN TRANSPORT MODEL.  IF THERE &
             &IS MORE THAN ONE TIME STEP IN THE BUDGET FILE FOR A GIVEN &
@@ -655,7 +655,7 @@ contains
         end if
         !
         ! -- if budget file kstp > 1, then kstp must match
-        if (this%bfr%kstp > 1 .and. (kstp /= this%bfr%kstp)) then
+        if (this%bfr%header%kstp > 1 .and. (kstp /= this%bfr%header%kstp)) then
           write (errmsg, '(4x,a)') 'TIME STEP NUMBER IN BUDGET FILE &
             &DOES NOT MATCH TIME STEP NUMBER IN TRANSPORT MODEL.  IF THERE &
             &IS MORE THAN ONE TIME STEP IN THE BUDGET FILE FOR A GIVEN STRESS &
@@ -720,7 +720,8 @@ contains
     else
       !
       ! -- write message to indicate that flows are being reused
-      write (this%iout, fmtbudkstpkper) kstp, kper, this%bfr%kstp, this%bfr%kper
+      write (this%iout, fmtbudkstpkper) kstp, kper, &
+        this%bfr%header%kstp, this%bfr%header%kper
       !
       ! -- set the flag to indicate that flows were not updated
       this%iflowsupdated = 0
@@ -764,8 +765,8 @@ contains
     ! -- or if that record is the last one in the head file.
     readnext = .true.
     if (kstp * kper > 1) then
-      if (this%hfr%kstp == 1) then
-        if (this%hfr%kpernext == kper + 1) then
+      if (this%hfr%header%kstp == 1) then
+        if (this%hfr%headernext%kper == kper + 1) then
           readnext = .false.
         else if (this%hfr%endoffile) then
           readnext = .false.
@@ -797,7 +798,7 @@ contains
         end if
         !
         ! -- Ensure kper is same between model and head file
-        if (kper /= this%hfr%kper) then
+        if (kper /= this%hfr%header%kper) then
           write (errmsg, '(4x,a)') 'PERIOD NUMBER IN HEAD FILE &
             &DOES NOT MATCH PERIOD NUMBER IN TRANSPORT MODEL.  IF THERE &
             &IS MORE THAN ONE TIME STEP IN THE HEAD FILE FOR A GIVEN STRESS &
@@ -808,7 +809,7 @@ contains
         end if
         !
         ! -- if head file kstp > 1, then kstp must match
-        if (this%hfr%kstp > 1 .and. (kstp /= this%hfr%kstp)) then
+        if (this%hfr%header%kstp > 1 .and. (kstp /= this%hfr%header%kstp)) then
           write (errmsg, '(4x,a)') 'TIME STEP NUMBER IN HEAD FILE &
             &DOES NOT MATCH TIME STEP NUMBER IN TRANSPORT MODEL.  IF THERE &
             &IS MORE THAN ONE TIME STEP IN THE HEAD FILE FOR A GIVEN STRESS &
@@ -829,7 +830,8 @@ contains
         end do
       end do
     else
-      write (this%iout, fmthdskstpkper) kstp, kper, this%hfr%kstp, this%hfr%kper
+      write (this%iout, fmthdskstpkper) kstp, kper, &
+        this%hfr%header%kstp, this%hfr%header%kper
     end if
   end subroutine advance_hfr
 

--- a/src/Utilities/BudgetFileReader.f90
+++ b/src/Utilities/BudgetFileReader.f90
@@ -75,11 +75,12 @@ contains
       if (.not. success) exit
       this%nbudterms = this%nbudterms + 1
       if (this%naux > maxaux) maxaux = this%naux
-      if (this%kstp /= this%kstpnext .or. this%kper /= this%kpernext) &
+      if (this%header%kstp /= this%headernext%kstp .or. &
+          this%header%kper /= this%headernext%kper) &
         exit
     end do
-    kstp_last = this%kstp
-    kper_last = this%kper
+    kstp_last = this%header%kstp
+    kper_last = this%header%kper
     allocate (this%budtxtarray(this%nbudterms))
     allocate (this%imetharray(this%nbudterms))
     allocate (this%dstpackagenamearray(this%nbudterms))
@@ -128,8 +129,8 @@ contains
       iout_opt = 0
     end if
     !
-    this%kstp = 0
-    this%kper = 0
+    this%header%kstp = 0
+    this%header%kper = 0
     this%budtxt = ''
     this%nval = 0
     this%naux = 0
@@ -141,16 +142,17 @@ contains
     this%dstpackagename = ''
 
     success = .true.
-    this%kstpnext = 0
-    this%kpernext = 0
-    read (this%inunit, iostat=iostat) this%kstp, this%kper, this%budtxt, &
-      this%nval, this%idum1, this%idum2
+    this%headernext%kstp = 0
+    this%headernext%kper = 0
+    read (this%inunit, iostat=iostat) this%header%kstp, this%header%kper, &
+      this%budtxt, this%nval, this%idum1, this%idum2
     if (iostat /= 0) then
       success = .false.
       if (iostat < 0) this%endoffile = .true.
       return
     end if
-    read (this%inunit) this%imeth, this%delt, this%pertim, this%totim
+    read (this%inunit) this%imeth, this%header%delt, &
+      this%header%pertim, this%header%totim
     if (this%imeth == 1) then
       if (trim(adjustl(this%budtxt)) == 'FLOW-JA-FACE') then
         if (allocated(this%flowja)) deallocate (this%flowja)
@@ -198,7 +200,7 @@ contains
       call store_error_unit(this%inunit)
     end if
     if (iout_opt > 0) then
-      write (iout_opt, '(1pg15.6, a, 1x, a)') this%totim, this%budtxt, &
+      write (iout_opt, '(1pg15.6, a, 1x, a)') this%header%totim, this%budtxt, &
         this%dstpackagename
     end if
     !

--- a/src/Utilities/BudgetObject.f90
+++ b/src/Utilities/BudgetObject.f90
@@ -644,7 +644,8 @@ contains
       if (this%bfr%endoffile) then
         readnext = .false.
       else
-        if (this%bfr%kpernext == kper + 1 .and. this%bfr%kstpnext == 1) &
+        if (this%bfr%headernext%kper == kper + 1 .and. &
+            this%bfr%headernext%kstp == 1) &
           readnext = .false.
       end if
     end if
@@ -661,7 +662,7 @@ contains
     else
       if (iout > 0) &
         write (iout, fmtbudkstpkper) trim(this%name), kstp, kper, &
-        this%bfr%kstp, this%bfr%kper
+        this%bfr%header%kstp, this%bfr%header%kper
     end if
   end subroutine bfr_advance
 

--- a/src/Utilities/HeadFileReader.f90
+++ b/src/Utilities/HeadFileReader.f90
@@ -38,8 +38,8 @@ contains
     !
     ! -- Read the first head data record to set kstp_last, kstp_last
     call this%read_record(success)
-    kstp_last = this%kstp
-    kper_last = this%kper
+    kstp_last = this%header%kstp
+    kper_last = this%header%kper
     rewind (this%inunit)
     !
     ! -- Determine number of records within a time step
@@ -49,7 +49,7 @@ contains
     do
       call this%read_record(success, iout)
       if (.not. success) exit
-      if (kstp_last /= this%kstp .or. kper_last /= this%kper) exit
+      if (kstp_last /= this%header%kstp .or. kper_last /= this%header%kper) exit
       this%nlay = this%nlay + 1
     end do
     rewind (this%inunit)
@@ -77,13 +77,13 @@ contains
       iout_opt = 0
     end if
     !
-    this%kstp = 0
-    this%kper = 0
+    this%header%kstp = 0
+    this%header%kper = 0
     success = .true.
-    this%kstpnext = 0
-    this%kpernext = 0
-    read (this%inunit, iostat=iostat) this%kstp, this%kper, this%pertim, &
-      this%totim, this%text, ncol, nrow, ilay
+    this%headernext%kstp = 0
+    this%headernext%kper = 0
+    read (this%inunit, iostat=iostat) this%header%kstp, this%header%kper, &
+      this%header%pertim, this%header%totim, this%text, ncol, nrow, ilay
     if (iostat /= 0) then
       success = .false.
       if (iostat < 0) this%endoffile = .true.


### PR DESCRIPTION
Followup to #2384. Collect header properties into a type and expose that from the binary file reader instead of properties individually. Just a tidying step. Next up, scan headers and build an index, which is needed for direction-agnostic readers. The index will come separately, also optionally, since that is a bigger change and has *performance considerations.

The header's file position property `pos` is unused for now. Also the "next" header is awkward, peeking at the next kper/kstp leaves the rest of it unfilled, but this can all be removed once an index is in, at which point there's no need to peek.

___

*Performance notes

I think the memory footprint of an index will be negligible compared to the data itself. It is more common to have a very large grid than a huge number of time steps?

Runtime cost would basically shift from read time (lookahead-and-back) to indexing time, with a small factor increase. It does mean rereads are cheaper, if that's ever necessary, although I'm not sure why multiple passes through a head or budget file would be needed in a single simulation. The main motivation for indexing in advance, rather than lazy reading, is for backwards particle tracking.