### PR TITLE
refactor: defer read_header, move delt, more tidying

### DIFF
--- a/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
@@ -216,8 +216,6 @@ contains
       end do
     end if
 
-    print *, "texit: ", texit, " tmax: ", tmax
-
     if (texit .gt. tmax) then
       ! The computed exit time is greater than the maximum time, so set
       ! final time for particle trajectory equal to maximum time and

--- a/src/Utilities/BinaryFileReader.f90
+++ b/src/Utilities/BinaryFileReader.f90
@@ -6,7 +6,7 @@ module BinaryFileReaderModule
 
   public :: BinaryFileHeaderType, BinaryFileReaderType
 
-  type, abstract :: BinaryFileHeaderType
+  type :: BinaryFileHeaderType
     integer(I4B) :: pos
     integer(I4B) :: kper, kstp
     real(DP) :: pertim, totim
@@ -23,6 +23,7 @@ module BinaryFileReaderModule
     procedure(read_header_if), deferred :: read_header
     procedure(read_record_if), deferred :: read_record
     procedure :: peek_record
+    procedure :: rewind
   end type BinaryFileReaderType
 
   abstract interface
@@ -76,4 +77,17 @@ contains
     end if
   end subroutine peek_record
 
+  !> @brief Rewind the file to the beginning.
+  subroutine rewind (this)
+    class(BinaryFileReaderType), intent(inout) :: this
+
+    rewind (this%inunit)
+    if (allocated(this%header)) deallocate (this%header)
+    if (allocated(this%headernext)) deallocate (this%headernext)
+    allocate (BinaryFileHeaderType :: this%header)
+    allocate (BinaryFileHeaderType :: this%headernext)
+    this%header%pos = 1
+    this%headernext%pos = 1
+    this%endoffile = .false.
+  end subroutine rewind
 end module BinaryFileReaderModule

--- a/src/Utilities/BinaryFileReader.f90
+++ b/src/Utilities/BinaryFileReader.f90
@@ -6,10 +6,10 @@ module BinaryFileReaderModule
 
   public :: BinaryFileHeaderType, BinaryFileReaderType
 
-  type :: BinaryFileHeaderType
+  type, abstract :: BinaryFileHeaderType
     integer(I4B) :: pos
     integer(I4B) :: kper, kstp
-    real(DP) :: delt, pertim, totim
+    real(DP) :: pertim, totim
   contains
     procedure :: get_str
   end type BinaryFileHeaderType
@@ -20,11 +20,20 @@ module BinaryFileReaderModule
     class(BinaryFileHeaderType), allocatable :: headernext
     logical(LGP) :: endoffile
   contains
+    procedure(read_header_if), deferred :: read_header
     procedure(read_record_if), deferred :: read_record
     procedure :: peek_record
   end type BinaryFileReaderType
 
   abstract interface
+    subroutine read_header_if(this, success, iout)
+      import BinaryFileReaderType
+      import I4B, LGP
+      class(BinaryFileReaderType), intent(inout) :: this
+      logical(LGP), intent(out) :: success
+      integer(I4B), intent(in), optional :: iout
+    end subroutine read_header_if
+
     subroutine read_record_if(this, success, iout)
       import BinaryFileReaderType
       import I4B, LGP
@@ -44,7 +53,6 @@ contains
       'Binary file header (pos: ', this%pos, &
       ', kper: ', this%kper, &
       ', kstp: ', this%kstp, &
-      ', delt: ', this%delt, &
       ', pertim: ', this%pertim, &
       ', totim: ', this%totim, &
       ')'

--- a/src/Utilities/BudgetFileReader.f90
+++ b/src/Utilities/BudgetFileReader.f90
@@ -39,6 +39,7 @@ module BudgetFileReaderModule
     procedure :: initialize
     procedure :: read_header
     procedure :: read_record
+    procedure :: rewind
     procedure :: finalize
   end type BudgetFileReaderType
 
@@ -59,13 +60,10 @@ contains
     logical :: success
     !
     this%inunit = iu
