### PR TITLE
fix(ci): windows extended build

### DIFF
--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -37,7 +37,7 @@ runs:
       if: steps.petsc-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        curl https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.20.5.tar.gz -O -J
+        curl https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.20.5.tar.gz -O
         mkdir petsc
         tar -xzf petsc-3.20.5.tar.gz -C petsc --strip-components=1
 


### PR DESCRIPTION
Fix for windows extended build failure in CI.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
