### PR TITLE
chore(dfns): use consistent boolean values

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/chf-cdb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-cdb.dfn
@@ -106,7 +106,7 @@ description REPLACE maxbound {'{#1}': 'critical depth boundary'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/chf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-chd.dfn
@@ -144,7 +144,7 @@ description REPLACE maxbound {'{#1}': 'constant-head'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/chf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-evp.dfn
@@ -146,7 +146,7 @@ description REPLACE maxbound {'{#1}': 'evaporation cells'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/chf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-flw.dfn
@@ -143,7 +143,7 @@ description REPLACE maxbound {'{#1}': 'inflow'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/chf-oc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-oc.dfn
@@ -223,7 +223,7 @@ description write format can be EXPONENTIAL, FIXED, GENERAL, or SCIENTIFIC.
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/chf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-pcp.dfn
@@ -146,7 +146,7 @@ description REPLACE maxbound {'{#1}': 'precipitation cells'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/chf-sto.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-sto.dfn
@@ -27,7 +27,7 @@ description keyword that specifies input grid arrays, which already support the 
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/chf-zdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-zdg.dfn
@@ -138,7 +138,7 @@ description REPLACE maxbound {'{#1}': 'zero-depth-gradient boundary'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwe-ctp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-ctp.dfn
@@ -147,7 +147,7 @@ description REPLACE maxbound {'{#1}': 'constant temperature'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwe-esl.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-esl.dfn
@@ -142,7 +142,7 @@ description REPLACE maxbound {'{#1}': 'source'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwe-lke.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-lke.dfn
@@ -335,7 +335,7 @@ description REPLACE boundname {'{#1}': 'lake'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwe-mwe.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-mwe.dfn
@@ -335,7 +335,7 @@ description REPLACE boundname {'{#1}': 'well'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwe-oc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-oc.dfn
@@ -191,7 +191,7 @@ description write format can be EXPONENTIAL, FIXED, GENERAL, or SCIENTIFIC.
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwe-sfe.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-sfe.dfn
@@ -335,7 +335,7 @@ description REPLACE boundname {'{#1}': 'reach'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwe-uze.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-uze.dfn
@@ -315,7 +315,7 @@ description REPLACE boundname {'{#1}': 'unsaturated zone flow'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-chd.dfn
@@ -157,7 +157,7 @@ description REPLACE maxbound {'{#1}': 'constant-head'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-csub.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-csub.dfn
@@ -752,7 +752,7 @@ description REPLACE boundname {'{#1}': 'CSUB'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-drn.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-drn.dfn
@@ -175,7 +175,7 @@ description REPLACE maxbound {'{#1}': 'drains'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
@@ -9,7 +9,7 @@ reader urword
 optional false
 longname use array-based grid input
 description indicates that array-based grid input will be used for the drain package.  This keyword must be specified to use array-based grid input.  When READARRAYGRID is specified, values must be provided for every cell within a model grid, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. No data cells should contain the value DNODATA (3.0E+30). 
-default_value True
+default_value true
 
 block options
 name auxiliary
@@ -152,7 +152,7 @@ description REPLACE maxbound {'{#1}': 'drains'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-evt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-evt.dfn
@@ -172,7 +172,7 @@ description number of ET segments.  Default is one.  When NSEG is greater than 1
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
@@ -10,7 +10,7 @@ reader urword
 optional false
 longname use array-based input
 description indicates that array-based input will be used for the Evapotranspiration Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.
-default_value True
+default_value true
 
 block options
 name fixed_cell
@@ -156,7 +156,7 @@ extended true
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-ghb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-ghb.dfn
@@ -156,7 +156,7 @@ description REPLACE maxbound {'{#1}': 'general-head boundary'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
@@ -9,7 +9,7 @@ reader urword
 optional false
 longname use array-based grid input
 description indicates that array-based grid input will be used for the general-head boundary package.  This keyword must be specified to use array-based grid input.  When READARRAYGRID is specified, values must be provided for every cell within a model grid, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. No data cells should contain the value DNODATA (3.0E+30). 
-default_value True
+default_value true
 
 block options
 name auxiliary
@@ -133,7 +133,7 @@ description REPLACE maxbound {'{#1}': 'general-head boundary'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-hfb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-hfb.dfn
@@ -25,7 +25,7 @@ description integer value specifying the maximum number of horizontal flow barri
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-lak.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-lak.dfn
@@ -673,7 +673,7 @@ description real value that defines the bed slope for the lake outlet. Any value
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-maw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-maw.dfn
@@ -513,7 +513,7 @@ description real value that defines the skin radius (filter pack radius) for the
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-mvr.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-mvr.dfn
@@ -161,7 +161,7 @@ description is the name of a package that may be included in a subsequent stress
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-oc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-oc.dfn
@@ -191,7 +191,7 @@ description write format can be EXPONENTIAL, FIXED, GENERAL, or SCIENTIFIC.
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-rch.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rch.dfn
@@ -156,7 +156,7 @@ description REPLACE maxbound {'{#1}': 'recharge cells'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
@@ -10,7 +10,7 @@ reader urword
 optional false
 longname use array-based input
 description indicates that array-based input will be used for the Recharge Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. 
-default_value True
+default_value true
 
 block options
 name fixed_cell
@@ -156,7 +156,7 @@ extended true
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-riv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-riv.dfn
@@ -156,7 +156,7 @@ description REPLACE maxbound {'{#1}': 'rivers'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
@@ -698,7 +698,7 @@ description real value that defines the initial stage for the reach. The program
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-sto.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sto.dfn
@@ -154,7 +154,7 @@ default_value 0.15
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-uzf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-uzf.dfn
@@ -492,7 +492,7 @@ description REPLACE boundname {'{#1}': 'UZF cell'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
@@ -211,7 +211,7 @@ description REPLACE maxbound {'{#1}': 'wells'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
@@ -9,7 +9,7 @@ reader urword
 optional false
 longname use array-based grid input
 description indicates that array-based grid input will be used for the well boundary package.  This keyword must be specified to use array-based grid input.  When READARRAYGRID is specified, values must be provided for every cell within a model grid, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. No data cells should contain the value DNODATA (3.0E+30).
-default_value True
+default_value true
 
 block options
 name auxiliary
@@ -189,7 +189,7 @@ description REPLACE maxbound {'{#1}': 'wells'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwt-cnc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-cnc.dfn
@@ -147,7 +147,7 @@ description REPLACE maxbound {'{#1}': 'constant concentrations'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwt-lkt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-lkt.dfn
@@ -315,7 +315,7 @@ description REPLACE boundname {'{#1}': 'lake'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwt-mwt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-mwt.dfn
@@ -315,7 +315,7 @@ description REPLACE boundname {'{#1}': 'well'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwt-oc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-oc.dfn
@@ -191,7 +191,7 @@ description write format can be EXPONENTIAL, FIXED, GENERAL, or SCIENTIFIC.
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwt-sft.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-sft.dfn
@@ -315,7 +315,7 @@ description REPLACE boundname {'{#1}': 'reach'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwt-src.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-src.dfn
@@ -152,7 +152,7 @@ description REPLACE maxbound {'{#1}': 'sources'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwt-uzt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-uzt.dfn
@@ -315,7 +315,7 @@ description REPLACE boundname {'{#1}': 'unsaturated zone flow'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/olf-cdb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-cdb.dfn
@@ -106,7 +106,7 @@ description REPLACE maxbound {'{#1}': 'critical depth boundary'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/olf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-chd.dfn
@@ -144,7 +144,7 @@ description REPLACE maxbound {'{#1}': 'constant-head'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/olf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-evp.dfn
@@ -146,7 +146,7 @@ description REPLACE maxbound {'{#1}': 'evaporation cells'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/olf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-flw.dfn
@@ -143,7 +143,7 @@ description REPLACE maxbound {'{#1}': 'inflow'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/olf-oc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-oc.dfn
@@ -223,7 +223,7 @@ description write format can be EXPONENTIAL, FIXED, GENERAL, or SCIENTIFIC.
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/olf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-pcp.dfn
@@ -146,7 +146,7 @@ description REPLACE maxbound {'{#1}': 'precipitation cells'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/olf-sto.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-sto.dfn
@@ -27,7 +27,7 @@ description keyword that specifies input grid arrays, which already support the 
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/olf-zdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-zdg.dfn
@@ -138,7 +138,7 @@ description REPLACE maxbound {'{#1}': 'zero-depth-gradient boundary'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/prt-oc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-oc.dfn
@@ -303,7 +303,7 @@ description real value that defines the tracking time with respect to the simula
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -386,7 +386,7 @@ description real value that defines the release time with respect to the simulat
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/sim-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/sim-nam.dfn
@@ -200,7 +200,7 @@ description is the name of the second model that is part of this exchange.
 block solutiongroup
 name group_num
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/swf-cdb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-cdb.dfn
@@ -106,7 +106,7 @@ description REPLACE maxbound {'{#1}': 'critical depth boundary'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/swf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-chd.dfn
@@ -144,7 +144,7 @@ description REPLACE maxbound {'{#1}': 'constant-head'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/swf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-evp.dfn
@@ -146,7 +146,7 @@ description REPLACE maxbound {'{#1}': 'evaporation cells'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/swf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-flw.dfn
@@ -143,7 +143,7 @@ description REPLACE maxbound {'{#1}': 'inflow'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/swf-oc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-oc.dfn
@@ -223,7 +223,7 @@ description write format can be EXPONENTIAL, FIXED, GENERAL, or SCIENTIFIC.
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/swf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-pcp.dfn
@@ -146,7 +146,7 @@ description REPLACE maxbound {'{#1}': 'precipitation cells'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/swf-sto.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-sto.dfn
@@ -27,7 +27,7 @@ description keyword that specifies input grid arrays, which already support the 
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/swf-zdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-zdg.dfn
@@ -138,7 +138,7 @@ description REPLACE maxbound {'{#1}': 'zero-depth-gradient boundary'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/utl-spc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-spc.dfn
@@ -67,7 +67,7 @@ description REPLACE maxbound {'{#1}': 'spc'}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/utl-spca.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-spca.dfn
@@ -9,7 +9,7 @@ reader urword
 optional false
 longname use array-based input
 description indicates that array-based input will be used for the SPC Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.
-default_value True
+default_value true
 
 block options
 name print_input
@@ -68,7 +68,7 @@ description defines a time-array-series file defining a time-array series that c
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/utl-tas.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-tas.dfn
@@ -102,7 +102,7 @@ description Scale factor, which will multiply all array values in time series. S
 block time
 name time_from_model_start
 type double precision
-block_variable True
+block_variable true
 in_record true
 shape
 tagged false

--- a/doc/mf6io/mf6ivar/dfn/utl-tvk.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-tvk.dfn
@@ -59,7 +59,7 @@ description REPLACE timeseriesfile {}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape

--- a/doc/mf6io/mf6ivar/dfn/utl-tvs.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-tvs.dfn
@@ -67,7 +67,7 @@ description REPLACE timeseriesfile {}
 block period
 name iper
 type integer
-block_variable True
+block_variable true
 in_record true
 tagged false
 shape


### PR DESCRIPTION
Use lowercase `true` for all boolean values. Just a consistency fix. Suggested in https://github.com/MODFLOW-ORG/modflow-devtools/pull/229#issuecomment-3105295416