### PR TITLE
fix(prt): fix storage budget

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/prt-oc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-oc.dfn
@@ -268,6 +268,62 @@ optional true
 longname print particle tracking events
 description print a verbose particle tracking event trace to standard output
 
+block options
+name budget_boundary
+type keyword
+reader urword
+optional true
+longname budget boundary termination
+description keyword to indicate that when a particle terminates at a boundary (status code 2), its mass should remain in the model budget
+
+block options
+name budget_weaksink
+type keyword
+reader urword
+optional true
+longname budget weaksink termination
+description keyword to indicate that when a particle terminates in a weak sink (status code 3), its mass should remain in the model budget
+
+block options
+name budget_no_exits
+type keyword
+reader urword
+optional true
+longname budget no exit face termination
+description keyword to indicate that when a particle terminates in a cell with no exit face (status code 5), its mass should remain in the model budget
+
+block options
+name budget_stopzone
+type keyword
+reader urword
+optional true
+longname budget stop zone termination
+description keyword to indicate that when a particle terminates in a cell with no exit face (status code 6), its mass should remain in the model budget
+
+block options
+name budget_inactive
+type keyword
+reader urword
+optional true
+longname track usertime
+description keyword to indicate that when a particle terminates in an inactive cell (status code 7), its mass should remain in the model budget
+
+block options
+name budget_no_exits_sub
+type keyword
+reader urword
+optional true
+longname track usertime
+description keyword to indicate that when a particle terminates in a subcell with no exit face (status code 9), its mass should remain in the model budget
+
+block options
+name budget_timeout
+type keyword
+reader urword
+optional true
+longname track usertime
+description keyword to indicate that when a particle terminates upon timing out (status code 10), its mass should remain in the model budget
+
 # --------------------- prt oc dimensions ------------------
 
 block dimensions

--- a/src/Model/ParticleTracking/prt-oc.f90
+++ b/src/Model/ParticleTracking/prt-oc.f90
@@ -30,6 +30,12 @@ module PrtOcModule
     logical(LGP), pointer :: trackterminate => null() !< whether to track termination events
     logical(LGP), pointer :: trackweaksink => null() !< whether to track weak sink exit events
     logical(LGP), pointer :: trackusertime => null() !< whether to track user-specified times
+    logical(LGP), pointer :: budget_boundary => null() !< whether to incldue particles terminating at boundary faces in budget
+    logical(LGP), pointer :: budget_weaksink => null() !< whether to include particles terminating in weak sinks in budget
+    logical(LGP), pointer :: budget_no_exits => null() !< whether to include particles terminating in subcells with no exit face in budget
+    logical(LGP), pointer :: budget_stopzone => null() !< whether to include particles terminating in stop zones in budget
+    logical(LGP), pointer :: budget_inactive => null() !< whether to include particles terminating in inactive cells in budget
+    logical(LGP), pointer :: budget_timeout => null() !< whether to include particles terminating due to timeout in budget
     integer(I4B), pointer :: ntracktimes => null() !< number of user-specified tracking times
     logical(LGP), pointer :: dump_event_trace => null() !< whether to dump event trace for debugging
     type(TimeSelectType), pointer :: tracktimes !< user-specified tracking times
@@ -90,6 +96,12 @@ contains
     call mem_allocate(this%trackterminate, 'ITRACKTER', this%memoryPath)
     call mem_allocate(this%trackweaksink, 'ITRACKWSK', this%memoryPath)
     call mem_allocate(this%trackusertime, 'ITRACKTLS', this%memoryPath)
+    call mem_allocate(this%budget_boundary, 'BUDGET_BOUNDARY', this%memoryPath)
+    call mem_allocate(this%budget_weaksink, 'BUDGET_WEAKSINK', this%memoryPath)
+    call mem_allocate(this%budget_no_exits, 'BUDGET_NO_EXITS', this%memoryPath)
+    call mem_allocate(this%budget_stopzone, 'BUDGET_STOPZONE', this%memoryPath)
+    call mem_allocate(this%budget_inactive, 'BUDGET_INACTIVE', this%memoryPath)
+    call mem_allocate(this%budget_timeout, 'BUDGET_TIMEOUT', this%memoryPath)
     call mem_allocate(this%ntracktimes, 'NTRACKTIMES', this%memoryPath)
 
     this%name_model = name_model
@@ -109,6 +121,12 @@ contains
     this%trackterminate = .false.
     this%trackweaksink = .false.
     this%trackusertime = .false.
+    this%budget_boundary = .false.
+    this%budget_weaksink = .false.
+    this%budget_no_exits = .false.
+    this%budget_stopzone = .false.
+    this%budget_inactive = .false.
+    this%budget_timeout = .false.
     this%ntracktimes = 0
 
   end subroutine prt_oc_allocate_scalars
@@ -181,6 +199,12 @@ contains
     call mem_deallocate(this%trackterminate)
     call mem_deallocate(this%trackweaksink)
     call mem_deallocate(this%trackusertime)
+    call mem_deallocate(this%budget_boundary)
+    call mem_deallocate(this%budget_weaksink)
+    call mem_deallocate(this%budget_no_exits)
+    call mem_deallocate(this%budget_stopzone)
+    call mem_deallocate(this%budget_inactive)
+    call mem_deallocate(this%budget_timeout)
     call mem_deallocate(this%ntracktimes)
 
   end subroutine prt_oc_da
