### PR TITLE
refactor(prt): move event-firing routines to tracking method

### DIFF
--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -949,13 +949,13 @@ contains
           ! indicates the permanently unreleased event
           ! is not yet recorded, status 8 it has been.
           if (particle%istatus == (-1 * TERM_UNRELEASED)) then
-            call this%events%terminate(particle, status=TERM_UNRELEASED)
+            call this%method%terminate(particle, status=TERM_UNRELEASED)
             call packobj%particles%put(particle, np)
           end if
           if (particle%istatus > ACTIVE) cycle ! Skip terminated particles
           particle%istatus = ACTIVE ! Set active status in case of release
           ! If the particle was released this time step, emit a release event
-          if (particle%trelease >= totimc) call this%events%release(particle)
+          if (particle%trelease >= totimc) call this%method%release(particle)
           ! Maximum time is the end of the time step or the particle
           ! stop time, whichever comes first, unless it's the final
           ! time step and the extend option is on, in which case
@@ -982,7 +982,7 @@ contains
           if (particle%istatus <= ACTIVE .and. &
               (particle%ttrack == particle%tstop .or. &
                (endofsimulation .and. particle%iextend == 0))) &
-            call this%events%terminate(particle, status=TERM_TIMEOUT)
+            call this%method%terminate(particle, status=TERM_TIMEOUT)
           ! Return the particle to the store
           call packobj%particles%put(particle, np)
         end do

--- a/src/Solution/ParticleTracker/Method/MethodCell.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCell.f90
@@ -4,6 +4,7 @@ module MethodCellModule
   use ConstantsModule, only: DONE, DZERO
   use MethodModule, only: MethodType
   use ParticleModule, only: ParticleType
+  use ParticleEventModule, only: ParticleEventType
   use CellDefnModule, only: CellDefnType
   implicit none
 
@@ -49,21 +50,21 @@ contains
 
     particle%izone = cell_defn%izone
     if (stop_zone) then
-      call this%events%terminate(particle, status=TERM_STOPZONE)
+      call this%terminate(particle, status=TERM_STOPZONE)
       return
     end if
 
     if (no_exit_face .and. .not. dry_cell) then
-      call this%events%terminate(particle, status=TERM_NO_EXITS)
+      call this%terminate(particle, status=TERM_NO_EXITS)
       return
     end if
 
     if (weak_sink) then
       if (particle%istopweaksink > 0) then
-        call this%events%terminate(particle, status=TERM_WEAKSINK)
+        call this%terminate(particle, status=TERM_WEAKSINK)
         return
       else
-        call this%events%weaksink(particle)
+        call this%weaksink(particle)
       end if
     end if
 
@@ -74,7 +75,7 @@ contains
         no_exit_face = .false.
       else if (particle%idrymeth == 1) then
         ! stop
-        call this%events%terminate(particle, status=TERM_INACTIVE)
+        call this%terminate(particle, status=TERM_INACTIVE)
         return
       else if (particle%idrymeth == 2) then
         ! stay
@@ -92,7 +93,7 @@ contains
         ! update tracking time to time
         ! step end time and save record
         particle%ttrack = totim
-        call this%events%timestep(particle)
+        call this%timestep(particle)
 
         ! record user tracking times
         call this%tracktimes%advance()
@@ -102,7 +103,7 @@ contains
             if (t < totimc) cycle
             if (t >= tmax) exit
             particle%ttrack = t
-            call this%events%usertime(particle)
+            call this%usertime(particle)
             if (t > ttrackmax) ttrackmax = t
           end do
         end if
@@ -110,7 +111,7 @@ contains
         ! terminate if last period/step
         if (endofsimulation) then
           particle%ttrack = ttrackmax
-          call this%events%terminate(particle, status=TERM_NO_EXITS)
+          call this%terminate(particle, status=TERM_NO_EXITS)
           return
         end if
       end if
@@ -118,10 +119,10 @@ contains
       if (particle%idrymeth == 0) then
         ! drop to water table
         particle%z = cell_defn%top
-        call this%events%cellexit(particle)
+        call this%cellexit(particle)
       else if (particle%idrymeth == 1) then
         ! stop
-        call this%events%terminate(particle, status=TERM_INACTIVE)
+        call this%terminate(particle, status=TERM_INACTIVE)
         return
       else if (particle%idrymeth == 2) then
         ! stay
@@ -139,7 +140,7 @@ contains
         ! update tracking time to time
         ! step end time and save record
         particle%ttrack = totim
-        call this%events%timestep(particle)
+        call this%timestep(particle)
 
         ! record user tracking times
         call this%tracktimes%advance()
@@ -149,7 +150,7 @@ contains
             if (t < totimc) cycle
             if (t >= tmax) exit
             particle%ttrack = t
-            call this%events%usertime(particle)
+            call this%usertime(particle)
             if (t > ttrackmax) ttrackmax = t
           end do
         end if