-    this%endoffile = .false.
     this%nbudterms = 0
     ncrbud = 0
     maxaux = 0
-    !
-    allocate (BudgetFileHeaderType :: this%header)
-    allocate (BudgetFileHeaderType :: this%headernext)
+    call this%rewind()
     !
     ! -- Determine number of budget terms within a time step
     if (iout > 0) &
@@ -95,7 +93,7 @@ contains
     allocate (this%nauxarray(this%nbudterms))
     allocate (this%auxtxtarray(maxaux, this%nbudterms))
     this%auxtxtarray(:, :) = ''
-    rewind (this%inunit)
+    call this%rewind()
     !
     ! -- Now read through again and store budget text names
     do ibudterm = 1, this%nbudterms
@@ -115,7 +113,7 @@ contains
         end if
       end select
     end do
-    rewind (this%inunit)
+    call this%rewind()
     if (iout > 0) &
       write (iout, '(a, i0, a)') 'Detected ', this%nbudterms, &
       ' unique flow terms in budget file.'
@@ -151,6 +149,7 @@ contains
       h%nlist = 0
       if (allocated(h%auxtxt)) deallocate (h%auxtxt)
 
+      inquire (unit=this%inunit, pos=h%pos)
       read (this%inunit, iostat=iostat) h%kstp, h%kper, &
         h%budtxt, h%nval, h%idum1, h%idum2
       if (iostat /= 0) then
@@ -284,5 +283,18 @@ contains
       ')'
     str = trim(temp)
   end function get_str
+
+  subroutine rewind (this)
+    class(BudgetFileReaderType), intent(inout) :: this
+
+    rewind (this%inunit)
+    this%endoffile = .false.
+    if (allocated(this%header)) deallocate (this%header)
+    if (allocated(this%headernext)) deallocate (this%headernext)
+    allocate (BudgetFileHeaderType :: this%header)
+    allocate (BudgetFileHeaderType :: this%headernext)
+    this%header%pos = 1
+    this%headernext%pos = 1
+  end subroutine rewind
 
 end module BudgetFileReaderModule

--- a/src/Utilities/BudgetFileReader.f90
+++ b/src/Utilities/BudgetFileReader.f90
@@ -2,7 +2,7 @@ module BudgetFileReaderModule
 
   use KindModule
   use SimModule, only: store_error, store_error_unit
-  use ConstantsModule, only: LINELENGTH
+  use ConstantsModule, only: LINELENGTH, LENHUGELINE
   use BinaryFileReaderModule, only: BinaryFileReaderType, BinaryFileHeaderType
 
   implicit none
@@ -13,6 +13,7 @@ module BudgetFileReaderModule
   type, extends(BinaryFileHeaderType) :: BudgetFileHeaderType
     character(len=16) :: budtxt
     integer(I4B) :: nval, idum1, idum2, imeth
+    real(DP) :: delt
     character(len=16) :: srcmodelname, srcpackagename
     character(len=16) :: dstmodelname, dstpackagename
     integer(I4B) :: ndat, naux, nlist
@@ -259,8 +260,9 @@ contains
   function get_str(this) result(str)
     class(BudgetFileHeaderType), intent(in) :: this
     character(len=:), allocatable :: str
+    character(len=LENHUGELINE) :: temp
 
-    write (str, '(*(G0))') &
+    write (temp, '(*(G0))') &
       'Budget file header (pos: ', this%pos, &
       ', kper: ', this%kper, &
       ', kstp: ', this%kstp, &
@@ -280,7 +282,7 @@ contains
       ', naux: ', this%naux, &
       ', nlist: ', this%nlist, &
       ')'
-    str = trim(str)
+    str = trim(temp)
   end function get_str
 
 end module BudgetFileReaderModule

--- a/src/Utilities/HeadFileReader.f90
+++ b/src/Utilities/HeadFileReader.f90
@@ -1,7 +1,7 @@
 module HeadFileReaderModule
 
   use KindModule
