### PR TITLE
fix(prt-prp): fix duplicate entries in memory manager

### DIFF
--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -297,7 +297,7 @@ contains
     integer(I4B) :: n
 
     call this%obs%obs_ar()
-    
+
     if (this%inamedbound /= 0) then
       do n = 1, this%nreleasepoints
         this%boundname(n) = this%rptname(n)

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -208,6 +208,8 @@ contains
     ! local
     integer(I4B) :: nps
 
+    call this%BndType%allocate_arrays()
+
     ! Allocate particle store, starting with the number
     ! of release points (arrays resized if/when needed)
     call create_particle_store( &
@@ -295,7 +297,7 @@ contains
     integer(I4B) :: n
 
     call this%obs%obs_ar()
-    call this%BndType%allocate_arrays()
+    
     if (this%inamedbound /= 0) then
       do n = 1, this%nreleasepoints
         this%boundname(n) = this%rptname(n)


### PR DESCRIPTION
The PRT PRP package was adding duplicate entries to the memory manager, producing warning messages in simulation output. The `BndType`'s `allocate_arrays()` was called from `prp_ar()` instead of from PRP's override of `allocate_arrays()`. This has been the case for a while, but only came to light recently when the memory manager began using a hash map thanks to @Manangka.