@@ -159,7 +160,7 @@ contains
     if (no_exit_face) then
       particle%advancing = .false.
       particle%istatus = TERM_NO_EXITS
-      call this%events%terminate(particle)
+      call this%terminate(particle)
       return
     end if
 

--- a/src/Solution/ParticleTracker/Method/MethodCellPassToBot.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCellPassToBot.f90
@@ -66,9 +66,9 @@ contains
       nlay = dis%nlay
     end select
     if (particle%ilay == nlay) &
-      call this%events%terminate(particle, status=TERM_NO_EXITS)
+      call this%terminate(particle, status=TERM_NO_EXITS)
 
-    call this%events%cellexit(particle)
+    call this%cellexit(particle)
   end subroutine apply_ptb
 
 end module MethodCellPassToBotModule

--- a/src/Solution/ParticleTracker/Method/MethodDis.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDis.f90
@@ -212,8 +212,8 @@ contains
       if (ic == particle%icp .and. inface == 7 .and. ilay < particle%ilay) then
         particle%idomain(2) = particle%icp
         particle%izone = particle%izp
-        call this%events%terminate(particle, &
-                                   status=TERM_BOUNDARY)
+        call this%terminate(particle, &
+                            status=TERM_BOUNDARY)
         return
       else
         particle%icp = particle%idomain(2)
@@ -299,8 +299,8 @@ contains
       ! boundary face, so terminate the particle.
       ! todo AMP: reconsider when multiple models supported
       if (cell%defn%facenbr(particle%iboundary(2)) .eq. 0) then
-        call this%events%terminate(particle, &
-                                   status=TERM_BOUNDARY)
+        call this%terminate(particle, &
+                            status=TERM_BOUNDARY)
       else
         ! Update old to new cell properties
         call this%load_particle(cell, particle)

--- a/src/Solution/ParticleTracker/Method/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDisv.f90
@@ -176,8 +176,8 @@ contains
       if (ic == particle%icp .and. inface == 7 .and. ilay < particle%ilay) then
         particle%idomain(2) = particle%icp
         particle%izone = particle%izp
-        call this%events%terminate(particle, &
-                                   status=TERM_BOUNDARY)
+        call this%terminate(particle, &
+                            status=TERM_BOUNDARY)
         return
       else
         particle%icp = particle%idomain(2)
@@ -239,8 +239,8 @@ contains
       ! boundary face, so terminate the particle.
       ! todo AMP: reconsider when multiple models supported
       if (cell%defn%facenbr(particle%iboundary(2)) .eq. 0) then
-        call this%events%terminate(particle, &
-                                   status=TERM_BOUNDARY)
+        call this%terminate(particle, &
+                            status=TERM_BOUNDARY)
       else
         ! Otherwise, load cell properties into the
         ! particle. It may be marked to terminate.

--- a/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
@@ -138,7 +138,7 @@ contains
     ! Subcell has no exit face, terminate the particle
     ! todo: after initial release, consider ramifications
     if ((statusVX .eq. 3) .and. (statusVY .eq. 3) .and. (statusVZ .eq. 3)) then
-      call this%events%terminate(particle, status=TERM_NO_EXITS_SUB)
+      call this%terminate(particle, status=TERM_NO_EXITS_SUB)
       return
     end if
 
@@ -150,7 +150,7 @@ contains
     ! tmax is not the end of the simulation, it's just a wildly high upper bound.
     if ((statusVX .eq. 2) .and. (statusVY .eq. 2) .and. (statusVZ .eq. 2) .and. &
         particle%iextend > 0 .and. endofsimulation) then
-      call this%events%terminate(particle, status=TERM_TIMEOUT)
+      call this%terminate(particle, status=TERM_TIMEOUT)
       return
     end if
 
@@ -212,7 +212,7 @@ contains
         particle%z = z * subcell%dz
         particle%ttrack = t
         particle%istatus = ACTIVE
-        call this%events%usertime(particle)
+        call this%usertime(particle)
       end do
     end if
 
@@ -275,7 +275,11 @@ contains
     particle%iboundary(3) = exitFace
 
     ! Save particle track record
-    if (event_code >= 0) call this%dispatch(particle, event_code=event_code)
+    if (event_code == TIMESTEP) then
+      call this%timestep(particle)
+    else if (event_code == CELLEXIT) then
+      call this%cellexit(particle)
+    end if
 
   end subroutine track_subcell
 

--- a/src/Solution/ParticleTracker/Method/MethodSubcellTernary.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellTernary.f90
@@ -213,8 +213,8 @@ contains
     ! If the subcell has no exit face, terminate the particle.
     ! todo: after initial release, consider ramifications
     if (itopbotexit == 0 .and. itrifaceexit == 0) then
-      call this%events%terminate(particle, &
-                                 status=TERM_NO_EXITS_SUB)
+      call this%terminate(particle, &
+                          status=TERM_NO_EXITS_SUB)
       return
     end if
 
