### PR TITLE
fix(prt): account for assigned boundary faces

### DIFF
--- a/autotest/test_prt_iflowface_interior.py
+++ b/autotest/test_prt_iflowface_interior.py
@@ -1,16 +1,13 @@
 """
-1D unconfined model with a constant head boundary on the left,
-5 RIV boundary cells on the right with the same stage, and recharge.
+1D unconfined model with a constant head boundary on the left and a pumping well
+in the middle. Modified from `test_prt_iflowface_stopzone.py`.
 
-Particles are placed in every cell center. There are several cases
-with extended tracking off, and several identical cases with it on.
+A single particle is placed near the left side of the grid. The well is centrally
+located. IFLOWFACE is assigned to the well's right face.
 
-The cases exercise different combinations of IFLOWFACE, either none
-or set to -1 (top) for the RIV boundary cells, as well as ISTOPZONE
-and STOP_AT_WEAK_SINK. PRT and MP7 results are compared.
+Exercises the `INTERNAL_ASSIGNED_BOUNDARY_FACE_METHOD` option in the PRT FMI package.
 
-Contributed by @aleaf in:
-https://github.com/MODFLOW-ORG/modflow6/issues/2358
+This test compares PRT and MP7 models.
 """
 
 import os
@@ -33,82 +30,17 @@ from prt_test_utils import get_model_name
 
 pd.set_option("display.max_columns", None)
 
