### PR TITLE
fix(SfrPackageWriter.f90) mf5to6 write CONNECTIONDATA for reaches with 0 connections

### DIFF
--- a/doc/ConverterGuide/converter_mf5to6.tex
+++ b/doc/ConverterGuide/converter_mf5to6.tex
@@ -287,7 +287,7 @@ This section describes changes introduced into the MODFLOW 6 converter with each
 \item
 \currentmodflowversion
 \begin{itemize}
-  \item None.
+  \item Fixed an issue in the conversion of SFR reaches with no connections to other reaches.  The converter did not write entries to the CONNECTIONDATA block for SFR reaches with no connections.
 \end{itemize}
 
 \item Version 6.1.0---December 12, 2019

--- a/utils/mf5to6/src/SfrPackageWriter.f90
+++ b/utils/mf5to6/src/SfrPackageWriter.f90
@@ -875,14 +875,14 @@ contains
       reach => this%GetReach(i)
       if (.not. reach%KeepReachActive) cycle
       ncon = size(reach%iconn)
+      write(line,70)reach%NewReachNum
       if (ncon > 0) then
-        write(line,70)reach%NewReachNum
         do j=1,ncon
           write(ic,80)reach%iconn(j)
           line = trim(line) // ' ' // ic
         enddo
-        write(iu,60)trim(line)
       endif
+      write(iu,60)trim(line)
     enddo
     !
     ! Write END

--- a/utils/mf5to6/src/SfrPackageWriter.f90
+++ b/utils/mf5to6/src/SfrPackageWriter.f90
@@ -875,14 +875,14 @@ contains
       reach => this%GetReach(i)
       if (.not. reach%KeepReachActive) cycle
       ncon = size(reach%iconn)
-      write(line,70)reach%NewReachNum
       if (ncon > 0) then
+        write(line,70)reach%NewReachNum
         do j=1,ncon
           write(ic,80)reach%iconn(j)
           line = trim(line) // ' ' // ic
         enddo
+        write(iu,60)trim(line)
       endif
-      write(iu,60)trim(line)
     enddo
     !
     ! Write END


### PR DESCRIPTION
Moved write() statements in the write_connectivity() subroutine of SfrPackageWriter.f90 outside the if statement checking whether each reach has >0 connections to write the appropriate CONNECTIONDATA block information for reaches without connections. Added item explaining fix in converter_mf5to6.tex. Resolves issue #2393.