@@ -242,8 +242,8 @@ contains
 
     ! -- Make sure dt is positive
     if (dtexit < DZERO) then
-      call this%events%terminate(particle, &
-                                 status=TERM_NO_EXITS_SUB)
+      call this%terminate(particle, &
+                          status=TERM_NO_EXITS_SUB)
       return
     end if
 
@@ -269,7 +269,7 @@ contains
         particle%z = z
         particle%ttrack = t
         particle%istatus = ACTIVE
-        call this%events%usertime(particle)
+        call this%usertime(particle)
       end do
     end if
 
@@ -301,7 +301,11 @@ contains
     particle%ttrack = t
     particle%iboundary(3) = exitFace
 
-    call this%dispatch(particle, event_code=event_code)
+    if (event_code == TIMESTEP) then
+      call this%timestep(particle)
+    else if (event_code == CELLEXIT) then
+      call this%cellexit(particle)
+    end if
   end subroutine track_subcell
 
   !> @brief Do calculations related to analytical z solution

--- a/src/Solution/ParticleTracker/Particle/ParticleEvents.f90
+++ b/src/Solution/ParticleTracker/Particle/ParticleEvents.f90
@@ -22,15 +22,8 @@ module ParticleEventsModule
   contains
     procedure, public :: subscribe
     procedure, public :: unsubscribe
-    procedure :: dispatch
+    procedure, public :: dispatch
     procedure :: destroy
-    ! particle events
-    procedure, public :: release
-    procedure, public :: cellexit
-    procedure, public :: timestep
-    procedure, public :: terminate
-    procedure, public :: weaksink
-    procedure, public :: usertime
   end type ParticleEventDispatcherType
 
   abstract interface
@@ -59,7 +52,7 @@ contains
     end if
   end subroutine unsubscribe
 
-  !> @brief Dispatch an event. Internal use only.
+  !> @brief Dispatch an event.
   subroutine dispatch(this, particle, event)
     use TdisModule, only: kper, kstp, totimc
     ! dummy
@@ -100,68 +93,5 @@ contains
     if (associated(this%consumer)) &
       deallocate (this%consumer)
   end subroutine destroy
-
-  !> @brief Particle is released.
-  subroutine release(this, particle)
-    class(ParticleEventDispatcherType), intent(inout) :: this
-    type(ParticleType), pointer, intent(inout) :: particle
-    class(ParticleEventType), pointer :: event
-
-    allocate (ReleaseEventType :: event)
-    call this%dispatch(particle, event)
-  end subroutine release
-
-  !> @brief Particle exits a cell.
-  subroutine cellexit(this, particle)
-    class(ParticleEventDispatcherType), intent(inout) :: this
-    type(ParticleType), pointer, intent(inout) :: particle
-    class(ParticleEventType), pointer :: event
-
-    allocate (CellExitEventType :: event)
-    call this%dispatch(particle, event)
-  end subroutine cellexit
-
-  !> @brief Particle terminates.
-  subroutine terminate(this, particle, status)
-    class(ParticleEventDispatcherType), intent(inout) :: this
-    type(ParticleType), pointer, intent(inout) :: particle
-    integer(I4B), intent(in), optional :: status
-    class(ParticleEventType), pointer :: event
-
-    particle%advancing = .false.
-    if (present(status)) particle%istatus = status
-    allocate (TerminationEventType :: event)
-    call this%dispatch(particle, event)
-  end subroutine terminate
-
-  !> @brief Time step ends.
-  subroutine timestep(this, particle)
-    class(ParticleEventDispatcherType), intent(inout) :: this
-    type(ParticleType), pointer, intent(inout) :: particle
-    class(ParticleEventType), pointer :: event
-
-    allocate (TimeStepEventType :: event)
-    call this%dispatch(particle, event)
-  end subroutine timestep
-
-  !> @brief Particle leaves a weak sink.
-  subroutine weaksink(this, particle)
-    class(ParticleEventDispatcherType), intent(inout) :: this
-    type(ParticleType), pointer, intent(inout) :: particle
-    class(ParticleEventType), pointer :: event
-
-    allocate (WeakSinkEventType :: event)
-    call this%dispatch(particle, event)
-  end subroutine weaksink
-
-  !> @brief User-defined tracking time occurs.
-  subroutine usertime(this, particle)
-    class(ParticleEventDispatcherType), intent(inout) :: this
-    type(ParticleType), pointer, intent(inout) :: particle
-    class(ParticleEventType), pointer :: event
-
-    allocate (UserTimeEventType :: event)
-    call this%dispatch(particle, event)
-  end subroutine usertime
 
 end module ParticleEventsModule


### PR DESCRIPTION
The event dispatcher should be generic, it's a concern of the method which event fires when. Eventually event routines should be defined by the relevant domain, i.e. cell-exit by the base cell method. May make sense to add subcell events too, which the user can opt into (tho shouldn't be included by default since subcell-scale therefore an implementation detail)?