### PR TITLE
refactor: add optional binary file indexing capability

### DIFF
--- a/src/Utilities/BudgetFileReader.f90
+++ b/src/Utilities/BudgetFileReader.f90
@@ -127,7 +127,7 @@ contains
     logical, intent(out) :: success
     integer(I4B), intent(in), optional :: iout
     ! -- local
-    integer(I4B) :: iostat
+    integer(I4B) :: iostat, pos
     character(len=LINELENGTH) :: errmsg
     !
     success = .true.
@@ -177,6 +177,8 @@ contains
         call store_error_unit(this%inunit)
       end if
     end select
+    inquire (unit=this%inunit, pos=pos)
+    this%header%size = pos - this%header%pos
   end subroutine read_header
 
   !< @brief read record

--- a/src/Utilities/HeadFileReader.f90
+++ b/src/Utilities/HeadFileReader.f90
@@ -74,7 +74,7 @@ contains
     logical, intent(out) :: success
     integer(I4B), intent(in), optional :: iout
     ! -- local
-    integer(I4B) :: iostat
+    integer(I4B) :: iostat, pos
     !
     success = .true.
     select type (h => this%header)
@@ -93,6 +93,8 @@ contains
         if (iostat < 0) this%endoffile = .true.
         return
       end if
+      inquire (unit=this%inunit, pos=pos)
+      this%header%size = pos - this%header%pos
     end select
   end subroutine read_header
 


### PR DESCRIPTION
Minimal, opt-in indexing capability for head and budget files. For use by the flow model interface in backwards particle tracking models, to navigate the files in reverse. The headers now know their own size, and the index stores the size of each record (header + data), which is enough to navigate with. But that's best handled by a wrapper type, not in the base binary file reader.

Indexing takes 2 passes over the file. Could be improved by using known data sizes to seek from header to header directly. A proper array of headers would also be cleaner, but I figure it makes sense to trade runtime for less memory. Headers are small compared to data, but holding all of them at once might still take up some space for massive files. Memory is a hard limit while runtime is an inconvenience?

Just meant to unlock some adjacent work for backwards tracking, hence optional and currently unused, but it could for instance be swapped in for the first `rewind()` in the head/budget file reader init routines