-  use ConstantsModule, only: LINELENGTH, LENBIGLINE
+  use ConstantsModule, only: LINELENGTH, LENBIGLINE, LENHUGELINE
   use BinaryFileReaderModule, only: BinaryFileReaderType, BinaryFileHeaderType
 
   implicit none
@@ -23,6 +23,7 @@ module HeadFileReaderModule
     procedure :: initialize
     procedure :: read_header
     procedure :: read_record
+    procedure :: rewind
     procedure :: finalize
   end type HeadFileReaderType
 
@@ -40,17 +41,14 @@ contains
     logical :: success
     !
     this%inunit = iu
-    this%endoffile = .false.
     this%nlay = 0
-    !
-    allocate (HeadFileHeaderType :: this%header)
-    allocate (HeadFileHeaderType :: this%headernext)
+    call this%rewind()
     !
     ! -- Read the first head data record to set kstp_last, kstp_last
     call this%read_record(success)
     kstp_last = this%header%kstp
     kper_last = this%header%kper
-    rewind (this%inunit)
+    call this%rewind()
     !
     ! -- Determine number of records within a time step
     if (iout > 0) &
@@ -62,7 +60,7 @@ contains
       if (kstp_last /= this%header%kstp .or. kper_last /= this%header%kper) exit
       this%nlay = this%nlay + 1
     end do
-    rewind (this%inunit)
+    call this%rewind()
     if (iout > 0) &
       write (iout, '(a, i0, a)') 'Detected ', this%nlay, &
       ' unique records in binary file.'
@@ -87,6 +85,7 @@ contains
       h%ncol = 0
       h%nrow = 0
       h%ilay = 0
+      inquire (unit=this%inunit, pos=h%pos)
       read (this%inunit, iostat=iostat) h%kstp, h%kper, &
         h%pertim, h%totim, h%text, h%ncol, h%nrow, h%ilay
       if (iostat /= 0) then
@@ -170,5 +169,18 @@ contains
       ')'
     str = trim(temp)
   end function get_str
+
+  subroutine rewind (this)
+    class(HeadFileReaderType), intent(inout) :: this
+
+    rewind (this%inunit)
+    this%endoffile = .false.
+    if (allocated(this%header)) deallocate (this%header)
+    if (allocated(this%headernext)) deallocate (this%headernext)
+    allocate (HeadFileHeaderType :: this%header)
+    allocate (HeadFileHeaderType :: this%headernext)
+    this%header%pos = 1
+    this%headernext%pos = 1
+  end subroutine rewind
 
 end module HeadFileReaderModule

--- a/src/Utilities/HeadFileReader.f90
+++ b/src/Utilities/HeadFileReader.f90
@@ -1,7 +1,7 @@
 module HeadFileReaderModule
 
   use KindModule
-  use ConstantsModule, only: LINELENGTH
+  use ConstantsModule, only: LINELENGTH, LENBIGLINE
   use BinaryFileReaderModule, only: BinaryFileReaderType, BinaryFileHeaderType
 
   implicit none
@@ -155,12 +155,12 @@ contains
   function get_str(this) result(str)
     class(HeadFileHeaderType), intent(in) :: this
     character(len=:), allocatable :: str
+    character(len=LENBIGLINE) :: temp
 
-    write (str, '(*(G0))') &
+    write (temp, '(*(G0))') &
       'Head file header (pos: ', this%pos, &
       ', kper: ', this%kper, &
       ', kstp: ', this%kstp, &
-      ', delt: ', this%delt, &
       ', pertim: ', this%pertim, &
       ', totim: ', this%totim, &
       ', text: ', trim(this%text), &
@@ -168,7 +168,7 @@ contains
       ', nrow: ', this%nrow, &
       ', ilay: ', this%ilay, &
       ')'
-    str = trim(str)
+    str = trim(temp)
   end function get_str
 
 end module HeadFileReaderModule


### PR DESCRIPTION
More prep for binary file indexing. Defer `read_header` to allow it be used in an indexing procedure defined in the base type. Also move `delt` to the budget file header type (not used for head file headers), fix string overfilling in logging routines, factor out a `rewind` routine, and remove a leftover debugging statement in some PRT code.