-simname = "prt2358"
+simname = "prtiffint"
 cases = {
-    f"{simname}_a": {
-        "stop_at_weak_sink": False,
-        "istopzone": None,
-        "iflowface": None,
-        "iface": None,
-        "extend": False,
+    f"{simname}stp": {
+        "iffmeth": "stop",
     },
-    f"{simname}_b": {
-        "stop_at_weak_sink": False,
-        "istopzone": None,
-        "iflowface": -1,
-        "iface": 6,
-        "extend": False,
-    },
-    f"{simname}_c": {
-        "stop_at_weak_sink": False,
-        "istopzone": -1,
-        "iflowface": -1,
-        "iface": 6,
-        "extend": False,
-    },
-    f"{simname}_d": {
-        "stop_at_weak_sink": False,
-        "istopzone": 1,
-        "iflowface": -1,
-        "iface": 6,
-        "extend": False,
-    },
-    f"{simname}_e": {
-        "stop_at_weak_sink": True,
-        "istopzone": None,
-        "iflowface": None,
-        "iface": None,
-        "extend": False,
-    },
-    f"{simname}_aext": {
-        "stop_at_weak_sink": False,
-        "istopzone": None,
-        "iflowface": None,
-        "iface": None,
-        "extend": True,
-    },
-    f"{simname}_bext": {
-        "stop_at_weak_sink": False,
-        "istopzone": None,
-        "iflowface": -1,
-        "iface": 6,
-        "extend": True,
-    },
-    f"{simname}_cext": {
-        "stop_at_weak_sink": False,
-        "istopzone": -1,
-        "iflowface": -1,
-        "iface": 6,
-        "extend": True,
-    },
-    f"{simname}_dext": {
-        "stop_at_weak_sink": False,
-        "istopzone": 1,
-        "iflowface": -1,
-        "iface": 6,
-        "extend": True,
-    },
-    f"{simname}_eext": {
-        "stop_at_weak_sink": True,
-        "istopzone": None,
-        "iflowface": None,
-        "iface": None,
-        "extend": True,
+    f"{simname}ign": {
+        "iffmeth": "ignore",
     },
 }
 
-# grid info
-top = 20.0
+top = 30.0
 botm = 0
 nlay = 1
 nrow = 1
@@ -117,11 +49,10 @@ nnodes = nlay * nrow * ncol
 delr = 100.0
 delc = 100.0
 
-# particle tracking info
 particledata = ParticleData(
-    partlocs=[(0, 0, i) for i in range(nnodes)],
+    partlocs=[(0, 0, i) for i in range(1, 2)],
     structured=True,
-    particleids=list(range(nnodes)),
+    particleids=list(range(1, 2)),
     localx=0.5,
     localy=0.5,
     localz=0.5,
@@ -129,7 +60,7 @@ particledata = ParticleData(
 porosity = 0.1
 
 
-def build_gwf_sim(name, ws, mf6, iflowface=None):
+def build_gwf_sim(name, ws, mf6):
     sim = flopy.mf6.MFSimulation(sim_name=name, exe_name=mf6, version="mf6", sim_ws=ws)
     tdis = flopy.mf6.modflow.mftdis.ModflowTdis(
         sim, pname="tdis", time_units="DAYS", nper=1, perioddata=[(1.0, 1, 1.0)]
@@ -158,45 +89,26 @@ def build_gwf_sim(name, ws, mf6, iflowface=None):
         save_specific_discharge=True,
         save_saturation=True,
     )
-    if iflowface is not None:
-        riv_period_array = [
-            ((0, 0, 5), 9.99, 1e6, 8.99, iflowface),
-            ((0, 0, 6), 9.99, 1e6, 8.98, iflowface),
-            ((0, 0, 7), 9.99, 1e6, 8.97, iflowface),
-            ((0, 0, 8), 9.99, 1e6, 8.96, iflowface),
-            ((0, 0, 9), 9.99, 1e6, 8.95, iflowface),
-        ]
-        chd_rec = [((0, 0, 0), 10.0, iflowface)]
-        auxiliary = ["iflowface"]
-    else:
-        riv_period_array = [
-            ((0, 0, 5), 9.99, 1e6, 8.99),
-            ((0, 0, 6), 9.99, 1e6, 8.98),
-            ((0, 0, 7), 9.99, 1e6, 8.97),
-            ((0, 0, 8), 9.99, 1e6, 8.96),
-            ((0, 0, 9), 9.99, 1e6, 8.95),
-        ]
-        chd_rec = [((0, 0, 0), 10.0)]
-        auxiliary = None
-    riv_period = {0: riv_period_array}
-    riv = flopy.mf6.ModflowGwfriv(
+    wel_period_array = [((0, 0, 7), -50.0, 3)]
+    wel_period = {0: wel_period_array}
+    wel = flopy.mf6.ModflowGwfwel(
         gwf,
         save_flows=f"{gwf_name}.cbc",
-        stress_period_data=riv_period,
-        auxiliary=auxiliary,
+        stress_period_data=wel_period,
+        auxiliary=["iflowface"],
     )
     rch1 = flopy.mf6.ModflowGwfrcha(
         gwf,
         recharge=5e-4,
-        auxiliary=auxiliary,
-        aux={0: [iflowface]} if iflowface is not None else None,
+        auxiliary=["iflowface"],
+        aux={0: [-1]},
     )
+    chd_rec = [((0, 0, 0), 30.0)]
     chd = flopy.mf6.modflow.mfgwfchd.ModflowGwfchd(
         gwf,
         maxbound=len(chd_rec),
         stress_period_data=chd_rec,
         save_flows=True,
-        auxiliary=["iflowface"] if iflowface is not None else None,
     )
     headfile = f"{gwf_name}.hds"
     head_filerecord = [headfile]
@@ -220,15 +132,12 @@ def build_prt_sim(
     gwf,
     prt_ws,
     mf6,
-    iflowface=None,
-    istopzone=None,
-    stop_at_weak_sink=False,
+    iffmeth="STOP",
     extend=False,
 ):
     prt_name = get_model_name(name, "prt")
     sim = flopy.mf6.MFSimulation(sim_name=prt_name, exe_name=mf6, sim_ws=prt_ws)
-    # Instantiate the MODFLOW 6 temporal discretization package
-    flopy.mf6.modflow.mftdis.ModflowTdis(
+    tdis = flopy.mf6.modflow.mftdis.ModflowTdis(
         sim,
         pname="tdis",
         time_units="DAYS",
@@ -238,8 +147,7 @@ def build_prt_sim(
     prt = flopy.mf6.ModflowPrt(
         sim, modelname=prt_name, model_nam_file=f"{prt_name}.nam"
     )
-
-    flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
+    dis = flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
         prt,
         pname="dis",
         nlay=nlay,
@@ -250,18 +158,9 @@ def build_prt_sim(
         top=top,
         botm=botm,
     )
-
-    if istopzone is not None:
-        izone_array = np.zeros((nlay, nrow, ncol), dtype=int)
-        izone_array[:, 0, 0] = istopzone
-        izone_array[:, 0, 5:] = istopzone
-    else:
-        izone_array = None
-
-    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=porosity, izone=izone_array)
-
+    mip = flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=porosity)
     prpdata = list(particledata.to_prp(gwf.modelgrid, localz=True))
-    flopy.mf6.ModflowPrtprp(
+    prp = flopy.mf6.ModflowPrtprp(
         prt,
         pname="prp",
         nreleasepts=len(prpdata),
@@ -269,18 +168,14 @@ def build_prt_sim(
         perioddata={0: ["FIRST"]},
         local_z=True,
         exit_solve_tolerance=1e-5,
-        stop_at_weak_sink=stop_at_weak_sink,
         extend_tracking=extend,
-        istopzone=istopzone,
     )
-    # Instantiate the MODFLOW 6 prt output control package
     budgetfile_prt = f"{prt_name}.cbc"
     trackfile_prt = f"{prt_name}.trk"
     trackcsvfile_prt = f"{prt_name}.trk.csv"
     budget_record = [budgetfile_prt]
     track_record = [trackfile_prt]
     trackcsv_record = [trackcsvfile_prt]
-    # track positions every year for 100 years
     flopy.mf6.ModflowPrtoc(
         prt,
         pname="oc",
@@ -292,18 +187,15 @@ def build_prt_sim(
         track_terminate=True,
         track_exit=True,
     )
-
     gwf_ws = gwf.model_ws
     rel_prt_folder = os.path.relpath(gwf_ws, start=prt_ws)
-
-    # Instantiate the MODFLOW 6 prt flow model interface
     fmi_pd = [
         ("GWFHEAD", f"{rel_prt_folder}/{gwf.name}.hds"),
         ("GWFBUDGET", f"{rel_prt_folder}/{gwf.name}.cbb"),
     ]
-    flopy.mf6.ModflowPrtfmi(prt, packagedata=fmi_pd)
-
-    # Create an explicit model solution (EMS) for the MODFLOW 6 prt model
+    fmi = flopy.mf6.ModflowPrtfmi(
+        prt, packagedata=fmi_pd, internal_iflowface_method=iffmeth
+    )
     ems = flopy.mf6.ModflowEms(
         sim,
         pname="ems",
@@ -318,14 +210,9 @@ def build_mp7_sim(
     ws,
     mp7,
     gwf,
-    iface=None,
-    istopzone=None,
-    stop_at_weak_sink=False,
     extend=False,
 ):
-    # make an equivalent MP7 simulation
     mp7_name = get_model_name(name, "mp7")
-
     pg = ParticleGroup(
         particledata=particledata,
     )
@@ -335,33 +222,20 @@ def build_mp7_sim(
         exe_name=mp7,
         model_ws=ws,
     )
-    defaultiface = (
-        dict() if iface is None else {"CHD": iface, "RIV": iface, "RCH": iface}
-    )
+    defaultiface = {"WEL": 2, "RCH": 6}
     mpbas = flopy.modpath.Modpath7Bas(
         mp,
         porosity=porosity,
         defaultiface=defaultiface,
     )
-    if istopzone is not None:
-        izone_array = np.zeros((nlay, nrow, ncol), dtype=int)
-        izone_array[:, 0, 0] = istopzone
-        izone_array[:, 0, 5:] = istopzone
-        zonedataoption = "on"
-    else:
-        zonedataoption = "off"
-        izone_array = None
     mpsim = flopy.modpath.Modpath7Sim(
         mp,
         simulationtype="pathline",
         trackingdirection="forward",
         budgetoutputoption="summary",
-        weaksinkoption="stop_at" if stop_at_weak_sink else "pass_through",
+        weaksinkoption="pass_through",
         referencetime=(0, 0, 0.0),
         stoptimeoption="extend" if extend else "total",
-        zonedataoption=zonedataoption,
-        stopzone=1,
-        zones=izone_array,
         particlegroups=[pg],
     )
     return mp
@@ -370,17 +244,13 @@ def build_mp7_sim(
 def build_models(
     idx,
     test,
-    iflowface=None,
-    iface=None,
-    istopzone=None,
-    stop_at_weak_sink=False,
+    iffmeth="STOP",
     extend=False,
 ):
     gwf_sim = build_gwf_sim(
         name=test.name,
         ws=test.workspace / "gwf",
         mf6=test.targets["mf6"],
-        iflowface=iflowface,
     )
     gwf = gwf_sim.get_model(get_model_name(test.name, "gwf"))
     prt_sim = build_prt_sim(
@@ -388,9 +258,7 @@ def build_models(
         gwf=gwf,
         prt_ws=test.workspace / "prt",
         mf6=test.targets["mf6"],
-        iflowface=iflowface,
-        istopzone=istopzone,
-        stop_at_weak_sink=stop_at_weak_sink,
+        iffmeth=iffmeth,
         extend=extend,
     )
     mp7_sim = build_mp7_sim(
@@ -398,19 +266,16 @@ def build_models(
         ws=test.workspace / "mp7",
         mp7=test.targets["mp7"],
         gwf=gwf,
-        iface=iface,
-        istopzone=istopzone,
-        stop_at_weak_sink=stop_at_weak_sink,
         extend=extend,
     )
     return gwf_sim, prt_sim, mp7_sim
 
 
-def compare_output(mf6_pls, mp7_pls, mp7_eps, tolerance=1e-3):
-    mf6_eps = mf6_pls[(mf6_pls.ireason == 3)]  # get prt start/endpoints
-    mp7_eps = to_mp7_pathlines(mp7_eps)  # convert mp7 pathlines to mp7 format
-    mf6_pls = to_mp7_pathlines(mf6_pls)  # convert mf6 pathlines to mp7 format
-    mf6_eps = to_mp7_pathlines(mf6_eps)  # convert mf6 endpoints to mp7 format
+def compare_output(name, mf6_pls, mp7_pls, mp7_eps, tolerance=1e-3):
+    mf6_eps = mf6_pls[(mf6_pls.ireason == 3)]
+    mp7_eps = to_mp7_pathlines(mp7_eps)
+    mf6_pls = to_mp7_pathlines(mf6_pls)
+    mf6_eps = to_mp7_pathlines(mf6_eps)
 
     # drop columns for which there is no direct correspondence between mf6 and mp7
     columns_to_remove = [
@@ -448,15 +313,12 @@ def compare_output(mf6_pls, mp7_pls, mp7_eps, tolerance=1e-3):
     drop_cols(mf6_eps, columns_to_remove)
     drop_cols(mp7_eps, columns_to_remove)
 
-    mf6_eps = mf6_eps.reindex(sorted(mf6_eps.columns), axis=1).sort_values(
-        by=["particleid", "time"]
-    )
-    mp7_eps = mp7_eps.reindex(sorted(mp7_eps.columns), axis=1).sort_values(
-        by=["particleid", "time"]
-    )
-
-    assert mf6_eps.shape == mp7_eps.shape
-    assert np.allclose(mf6_eps, mp7_eps, atol=tolerance)
+    assert np.isclose(mf6_eps.x, 800 if "stp" in name else 700)
+    assert np.isclose(mp7_eps.x, 700)
+    assert np.isclose(mf6_eps.y, 50)
+    assert np.isclose(mp7_eps.y, 50)
+    assert np.isclose(mf6_eps.z, 12.4488, atol=tolerance)
+    assert np.isclose(mp7_eps.z, 12.4488, atol=tolerance)
 
 
 def check_output(idx, test):
@@ -471,7 +333,6 @@ def check_output(idx, test):
     gwf = gwf_sim.get_model(gwf_name)
     mg = gwf.modelgrid
 
-    # check mf6 output files exist
     gwf_budget_file = f"{gwf_name}.bud"
     gwf_head_file = f"{gwf_name}.hds"
     prt_track_file = f"{prt_name}.trk"
@@ -481,14 +342,12 @@ def check_output(idx, test):
     mp7_pathline_file = f"{mp7_name}.mppth"
     mp7_endpoint_file = f"{mp7_name}.mpend"
 
-    # extract head, budget, and specific discharge results from GWF model
     headfile = HeadFile(gwf_ws / gwf_head_file)
     hds = headfile.get_data()
     bud = gwf.output.budget()
     spdis = bud.get_data(text="DATA-SPDIS")[0]
     qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(spdis, gwf)
 
-    # load mp7 pathline results
     plf = PathlineFile(mp7_ws / mp7_pathline_file)
     mp7_pls = pd.DataFrame(
         plf.get_destination_pathline_data(range(mg.nnodes), to_recarray=True)
@@ -497,18 +356,16 @@ def check_output(idx, test):
     mp7_pls["node"] = mp7_pls["node"] + 1
     mp7_pls["k"] = mp7_pls["k"] + 1
 
-    # load mp7 endpoint results
     epf = EndpointFile(mp7_ws / mp7_endpoint_file)
     mp7_eps = pd.DataFrame(epf.get_destination_endpoint_data(range(mg.nnodes)))
     mp7_eps["particlegroup"] = mp7_eps["particlegroup"] + 1
     mp7_eps["node"] = mp7_eps["node"] + 1
     mp7_eps["k"] = mp7_eps["k"] + 1
 
-    # load mf6 pathline results
     mf6_pls = pd.read_csv(prt_ws / prt_track_csv_file, na_filter=False)
 
     compare_output(
-        mf6_pls, mp7_pls, mp7_eps, tolerance=1e-1 if "ext" in test.name else 1e-3
+        name, mf6_pls, mp7_pls, mp7_eps, tolerance=1e-1 if "ext" in test.name else 1e-3
     )
 
 
@@ -524,7 +381,6 @@ def plot_output(idx, test):
     gwf = gwf_sim.get_model(gwf_name)
     mg = gwf.modelgrid
 
-    # check mf6 output files exist
     gwf_budget_file = f"{gwf_name}.bud"
     gwf_head_file = f"{gwf_name}.hds"
     prt_track_file = f"{prt_name}.trk"
@@ -534,44 +390,38 @@ def plot_output(idx, test):
     mp7_pathline_file = f"{mp7_name}.mppth"
     mp7_endpoint_file = f"{mp7_name}.mpend"
 
-    # extract head, budget, and specific discharge results from GWF model
     headfile = HeadFile(gwf_ws / gwf_head_file)
     hds = headfile.get_data()
     bud = gwf.output.budget()
     spdis = bud.get_data(text="DATA-SPDIS")[0]
     qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(spdis, gwf)
 
-    # load mp7 pathline results
     plf = PathlineFile(mp7_ws / mp7_pathline_file)
     mp7_pls = pd.DataFrame(
         plf.get_destination_pathline_data(range(mg.nnodes), to_recarray=True)
     )
-    # convert zero-based to one-based indexing in mp7 results
     mp7_pls["particlegroup"] = mp7_pls["particlegroup"] + 1
     mp7_pls["node"] = mp7_pls["node"] + 1
     mp7_pls["k"] = mp7_pls["k"] + 1
 
-    # load mp7 endpoint results
     epf = EndpointFile(mp7_ws / mp7_endpoint_file)
     mp7_eps = pd.DataFrame(epf.get_destination_endpoint_data(range(mg.nnodes)))
-    # convert zero-based to one-based indexing in mp7 results
     mp7_eps["particlegroup"] = mp7_eps["particlegroup"] + 1
     mp7_eps["node"] = mp7_eps["node"] + 1
     mp7_eps["k"] = mp7_eps["k"] + 1
 
-    # load mf6 pathline results
     mf6_pls = pd.read_csv(prt_ws / prt_track_csv_file, na_filter=False)
     mf6_eps = to_mp7_pathlines(mf6_pls[mf6_pls.ireason == 3])
 
-    # setup plot
     fig, ax = plt.subplots(nrows=2, ncols=2, figsize=(10, 10))
     fig.tight_layout(pad=3.0)
     for a in ax.ravel():
         a.set_aspect("equal")
 
-    # plot mf6 pathlines in map view
-    pmv = flopy.plot.PlotMapView(modelgrid=mg, ax=ax[0][0])
+    pmv = flopy.plot.PlotMapView(model=gwf, ax=ax[0][0])
     pmv.plot_grid()
+    pmv.plot_bc("CHD", alpha=0.4)
+    pmv.plot_bc("WEL", alpha=0.4)
     pmv.plot_array(hds[0], alpha=0.1)
     pmv.plot_vector(qx, qy, normalize=True, color="white")
     mf6_plines = mf6_pls.groupby(["iprp", "irpt", "trelease"])
@@ -587,9 +437,10 @@ def plot_output(idx, test):
             lw=2,
         )
 
-    # plot mp7 pathlines in map view
-    pmv = flopy.plot.PlotMapView(modelgrid=mg, ax=ax[0][1])
+    pmv = flopy.plot.PlotMapView(model=gwf, ax=ax[0][1])
     pmv.plot_grid()
+    pmv.plot_bc("CHD", alpha=0.4)
+    pmv.plot_bc("WEL", alpha=0.4)
     pmv.plot_array(hds[0], alpha=0.1)
     pmv.plot_vector(qx, qy, normalize=True, color="white")
     mp7_plines = mp7_pls.groupby(["particleid"])
@@ -605,9 +456,10 @@ def plot_output(idx, test):
             lw=2,
         )
 
-    # plot mf6 pathlines in cross section
-    pxs = flopy.plot.PlotCrossSection(modelgrid=mg, ax=ax[1][0], line={"row": 0})
+    pxs = flopy.plot.PlotCrossSection(model=gwf, ax=ax[1][0], line={"row": 0})
     pxs.plot_grid()
+    pxs.plot_bc("CHD", alpha=0.4)
+    pxs.plot_bc("WEL", alpha=0.4)
     pxs.plot_array(hds[0], alpha=0.1)
     pxs.plot_vector(qx, qy, qz, normalize=True, color="white")
     for ipl, ((iprp, irpt, trelease), pl) in enumerate(mf6_plines):
@@ -622,9 +474,10 @@ def plot_output(idx, test):
             lw=2,
         )
 
-    # plot mp7 pathlines in cross section
-    pxs = flopy.plot.PlotCrossSection(modelgrid=mg, ax=ax[1][1], line={"row": 0})
+    pxs = flopy.plot.PlotCrossSection(model=gwf, ax=ax[1][1], line={"row": 0})
     pxs.plot_grid()
+    pxs.plot_bc("CHD", alpha=0.4)
+    pxs.plot_bc("WEL", alpha=0.4)
     pxs.plot_array(hds[0], alpha=0.1)
     pxs.plot_vector(qx, qy, qz, normalize=True, color="white")
     for ipl, (pid, pl) in enumerate(mp7_plines):
@@ -639,7 +492,6 @@ def plot_output(idx, test):
             lw=2,
         )
 
-    # view/save plot
     plt.show()
     plt.savefig(gwf_ws / f"{name}.png")
 
@@ -653,11 +505,8 @@ def test_mf6model(idx, name, function_tmpdir, targets, plot):
         build=lambda t: build_models(
             idx,
             t,
-            iflowface=case["iflowface"],
-            iface=case["iface"],
-            istopzone=case["istopzone"],
-            stop_at_weak_sink=case["stop_at_weak_sink"],
-            extend=case["extend"],
+            iffmeth=case["iffmeth"],
+            extend=True,
         ),
         check=lambda t: check_output(idx, t),
         plot=lambda t: plot_output(idx, t) if plot else None,

--- a/autotest/test_prt_iflowface_interior.py
+++ b/autotest/test_prt_iflowface_interior.py
@@ -5,7 +5,7 @@ in the middle. Modified from `test_prt_iflowface_stopzone.py`.
 A single particle is placed near the left side of the grid. The well is centrally
 located. IFLOWFACE is assigned to the well's right face.
 
-Exercises the `INTERNAL_ASSIGNED_BOUNDARY_FACE_METHOD` option in the PRT FMI package.
+Exercises the `INTERNAL_IFLOWFACE_METHOD` option in the PRT FMI package.
 
 This test compares PRT and MP7 models.
 """

--- a/autotest/test_prt_iflowface_stopzone.py
+++ b/autotest/test_prt_iflowface_stopzone.py
@@ -2,7 +2,7 @@
 1D unconfined model with a constant head boundary on the left,
 5 RIV boundary cells on the right with the same stage, and recharge.
 
-Particles are placed in every cell center. There are several cases
+Particles are placed at every cell center. There are several cases
 with extended tracking off, and several identical cases with it on.
 
 The cases exercise different combinations of IFLOWFACE, either none

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -83,4 +83,12 @@ section = "fixes"
 subsection = "internal"
 description = "Clarified the definition of the rtp parameter in the SFR PACKAGEDATA block."
 
+[[items]]
+section = "fixes"
+subsection = "solution"
+description = "Fixed potential infinite loop conditions related to inadequate handling of boundary faces assigned with IFLOWFACE."
 
+[[items]]
+section = "features"
+subsection = "solution"
+description = "Added an option INTERNAL\\_IFLOWFACE\\_METHOD to the PRT Model's FMI package, determining how to proceed for particles in cells with IFLOWFACE assigned boundary face adjacent to an active cell (i.e. 'internal' boundary faces). Options are: STOP at internal assigned boundary face(s) after tracking through the cell (the default), or IGNORE internal assigned boundary face(s) like MP7, issuing a warning."

--- a/doc/mf6io/mf6ivar/dfn/prt-fmi.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-fmi.dfn
@@ -8,6 +8,16 @@ optional true
 longname save cell-by-cell flows to budget file
 description REPLACE save_flows {'{#1}': 'FMI'}
 
+block options
+name internal_iflowface_method
+type string
+valid stop ignore
+reader urword
+optional true
+mf6internal iffmeth
+longname internal assigned boundary face tracking method
+description is a string determining how tracking should proceed in cells containing boundary packages assigning IFLOWFACE to faces adjacent to active cells. The default value STOP allows tracking through the boundary cell, then terminates particles on reaching an assigned face. IGNORE ignores internal boundary face assignments, mimicking the behavior of MODPATH 7, and prints a warning.
+
 # --------------------- prt fmi packagedata ---------------------
 
 block packagedata

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -290,7 +290,7 @@ reader urword
 optional true
 mf6internal ichkmeth
 longname coordinate checking method
-description approach for verifying that release point coordinates are in the cell with the specified ID. By default, release point coordinates are checked at release time.
+description is a string determining whether and when to verify that release point coordinates are in the cell with the specified ID. By default, release point coordinates are checked at release time (EAGER).
 default eager
 
 block options

--- a/src/Idm/prt-fmiidm.f90
+++ b/src/Idm/prt-fmiidm.f90
@@ -13,6 +13,7 @@ module PrtFmiInputModule
 
   type PrtFmiParamFoundType
     logical :: save_flows = .false.
+    logical :: iffmeth = .false.
     logical :: flowtype = .false.
     logical :: filein = .false.
     logical :: fname = .false.
@@ -37,6 +38,24 @@ module PrtFmiInputModule
     'KEYWORD', & ! type
     '', & ! shape
     'save cell-by-cell flows to budget file', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtfmi_iffmeth = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'FMI', & ! subcomponent
+    'OPTIONS', & ! block
+    'INTERNAL_IFLOWFACE_METHOD', & ! tag name
+    'IFFMETH', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'internal assigned boundary face tracking method', & ! longname
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
@@ -102,6 +121,7 @@ module PrtFmiInputModule
     prt_fmi_param_definitions(*) = &
     [ &
     prtfmi_save_flows, &
+    prtfmi_iffmeth, &
     prtfmi_flowtype, &
     prtfmi_filein, &
     prtfmi_fname &

--- a/src/Model/ParticleTracking/prt-fmi.f90
+++ b/src/Model/ParticleTracking/prt-fmi.f90
@@ -1,13 +1,15 @@
 module PrtFmiModule
 
-  use KindModule, only: DP, I4B
-  use ConstantsModule, only: DZERO, LENAUXNAME, LENPACKAGENAME
-  use SimModule, only: store_error
-  use SimVariablesModule, only: errmsg
+  use KindModule, only: DP, I4B, LGP
+  use ErrorUtilModule, only: pstop
+  use ConstantsModule, only: DZERO, LENAUXNAME, LENPACKAGENAME, LENVARNAME
+  use SimModule, only: store_error, store_warning
+  use SimVariablesModule, only: errmsg, warnmsg
   use FlowModelInterfaceModule, only: FlowModelInterfaceType
   use BaseDisModule, only: DisBaseType
   use BudgetObjectModule, only: BudgetObjectType
   use CellModule, only: MAX_POLY_CELLS
+  use CellDefnModule, only: CellDefnType
 
   implicit none
   private
@@ -18,16 +20,23 @@ module PrtFmiModule
 
   type, extends(FlowModelInterfaceType) :: PrtFmiType
 
-    double precision, allocatable, public :: SourceFlows(:) ! cell source flows array
-    double precision, allocatable, public :: SinkFlows(:) ! cell sink flows array
-    double precision, allocatable, public :: StorageFlows(:) ! cell storage flows array
-    double precision, allocatable, public :: BoundaryFlows(:) ! cell boundary flows array
+    integer(I4B), pointer :: iffmeth => null() !< internal iflowface method: 0 = stop, 1 = ignore
+    real(DP), allocatable, public :: SourceFlows(:) ! cell source flows
+    real(DP), allocatable, public :: SinkFlows(:) ! cell sink flows
+    real(DP), allocatable, public :: StorageFlows(:) ! cell storage flows
+    real(DP), allocatable, public :: BoundaryFlows(:) ! cell boundary flows
+    integer(I4B), allocatable, public :: BoundaryFaces(:) ! bitmask of cell iflowface, 0-30: lateral, 31 (-2): bottom, 32 (-1): top
 
   contains
 
     procedure :: fmi_ad
     procedure :: fmi_df => prtfmi_df
+    procedure :: allocate_scalars => prtfmi_allocate_scalars
+    procedure :: source_options => prtfmi_options
     procedure, private :: accumulate_flows
+    procedure :: mark_boundary_face
+    procedure :: is_boundary_face
+    procedure :: validate_boundary_faces
 
   end type PrtFmiType
 
@@ -41,21 +50,21 @@ contains
     character(len=*), intent(in) :: input_mempath
     integer(I4B), intent(inout) :: inunit
     integer(I4B), intent(in) :: iout
-    !
+
     ! Create the object
     allocate (fmiobj)
-    !
+
     ! create name and memory path
     call fmiobj%set_names(1, name_model, 'FMI', 'FMI', input_mempath)
     fmiobj%text = text
-    !
+
     ! Allocate scalars
     call fmiobj%allocate_scalars()
-    !
+
     ! Set variables
     fmiobj%inunit = inunit
     fmiobj%iout = iout
-    !
+
     ! Assign dependent variable label
     fmiobj%depvartype = 'TRACKS          '
 
@@ -74,41 +83,41 @@ contains
      &"(/1X,'WARNING: DRY CELL ENCOUNTERED AT ',a,';  RESET AS INACTIVE')"
     character(len=*), parameter :: fmtrewet = &
      &"(/1X,'DRY CELL REACTIVATED AT ', a)"
-    !
+
     ! Set flag to indicated that flows are being updated.  For the case where
-    !    flows may be reused (only when flows are read from a file) then set
-    !    the flag to zero to indicated that flows were not updated
+    ! flows may be reused (only when flows are read from a file) then set
+    ! the flag to zero to indicated that flows were not updated
     this%iflowsupdated = 1
-    !
+
     ! If reading flows from a budget file, read the next set of records
-    if (this%iubud /= 0) then
+    if (this%iubud /= 0) &
       call this%advance_bfr()
-    end if
-    !
+
     ! If reading heads from a head file, read the next set of records
-    if (this%iuhds /= 0) then
+    if (this%iuhds /= 0) &
       call this%advance_hfr()
-    end if
-    !
+
     ! If mover flows are being read from file, read the next set of records
-    if (this%iumvr /= 0) then
+    if (this%iumvr /= 0) &
       call this%mvrbudobj%bfr_advance(this%dis, this%iout)
-    end if
-    !
+
     ! Accumulate flows
     call this%accumulate_flows()
-    !
+
+    ! Validate IFLOWFACE assignments
+    call this%validate_boundary_faces()
+
     ! if flow cell is dry, then set this%ibound = 0
     do n = 1, this%dis%nodes
-      !
+
       ! Calculate the ibound-like array that has 0 if saturation
-      !    is zero and 1 otherwise
+      ! is zero and 1 otherwise
       if (this%gwfsat(n) > DZERO) then
         this%ibdgwfsat0(n) = 1
       else
         this%ibdgwfsat0(n) = 0
       end if
-      !
+
       ! Check if active model cell is inactive for flow
       if (this%ibound(n) > 0) then
         if (this%gwfhead(n) == DHDRY) then
@@ -118,7 +127,7 @@ contains
           write (this%iout, fmtdry) trim(nodestr)
         end if
       end if
-      !
+
       ! Convert dry model cell to active if flow has rewet
       if (this%ibound(n) == 0) then
         if (this%gwfhead(n) /= DHDRY) then
@@ -129,7 +138,6 @@ contains
         end if
       end if
     end do
-
   end subroutine fmi_ad
 
   !> @brief Define the flow model interface
@@ -140,17 +148,71 @@ contains
     class(PrtFmiType) :: this
     class(DisBaseType), pointer, intent(in) :: dis
     integer(I4B), intent(in) :: idryinactive
-    !
-    ! Call parent class define
-    call this%FlowModelInterfaceType%fmi_df(dis, idryinactive)
-    !
+    ! formats
+    character(len=*), parameter :: fmtfmi = &
+      "(1x,/1x,'FMI -- FLOW MODEL INTERFACE, VERSION 2, 8/17/2023',            &
+      &' INPUT READ FROM MEMPATH: ', A, //)"
+    character(len=*), parameter :: fmtfmi0 = &
+                    "(1x,/1x,'FMI -- FLOW MODEL INTERFACE,'&
+                    &' VERSION 2, 8/17/2023')"
+
+    ! Print a message identifying the FMI package.
+    if (this%iout > 0) then
+      if (this%inunit /= 0) then
+        write (this%iout, fmtfmi) this%input_mempath
+      else
+        write (this%iout, fmtfmi0)
+        if (this%flows_from_file) then
+          write (this%iout, '(a)') '  FLOWS ARE ASSUMED TO BE ZERO.'
+        else
+          write (this%iout, '(a)') '  FLOWS PROVIDED BY A GWF MODEL IN THIS &
+            &SIMULATION'
+        end if
+      end if
+    end if
+
+    ! Store pointers
+    this%dis => dis
+
+    ! Read fmi options
+    if (this%inunit /= 0) then
+      call this%source_options()
+    end if
+
+    ! Read packagedata options
+    if (this%inunit /= 0 .and. this%flows_from_file) then
+      call this%source_packagedata()
+      call this%initialize_gwfterms_from_bfr()
+    end if
+
+    ! If GWF-Model exchange is active, setup flow terms
+    if (.not. this%flows_from_file) then
+      call this%initialize_gwfterms_from_gwfbndlist()
+    end if
+
+    ! Set flag that stops dry flows from being deactivated in a GWE
+    ! transport model since conduction will still be simulated.
+    ! 0: GWE (skip deactivation step); 1: GWT (default: use existing code)
+    this%idryinactive = idryinactive
+
     ! Allocate arrays
     allocate (this%StorageFlows(this%dis%nodes))
     allocate (this%SourceFlows(this%dis%nodes))
     allocate (this%SinkFlows(this%dis%nodes))
     allocate (this%BoundaryFlows(this%dis%nodes * MAX_POLY_CELLS))
+    allocate (this%BoundaryFaces(this%dis%nodes))
 
   end subroutine prtfmi_df
+
+  !> @brief Allocate scalars
+  subroutine prtfmi_allocate_scalars(this)
+    use MemoryManagerModule, only: mem_allocate
+    class(PrtFmiType) :: this
+
+    call this%FlowModelInterfaceType%allocate_scalars()
+    call mem_allocate(this%iffmeth, "IFFMETH", this%memoryPath)
+    this%iffmeth = 0
+  end subroutine prtfmi_allocate_scalars
 
   !> @brief Accumulate flows
   subroutine accumulate_flows(this)
@@ -163,7 +225,7 @@ contains
     real(DP) :: qbnd
     character(len=LENAUXNAME) :: auxname
     integer(I4B) :: naux
-    !
+
     this%StorageFlows = DZERO
     if (this%igwfstrgss /= 0) &
       this%StorageFlows = this%StorageFlows + &
@@ -171,10 +233,10 @@ contains
     if (this%igwfstrgsy /= 0) &
       this%StorageFlows = this%StorageFlows + &
                           this%gwfstrgsy
-
     this%SourceFlows = DZERO
     this%SinkFlows = DZERO
     this%BoundaryFlows = DZERO
+    this%BoundaryFaces = 0
     do ip = 1, this%nflowpack
       iauxiflowface = 0
       naux = this%gwfpackages(ip)%naux
@@ -196,10 +258,12 @@ contains
         iflowface = 0
         if (iauxiflowface > 0) then
           iflowface = NINT(this%gwfpackages(ip)%auxvar(iauxiflowface, ib))
+          if (this%iffmeth /= 1 .and. iflowface > 0) &
+            call this%mark_boundary_face(i, iflowface)
           ! this maps bot -2 -> 9, top -1 -> 10; see note re: max faces below
           if (iflowface < 0) iflowface = iflowface + MAX_POLY_CELLS + 1
         end if
-        if (iflowface .gt. 0) then
+        if (this%iffmeth /= 1 .and. iflowface > 0) then
           ioffset = (i - 1) * MAX_POLY_CELLS
           this%BoundaryFlows(ioffset + iflowface) = &
             this%BoundaryFlows(ioffset + iflowface) + qbnd
@@ -210,7 +274,135 @@ contains
         end if
       end do
     end do
-
   end subroutine accumulate_flows
+
+  !> @brief Mark a face as a boundary face. Maps IFLOWFACE to bit position.
+  subroutine mark_boundary_face(this, n, iflowface)
+    class(PrtFmiType) :: this
+    integer(I4B), intent(in) :: n, iflowface
+    integer(I4B) :: bit_pos
+
+    if (n <= 0 .or. n > size(this%BoundaryFaces)) return
+    if (iflowface == 0) return
+    if (iflowface > 0) then
+      bit_pos = iflowface
+    else
+      bit_pos = 32 + iflowface ! -1: 31 (top), -2: 30 (bottom)
+    end if
+    if (bit_pos < 1 .or. bit_pos > 32) then
+      print *, 'Invalid IFLOWFACE: ', iflowface
+      call pstop(1)
+    end if
+    this%BoundaryFaces(n) = ibset(this%BoundaryFaces(n), bit_pos - 1)
+  end subroutine mark_boundary_face
+
+  !> @brief Check if a face is marked as boundary.
+  function is_boundary_face(this, n, iflowface) result(is_boundary)
+    class(PrtFmiType) :: this
+    integer(I4B), intent(in) :: n, iflowface
+    ! local
+    logical :: is_boundary
+    integer(I4B) :: bit_pos
+
+    is_boundary = .false.
+    if (n <= 0 .or. n > size(this%BoundaryFaces)) return
+    if (iflowface == 0) return
+    if (iflowface > 0) then
+      bit_pos = iflowface
+    else
+      bit_pos = 32 + iflowface ! -1: 31 (top), -2: 30 (bottom)
+    end if
+    if (bit_pos < 1 .or. bit_pos > 32) then
+      print *, 'Invalid IFLOWFACE: ', iflowface
+      call pstop(1)
+    end if
+    is_boundary = btest(this%BoundaryFaces(n), bit_pos - 1)
+  end function is_boundary_face
+
+  !> @brief Validate IFLOWFACE assignments.
+  subroutine validate_boundary_faces(this)
+    class(PrtFmiType) :: this
+    ! local
+    integer(I4B) :: n, iflowface, face_count
+    integer(I4B), parameter :: max_faces = 30
+    integer(I4B) :: assigned_faces(max_faces)
+    ! formats
+    character(len=*), parameter :: fmt_warn = &
+      "('WARNING: Cell ', i0, ' &
+      &  IFLOWFACE will be ignored: ', 20i3)"
+
+    do n = 1, this%dis%nodes
+      if (this%BoundaryFaces(n) == 0) cycle
+      face_count = 0
+      assigned_faces = 0
+      ! positive (lateral)
+      do iflowface = 1, max_faces
+        if (btest(this%BoundaryFaces(n), iflowface - 1)) then
+          face_count = face_count + 1
+          if (face_count <= max_faces) assigned_faces(face_count) = iflowface
+        end if
+      end do
+      ! negative (top/bottom)
+      if (btest(this%BoundaryFaces(n), 30)) then ! -2 -> bit 30
+        face_count = face_count + 1
+        if (face_count <= max_faces) assigned_faces(face_count) = -2
+      end if
+      if (btest(this%BoundaryFaces(n), 31)) then ! -1 -> bit 31
+        face_count = face_count + 1
+        if (face_count <= max_faces) assigned_faces(face_count) = -1
+      end if
+      ! no validation per se just warning that IFLOWFACE
+      ! is ignored if INTERNAL_BOUNDARY_METHOD is IGNORE
+      if (this%iffmeth == 1 .and. face_count > 1) then
+        write (warnmsg, fmt_warn) n, assigned_faces(1:min(face_count, 20))
+        call store_warning(trim(adjustl(warnmsg)))
+      end if
+    end do
+  end subroutine validate_boundary_faces
+
+  !> @ brief Source input options for package
+  subroutine prtfmi_options(this)
+    ! modules
+    use MemoryManagerExtModule, only: mem_set_value
+    ! dummy
+    class(PrtFmiType) :: this
+    ! local
+    logical(LGP) :: found_ipakcb, found_iffmeth
+    character(len=LENVARNAME), dimension(2) :: iff_method = &
+      &[character(len=LENVARNAME) :: 'STOP', 'IGNORE']
+    ! formats
+    character(len=*), parameter :: fmtisvflow = &
+      "(4x,'CELL-BY-CELL FLOW INFORMATION WILL BE SAVED TO BINARY FILE &
+      &WHENEVER ICBCFL IS NOT ZERO AND FLOW IMBALANCE CORRECTION ACTIVE.')"
+
+    ! source base class options
+    call this%FlowModelInterfaceType%source_options()
+
+    ! source package input
+    call mem_set_value(this%ipakcb, 'SAVE_FLOWS', this%input_mempath, &
+                       found_ipakcb)
+    call mem_set_value(this%iffmeth, 'IFFMETH', this%input_mempath, &
+                       iff_method, found_iffmeth)
+
+    write (this%iout, '(1x,a)') 'PROCESSING FMI OPTIONS'
+
+    if (found_ipakcb) then
+      this%ipakcb = -1
+      write (this%iout, fmtisvflow)
+    end if
+
+    if (found_iffmeth) then
+      if (this%iffmeth == 0) then
+        write (errmsg, '(a)') 'Unsupported internal boundary method. &
+          &INTERNAL_BOUNDARY_METHOD must be "STOP" or "IGNORE"'
+        call store_error(errmsg)
+      else
+        ! adjust for method zero indexing
+        this%iffmeth = this%iffmeth - 1
+      end if
+    end if
+
+    write (this%iout, '(1x,a)') 'END OF FMI OPTIONS'
+  end subroutine prtfmi_options
 
 end module PrtFmiModule

--- a/src/Model/ParticleTracking/prt-fmi.f90
+++ b/src/Model/ParticleTracking/prt-fmi.f90
@@ -190,9 +190,8 @@ contains
       call this%initialize_gwfterms_from_gwfbndlist()
     end if
 
-    ! Set flag that stops dry flows from being deactivated in a GWE
-    ! transport model since conduction will still be simulated.
-    ! 0: GWE (skip deactivation step); 1: GWT (default: use existing code)
+    ! Set flag that stops dry flows from being deactivated
+    ! TODO: consider if relevant to PRT
     this%idryinactive = idryinactive
 
     ! Allocate arrays
@@ -260,7 +259,7 @@ contains
           iflowface = NINT(this%gwfpackages(ip)%auxvar(iauxiflowface, ib))
           if (this%iffmeth /= 1 .and. iflowface > 0) &
             call this%mark_boundary_face(i, iflowface)
-          ! this maps bot -2 -> 9, top -1 -> 10; see note re: max faces below
+          ! maps bot -2 -> MAX_POLY_CELLS - 1, top -1 -> MAX_POLY_CELLS
           if (iflowface < 0) iflowface = iflowface + MAX_POLY_CELLS + 1
         end if
         if (this%iffmeth /= 1 .and. iflowface > 0) then

--- a/src/Solution/ParticleTracker/Method/MethodCell.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCell.f90
@@ -225,8 +225,8 @@ contains
           print *, "Back ", nhist - i + 1, ": ", prev%get_text()
         end select
       end do
-      print *, "Current :", event%get_text()
-      call pstop(1, 'Cyclic pathline detected, aborting')
+      print *, "Current           : ", event%get_text()
+      call pstop(1, 'Aborting')
     else
       call this%store_event(particle, event)
     end if

--- a/src/Solution/ParticleTracker/Method/MethodDis.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDis.f90
@@ -300,14 +300,12 @@ contains
       ! boundary face, so terminate the particle.
       ! todo AMP: reconsider when multiple models supported
       if (cell%defn%facenbr(particle%iboundary(LEVEL_FEATURE)) .eq. 0) then
-        call this%terminate(particle, &
-                            status=TERM_BOUNDARY)
+        call this%terminate(particle, status=TERM_BOUNDARY)
       else
-        ! Update old to new cell properties
+        call this%check_internal_boundary(particle, cell)
+        if (.not. particle%advancing) return
         call this%load_particle(cell, particle)
         if (.not. particle%advancing) return
-
-        ! Update intercell mass flows
         call this%update_flowja(cell, particle)
       end if
     end select

--- a/src/Solution/ParticleTracker/Method/MethodDis.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDis.f90
@@ -523,9 +523,9 @@ contains
                        this%fmi%BoundaryFlows(ioffset + 4)
     defn%faceflow(5) = defn%faceflow(1)
     defn%faceflow(6) = defn%faceflow(6) + &
-                       this%fmi%BoundaryFlows(ioffset + 9)
+                       this%fmi%BoundaryFlows(ioffset + MAX_POLY_CELLS - 1)
     defn%faceflow(7) = defn%faceflow(7) + &
-                       this%fmi%BoundaryFlows(ioffset + 10)
+                       this%fmi%BoundaryFlows(ioffset + MAX_POLY_CELLS)
   end subroutine load_boundary_flows_to_defn
 
 end module MethodDisModule

--- a/src/Solution/ParticleTracker/Method/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDisv.f90
@@ -526,7 +526,7 @@ contains
 
     ! assignment of BoundaryFlows to faceflow below assumes clockwise
     ! ordering of faces, with face 1 being the "western" face
-    ioffset = (defn%icell - 1) * 10
+    ioffset = (defn%icell - 1) * MAX_POLY_CELLS
     defn%faceflow(1) = defn%faceflow(1) + &
                        this%fmi%BoundaryFlows(ioffset + 4)
     defn%faceflow(2) = defn%faceflow(2) + &
@@ -537,9 +537,9 @@ contains
                        this%fmi%BoundaryFlows(ioffset + 1)
     defn%faceflow(5) = defn%faceflow(1)
     defn%faceflow(6) = defn%faceflow(6) + &
-                       this%fmi%BoundaryFlows(ioffset + 9)
+                       this%fmi%BoundaryFlows(ioffset + MAX_POLY_CELLS - 1)
     defn%faceflow(7) = defn%faceflow(7) + &
-                       this%fmi%BoundaryFlows(ioffset + 10)
+                       this%fmi%BoundaryFlows(ioffset + MAX_POLY_CELLS)
   end subroutine load_boundary_flows_to_defn_rect
 
   !> @brief Load boundary flows from the grid into rectangular quadcell.
@@ -560,7 +560,7 @@ contains
     real(DP) :: qbf
     integer(I4B) :: irectvert(5)
 
-    ioffset = (defn%icell - 1) * 10
+    ioffset = (defn%icell - 1) * MAX_POLY_CELLS
 
     ! Polygon faces in positions 1 through npolyverts
     do n = 1, 4
@@ -600,11 +600,11 @@ contains
     ! Bottom in position npolyverts+2
     m = m + 1
     defn%faceflow(m) = defn%faceflow(m) + &
-                       this%fmi%BoundaryFlows(ioffset + 9)
+                       this%fmi%BoundaryFlows(ioffset + MAX_POLY_CELLS - 1)
     ! Top in position npolyverts+3
     m = m + 1
     defn%faceflow(m) = defn%faceflow(m) + &
-                       this%fmi%BoundaryFlows(ioffset + 10)
+                       this%fmi%BoundaryFlows(ioffset + MAX_POLY_CELLS)
 
   end subroutine load_boundary_flows_to_defn_rect_quad
 

--- a/src/Solution/ParticleTracker/Method/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDisv.f90
@@ -240,15 +240,12 @@ contains
       ! boundary face, so terminate the particle.
       ! todo AMP: reconsider when multiple models supported
       if (cell%defn%facenbr(particle%iboundary(LEVEL_FEATURE)) .eq. 0) then
-        call this%terminate(particle, &
-                            status=TERM_BOUNDARY)
+        call this%terminate(particle, status=TERM_BOUNDARY)
       else
-        ! Otherwise, load cell properties into the
-        ! particle. It may be marked to terminate.
+        call this%check_internal_boundary(particle, cell)
+        if (.not. particle%advancing) return
         call this%load_particle(cell, particle)
         if (.not. particle%advancing) return
-
-        ! Update intercell mass flows
         call this%update_flowja(cell, particle)
       end if
     end select

--- a/src/Solution/ParticleTracker/Method/MethodModel.f90
+++ b/src/Solution/ParticleTracker/Method/MethodModel.f90
@@ -1,17 +1,21 @@
 module MethodModelModule
   use KindModule, only: DP, I4B
   use MethodModule, only: MethodType, LEVEL_MODEL
-  use ParticleModule, only: ParticleType
+  use CellModule, only: CellType
+  use ParticleModule, only: ParticleType, TERM_BOUNDARY
   use CellDefnModule, only: CellDefnType
   use ParticleEventModule, only: ParticleEventType
 
   private
   public :: MethodModelType
+  public :: iface_to_iflowface
+  public :: iflowface_to_iface
 
   type, abstract, extends(MethodType) :: MethodModelType
   contains
     procedure, public :: assess
     procedure, public :: get_level
+    procedure, public :: check_internal_boundary
   end type MethodModelType
 
 contains
@@ -32,5 +36,75 @@ contains
     integer(I4B) :: level
     level = LEVEL_MODEL
   end function get_level
+
+  !> @brief Determine whether to stop at an internal assigned boundary face.
+  !!
+  !! This subroutine implements the logic for handling particles that reach
+  !! internal boundary faces (faces assigned with IFLOWFACE). The behavior
+  !! depends on the particle's INTERNAL_BOUNDARY_METHOD setting:
+  !!
+  !! - STOP: Terminate the particle at the face (default option)
+  !! - IGNORE: Ignore boundary face assign, mimicking MODPATH 7
+  !<
+  subroutine check_internal_boundary(this, particle, cell)
+    class(MethodModelType), intent(inout) :: this
+    type(ParticleType), pointer, intent(inout) :: particle
+    class(*), intent(inout) :: cell
+    ! local
+    integer(I4B) :: iflowface
+
+    select type (cell)
+    class is (CellType)
+      iflowface = iface_to_iflowface(particle%iboundary(2), cell%defn%npolyverts)
+      if (.not. this%fmi%is_boundary_face(cell%defn%icell, iflowface)) return
+      select case (this%fmi%iffmeth)
+      case (0) ! STOP
+        call this%terminate(particle, status=TERM_BOUNDARY)
+      case default
+        ! no action needed for other methods, they are handled
+        ! by differences in FMI's accounting of boundary flows
+      end select
+    end select
+  end subroutine check_internal_boundary
+
+  !> @brief Convert IFLOWFACE value to internal face index
+  !! IFLOWFACE: 1-N = lateral faces, -1 = top, -2 = bottom
+  !! Internal: 1-N = lateral faces, N+3 = top, N+2 = bottom
+  function iflowface_to_iface(iflowface, npolyverts) result(iface)
+    integer(I4B), intent(in) :: iflowface !< IFLOWFACE value
+    integer(I4B), intent(in) :: npolyverts !< number of polygon vertices/lateral faces
+    integer(I4B) :: iface
+
+    if (iflowface == -1) then
+      iface = npolyverts + 3 ! Top face
+    else if (iflowface == -2) then
+      iface = npolyverts + 2 ! Bottom face
+    else if (iflowface >= 1 .and. iflowface <= npolyverts) then
+      iface = iflowface ! Lateral faces (direct mapping)
+    else
+      iface = 0 ! Invalid IFLOWFACE
+    end if
+
+  end function iflowface_to_iface
+
+  !> @brief Convert internal face index to IFLOWFACE value
+  !! Internal: 1-N = lateral faces, N+2 = bottom, N+3 = top
+  !! IFLOWFACE: 1-N = lateral faces, -2 = bottom, -1 = top
+  function iface_to_iflowface(iface, npolyverts) result(iflowface)
+    integer(I4B), intent(in) :: iface !< internal face index
+    integer(I4B), intent(in) :: npolyverts !< number of polygon vertices/lateral faces
+    integer(I4B) :: iflowface
+
+    if (iface == npolyverts + 2) then
+      iflowface = -2 ! Bottom face
+    else if (iface == npolyverts + 3) then
+      iflowface = -1 ! Top face
+    else if (iface >= 1 .and. iface <= npolyverts) then
+      iflowface = iface ! Lateral faces (direct mapping)
+    else
+      iflowface = 0 ! Invalid face index
+    end if
+
+  end function iface_to_iflowface
 
 end module MethodModelModule

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -1001,7 +1001,7 @@ if __name__ == "__main__":
     verbose = args.verbose
 
     if isinstance(dfn, list):
-        dfn = [Path(p) for p in dfn]
+        dfn = [Path(str(p).strip()) for p in dfn]
     elif isinstance(dfn, (str, Path)):
         dfn = [Path(dfn)]
     else:


### PR DESCRIPTION
The particle tracking method "sees" boundary cell flows but not boundary faces. When boundary faces are assigned internal to the model, i.e. an `IFLOWFACE` is adjacent to another active cell, this can lead to cycles, as the two adjacent cells do not agree on the flow through their shared face. 

MODPATH 7 avoids this by ignoring internal boundary faces, treating the cell as if they were not assigned.

Add FMI option `INTERNAL_IFLOWFACE_METHOD` determining what to do with particles in cells with an `IFLOWFACE` boundary assigned to an "internal" face (facing another active cell).

- `STOP` at internal assigned boundary face(s) after tracking through the cell, the default
- `IGNORE` internal assigned boundary face(s) like MP7 and issue a warning.

Boundary faces are stored in an integer bitmask which with 32 slots can fit 30 lateral faces, way above the current limit of 10, but the implementation may need to change if face count restriction is ever relaxed.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request