### PR TITLE
fix(par): memory exception when writing outer convergence info to csv

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -46,4 +46,4 @@ description = "With the PRT model's Particle Release Package's EXTEND\\_TRACKING
 [[items]]
 section = "fixes"
 subsection = "parallel"
-description = "Fixed a memory access exception that can occur when writing convergence information to a CSV file (through the CSV_OUTER_OUTPUT option in IMS) for a parallel solution."
+description = "Fixed a memory access exception that can occur when writing convergence information to a CSV file (through the CSV\\_OUTER\\_OUTPUT option in IMS) for a parallel solution."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -42,3 +42,8 @@ description = "Fixed bugs in the GWF VSC and BUY packages, affecting GWT simulat
 section = "fixes"
 subsection = "solution"
 description = "With the PRT model's Particle Release Package's EXTEND\\_TRACKING option enabled, particles beginning the simulation's final timestep in a stationary cell (an active cell with no flow across any boundary) were not terminated gracefully. Particles in these conditions will now terminate properly with status code 10 (timeout)."
+
+[[items]]
+section = "fixes"
+subsection = "parallel"
+description = "Fixed a memory access exception that can occur when writing convergence information to a CSV file (through the CSV_OUTER_OUTPUT option in IMS) for a parallel solution."

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'fortran',
   version: '6.7.0.dev2',
   license: 'CC0',
-  meson_version: '>= 1.7.1',
+  meson_version: '>= 1.0',
   default_options : [
     'b_vscrt=static_from_buildtype', # Link runtime libraries statically on Windows
     'buildtype=release',

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'fortran',
   version: '6.7.0.dev2',
   license: 'CC0',
-  meson_version: '>= 1.0',
+  meson_version: '>= 1.7.1',
   default_options : [
     'b_vscrt=static_from_buildtype', # Link runtime libraries statically on Windows
     'buildtype=release',

--- a/src/Solution/NumericalSolution.f90
+++ b/src/Solution/NumericalSolution.f90
@@ -1816,6 +1816,7 @@ contains
       ! -- write line to outer iteration csv file
       if (m_idx > 0) then
         mp => GetNumericalModelFromList(this%modellist, m_idx) ! TODO_MJR: right list?
+        write(*,*) 'Writing outer iteration csv file for model idx: ', m_idx, ' out of ', this%modellist%Count()
         model_id = mp%id
       else
         model_id = 0

--- a/src/Solution/NumericalSolution.f90
+++ b/src/Solution/NumericalSolution.f90
@@ -1795,9 +1795,11 @@ contains
         !
         ! -- get model number and user node number
         call this%sln_get_nodeu(this%lrch(1, kiter), m_idx, node_user)
+        mp => GetNumericalModelFromList(this%modellist, m_idx)
+        model_id = mp%id
         cpakout = ''
       else if (outer_hncg == DZERO .and. dpak == DZERO) then ! zero change, location could be any
-        m_idx = 0
+        model_id = 0
         node_user = 0
         !
         ! -- then it's a package convergence error
@@ -1805,23 +1807,14 @@ contains
         !
         ! -- set convergence error, model number, user node number,
         !    and package name
-        write(*,*) 'Package convergence error: ', cmod
         outer_hncg = dpak
         ipos0 = index(cmod, '_')
-        read (cmod(1:ipos0 - 1), *) m_idx
+        read (cmod(1:ipos0 - 1), *) model_id
         node_user = ipak
         ipos0 = index(cpak, '-', back=.true.)
         cpakout = cpak(1:ipos0 - 1)
       end if
-      !
-      ! -- write line to outer iteration csv file
-      if (m_idx > 0) then
-        mp => GetNumericalModelFromList(this%modellist, m_idx) ! TODO_MJR: right list?
-        write(*,*) 'Writing outer iteration csv file for model idx: ', m_idx, ' out of ', this%modellist%Count()
-        model_id = mp%id
-      else
-        model_id = 0
-      end if
+
       write (this%icsvouterout, '(*(G0,:,","))') &
         this%itertot_sim, totim, kper, kstp, kiter, iter, &
         outer_hncg, model_id, trim(cpakout), node_user

--- a/src/Solution/NumericalSolution.f90
+++ b/src/Solution/NumericalSolution.f90
@@ -1805,6 +1805,7 @@ contains
         !
         ! -- set convergence error, model number, user node number,
         !    and package name
+        write(*,*) 'Package convergence error: ', cmod
         outer_hncg = dpak
         ipos0 = index(cmod, '_')
         read (cmod(1:ipos0 - 1), *) m_idx


### PR DESCRIPTION
The exception is caused by mixing up the model index in the solution versus the index in the global model list (= model id). In serial they are the same and the problem cannot occur.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request