@@ -302,6 +326,24 @@ contains
           param_found = .true.
         case ('DEV_DUMP_EVENT_TRACE')
           this%dump_event_trace = .true.
+          param_found = .true.
+        case ('BUDGET_BOUNDARY')
+          this%budget_boundary = .true.
+          param_found = .true.
+        case ('BUDGET_WEAKSINK')
+          this%budget_weaksink = .true.
+          param_found = .true.
+        case ('BUDGET_NO_EXITS')
+          this%budget_no_exits = .true.
+          param_found = .true.
+        case ('BUDGET_STOPZONE')
+          this%budget_stopzone = .true.
+          param_found = .true.
+        case ('BUDGET_INACTIVE')
+          this%budget_inactive = .true.
+          param_found = .true.
+        case ('BUDGET_TIMEOUT')
+          this%budget_timeout = .true.
           param_found = .true.
         case default
           param_found = .false.

--- a/src/Model/ParticleTracking/prt-oc.f90
+++ b/src/Model/ParticleTracking/prt-oc.f90
@@ -30,7 +30,7 @@ module PrtOcModule
     logical(LGP), pointer :: trackterminate => null() !< whether to track termination events
     logical(LGP), pointer :: trackweaksink => null() !< whether to track weak sink exit events
     logical(LGP), pointer :: trackusertime => null() !< whether to track user-specified times
-    logical(LGP), pointer :: budget_boundary => null() !< whether to incldue particles terminating at boundary faces in budget
+    logical(LGP), pointer :: budget_boundary => null() !< whether to include particles terminating at boundary faces in budget
     logical(LGP), pointer :: budget_weaksink => null() !< whether to include particles terminating in weak sinks in budget
     logical(LGP), pointer :: budget_no_exits => null() !< whether to include particles terminating in subcells with no exit face in budget
     logical(LGP), pointer :: budget_stopzone => null() !< whether to include particles terminating in stop zones in budget

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -643,22 +643,15 @@ contains
     integer(I4B) :: idiag
     real(DP) :: rrate
 
-    ! If no boundaries, skip flow calculations.
     if (this%nbound <= 0) return
 
-    ! Loop through each boundary calculating flow.
-    do i = 1, this%nbound
+    do i = 1, this%nbound ! release points
       node = this%nodelist(i)
       rrate = DZERO
-      ! If cell is no-flow or constant-head, then ignore it.
-      if (node > 0) then
-        ! Calculate the flow rate into the cell.
-        idiag = this%dis%con%ia(node)
-        rrate = this%rptm(i) * (DONE / delt) ! reciprocal of tstp length
-        flowja(idiag) = flowja(idiag) + rrate
-      end if
-
-      ! Save simulated value to simvals array.
+      if (node < 1) cycle
+      idiag = this%dis%con%ia(node)
+      rrate = this%rptm(i) * (DONE / delt) ! reciprocal of tstp length
+      flowja(idiag) = flowja(idiag) + rrate
       this%simvals(i) = rrate
     end do
   end subroutine prp_cq_simrate

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -86,6 +86,7 @@ module PrtModule
     procedure, private :: create_packages
     procedure, private :: create_bndpkgs
     procedure, private :: log_namfile_options
+    procedure, private :: budget_termination_code
 
   end type PrtModelType
 
@@ -461,8 +462,8 @@ contains
       type is (PrtPrpType)
         do np = 1, packobj%nparticles
           istatus = packobj%particles%istatus(np)
-          ! this may need to change if istatus flags change
-          if ((istatus > 0) .and. (istatus /= 8)) then
+          if (istatus == 1 .or. &
+              this%budget_termination_code(istatus)) then
             n = packobj%particles%idomain(np, 2)
             ! Each particle currently assigned unit mass
             this%masssto(n) = this%masssto(n) + DONE
@@ -477,6 +478,24 @@ contains
       this%flowja(idiag) = this%flowja(idiag) + rate
     end do
   end subroutine prt_cq_sto
+
+  logical function budget_termination_code(this, istatus) result(budget)
+    use ParticleModule, only: TERM_BOUNDARY, TERM_WEAKSINK, &
+                              TERM_NO_EXITS, TERM_STOPZONE, &
+                              TERM_INACTIVE, TERM_NO_EXITS_SUB, &
+                              TERM_TIMEOUT
+    class(PrtModelType) :: this
+    integer(I4B), intent(in) :: istatus
+
+    budget = ((istatus == TERM_BOUNDARY .and. this%oc%budget_boundary) .or. &
+              (istatus == TERM_WEAKSINK .and. this%oc%budget_weaksink) .or. &
+              ((istatus == TERM_NO_EXITS .or. &
+                istatus == TERM_NO_EXITS_SUB) .and. &
+               this%oc%budget_no_exits) .or. &
+              (istatus == TERM_STOPZONE .and. this%oc%budget_stopzone) .or. &
+              (istatus == TERM_INACTIVE .and. this%oc%budget_inactive) .or. &
+              (istatus == TERM_TIMEOUT .and. this%oc%budget_timeout))
+  end function budget_termination_code
 
   !> @brief Calculate flows and budget
   !!


### PR DESCRIPTION
PRT kept particle mass in the storage budget term at termination. Instead, remove mass from storage at termination, and introduce optional OC keywords to selectively disable this, so the mass of particles terminating in the chosen condition(s) stay in the storage term

___

- [x] Replaced section above with description of pull request
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
