### PR TITLE
fix(prt): add termination term to balance cumulative budget

### DIFF
--- a/autotest/test_prt_budget.py
+++ b/autotest/test_prt_budget.py
@@ -1,372 +1,359 @@
 """
-Tests particle mass budget tracking with a very
-simple horizontal steady-state flow system. The
-grid is a 1x1x10 horizontal line with 10 columns.
-Particles are released from the left-most cell.
-Pathlines are compared against a MODPATH 7 model.
+Tests particle mass budget tracking.
 """
 
-from pathlib import Path
-
 import flopy
-import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
-from flopy.mf6.utils.postprocessing import get_structured_faceflows
-from flopy.utils import PathlineFile
 from flopy.utils.binaryfile import HeadFile
 from framework import TestFramework
 from prt_test_utils import (
-    HorizontalCase,
-    all_equal,
-    check_budget_data,
-    check_track_data,
     get_model_name,
-    get_partdata,
-    has_default_boundnames,
 )
 
 simname = "prtbud"
 cases = [simname]
 
+# model names
+gwf_name = get_model_name(simname, "gwf")
+gwt_name = get_model_name(simname, "gwt")
+prt_name = get_model_name(simname, "prt")
 
-def build_prt_sim(name, gwf_ws, prt_ws, mf6):
-    # create simulation
-    sim = flopy.mf6.MFSimulation(
-        sim_name=name,
-        exe_name=mf6,
-        version="mf6",
-        sim_ws=prt_ws,
-    )
+# tdis data
+years = 550.0
+year_delt = 365.25
+perlen = year_delt * years
+nstp = 10
+tsmult = 1.0
+tdis_spd = [[perlen, nstp, tsmult]]
+nper = len(tdis_spd)
 
-    # create tdis package
-    flopy.mf6.modflow.mftdis.ModflowTdis(
+# grid data
+nlay, nrow, ncol = 5, 101, 101
+delr, delc = 100.0, 100.0
+top = 1.0
+botm = np.linspace(-10, -100, nlay)
+
+# gwf chd data
+chd_spd = [[(0, i, 0), 1.0, 6, -1] for i in range(nrow)]
+chd_spd += [[(0, i, ncol - 1), 0.0, 6, -1] for i in range(nrow)]
+
+# gwf maw data
+maw_spd = [((2, 50, 50), -5000.0, 0, 0), ((4, 50, 50), -5000.0, 0, 0)]
+
+# gwf output file names
+gwf_budget_file = f"{gwf_name}.bud"
+gwf_head_file = f"{gwf_name}.hds"
+
+# gwt src data
+gwt_srcs = []
+for k in [0, 1, 2, 3]:  # range(nlay):
+    gwt_srcs += [(k, i, 1) for i in range(nrow)]
+src_rate = 4.9779105e-4
+src_spd = []
+for cid in gwt_srcs:
+    src_spd.append([cid, "SRCRATE"])
+src_spd = {0: src_spd}
+src_tsdata = [
+    (0.0, src_rate),
+    (perlen / 100.0, 0.0),
+    (perlen, 0.0),
+]
+
+# prt prp data
+prt_nodes = []
+for k in [0, 1, 2, 3]:
+    prt_nodes += [(k, i, 1) for i in range(nrow)]
+particle_data = flopy.modpath.ParticleData(
+    prt_nodes,
+    drape=0,
+    structured=True,
+)
+
+# prt mip data
+izone = np.zeros((nlay, nrow, ncol), dtype=int)
+well_zone = (1, 2)
+for idx, k in enumerate((2, 4)):
+    izone[k, 50, 50] = well_zone[idx]
+
+# prt oc data
+tracktimes = list(range(0, 72000, 1000))
+
+# prt output file names
+prt_listfile = f"{prt_name}.lst"
+prt_budgetfile = f"{prt_name}.cbb"
+prt_trackfile = f"{prt_name}.trk"
+prt_trackcsvfile = f"{prt_name}.trk.csv"
+
+
+def build_gwf_sim(gwf_ws, mf6):
+    sim = flopy.mf6.MFSimulation(sim_name=gwf_name, sim_ws=gwf_ws, exe_name=mf6)
+    tdis = flopy.mf6.ModflowTdis(sim, nper=1, perioddata=tdis_spd)
+    ims = flopy.mf6.ModflowIms(sim, linear_acceleration="bicgstab", complexity="simple")
+    gwf = flopy.mf6.ModflowGwf(
         sim,
-        pname="tdis",
-        time_units="DAYS",
-        nper=HorizontalCase.nper,
-        perioddata=[
-            (HorizontalCase.perlen, HorizontalCase.nstp, HorizontalCase.tsmult)
+        modelname=gwf_name,
+        save_flows=True,
+        newtonoptions="newton under_relaxation",
+    )
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf, nlay=nlay, nrow=nrow, ncol=ncol, delr=100, delc=100, top=top, botm=botm
+    )
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf, icelltype=1, save_specific_discharge=True, save_saturation=True, k=100.0
+    )
+    sto = flopy.mf6.ModflowGwfsto(
+        gwf, iconvert=1, steady_state={0: False}, transient={0: True}
+    )
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=0.0)
+    chd = flopy.mf6.ModflowGwfchd(
+        gwf,
+        auxiliary=["iface", "iflowface"],
+        maxbound=len(chd_spd),
+        stress_period_data=chd_spd,
+        pname="chd",
+    )
+    maw = flopy.mf6.ModflowGwfwel(
+        gwf,
+        auxiliary=["iface", "iflowface"],
+        maxbound=len(maw_spd),
+        stress_period_data=maw_spd,
+    )
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=gwf_head_file,
+        budget_filerecord=gwf_budget_file,
+        printrecord=[("budget", "all")],
+        saverecord=[("head", "all"), ("budget", "all")],
+    )
+    return sim
+
+
+def build_gwt_sim(gwf_ws, gwt_ws, mf6):
+    sim = flopy.mf6.MFSimulation(sim_name=gwt_name, sim_ws=gwt_ws, exe_name=mf6)
+    tdis = flopy.mf6.modflow.mftdis.ModflowTdis(sim, nper=nper, perioddata=tdis_spd)
+    gwt = flopy.mf6.ModflowGwt(sim, modelname=gwt_name, print_input=True)
+    dis = flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
+        gwt,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+    ic = flopy.mf6.ModflowGwtic(gwt, strt=0)
+    mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="TVD")
+    dsp = flopy.mf6.ModflowGwtdsp(
+        gwt,
+        xt3d_off=True,
+        alh=250.0,
+        ath1=25.0,
+        ath2=25.0,
+    )
+    ssm = flopy.mf6.ModflowGwtssm(gwt)
+    src = flopy.mf6.ModflowGwtsrc(
+        gwt,
+        stress_period_data=src_spd,
+        timeseries={
+            "timeseries": src_tsdata,
+            "time_series_namerecord": "SRCRATE",
+            "interpolation_methodrecord": "STEPWISE",
+        },
+    )
+    oc = flopy.mf6.ModflowGwtoc(
+        gwt,
+        budget_filerecord=f"{gwt_name}.cbb",
+        concentration_filerecord=f"{gwt_name}.ucn",
+        saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
+        printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "ALL")],
+    )
+    fmi = flopy.mf6.ModflowGwtfmi(
+        gwt,
+        packagedata=[
+            ("GWFHEAD", gwf_ws / gwf_head_file),
+            ("GWFBUDGET", gwf_ws / gwf_budget_file),
         ],
     )
-
-    # create prt model
-    prt_name = get_model_name(name, "prt")
-    prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name, save_flows=True)
-
-    # create prt discretization
-    flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
-        prt,
-        pname="dis",
-        nlay=HorizontalCase.nlay,
-        nrow=HorizontalCase.nrow,
-        ncol=HorizontalCase.ncol,
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        pname="ims",
+        filename=f"{gwt_name}.ims",
+        print_option="summary",
+        inner_maximum=300,
+        linear_acceleration="bicgstab",
+        inner_dvclose=1e-9,
     )
+    sim.register_solution_package(ims, [gwt.name])
+    return sim
 
-    # create mip package
-    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=HorizontalCase.porosity)
 
-    # convert mp7 to prt release points and check against expectation
-    partdata = get_partdata(prt.modelgrid, HorizontalCase.releasepts_mp7)
-    coords = partdata.to_coords(prt.modelgrid)
-    releasepts = [(i, 0, 0, 0, c[0], c[1], c[2]) for i, c in enumerate(coords)]
-
-    # create prp package
-    prp_track_file = f"{prt_name}.prp.trk"
-    prp_track_csv_file = f"{prt_name}.prp.trk.csv"
-    flopy.mf6.ModflowPrtprp(
+def build_prt_sim(gwf_ws, prt_ws, mf6):
+    sim = flopy.mf6.MFSimulation(sim_name=prt_name, sim_ws=prt_ws, exe_name=mf6)
+    tdis = flopy.mf6.modflow.mftdis.ModflowTdis(sim, nper=nper, perioddata=tdis_spd)
+    prt = flopy.mf6.ModflowPrt(
+        sim, modelname=prt_name, print_input=True, save_flows=True
+    )
+    dis = flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
         prt,
-        pname="prp1",
-        filename=f"{prt_name}_1.prp",
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+    mip = flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=0.1, izone=izone)
+    releasepts = list(particle_data.to_prp(prt.modelgrid))
+    prp = flopy.mf6.ModflowPrtprp(
+        prt,
         nreleasepts=len(releasepts),
         packagedata=releasepts,
         perioddata={0: ["FIRST"]},
-        track_filerecord=[prp_track_file],
-        trackcsv_filerecord=[prp_track_csv_file],
-        stop_at_weak_sink=False,
-        boundnames=True,
-        extend_tracking=True,
+        exit_solve_tolerance=1e-5,
+        extend_tracking=False,
+        print_input=True,
     )
-
-    # create output control package
-    prt_budget_file = f"{prt_name}.bud"
-    prt_track_file = f"{prt_name}.trk"
-    prt_track_csv_file = f"{prt_name}.trk.csv"
-    flopy.mf6.ModflowPrtoc(
+    oc = flopy.mf6.ModflowPrtoc(
         prt,
-        pname="oc",
-        budget_filerecord=[prt_budget_file],
-        track_filerecord=[prt_track_file],
-        trackcsv_filerecord=[prt_track_csv_file],
+        budget_filerecord=[prt_budgetfile],
+        track_filerecord=[prt_trackfile],
+        trackcsv_filerecord=[prt_trackcsvfile],
+        ntracktimes=len(tracktimes),
+        tracktimes=[(t,) for t in tracktimes],
+        printrecord=[("BUDGET", "ALL")],
         saverecord=[("BUDGET", "ALL")],
     )
-
-    # create the flow model interface
-    gwf_name = get_model_name(name, "gwf")
-    gwf_budget_file = gwf_ws / f"{gwf_name}.bud"
-    gwf_head_file = gwf_ws / f"{gwf_name}.hds"
-    flopy.mf6.ModflowPrtfmi(
+    fmi = flopy.mf6.ModflowPrtfmi(
         prt,
         packagedata=[
-            ("GWFHEAD", gwf_head_file),
-            ("GWFBUDGET", gwf_budget_file),
+            ("GWFHEAD", gwf_ws / gwf_head_file),
+            ("GWFBUDGET", gwf_ws / gwf_budget_file),
         ],
     )
-
-    # add explicit model solution
     ems = flopy.mf6.ModflowEms(
         sim,
         pname="ems",
         filename=f"{prt_name}.ems",
     )
     sim.register_solution_package(ems, [prt.name])
-
     return sim
 
 
-def build_mp7_sim(name, ws, mp7, gwf):
-    partdata = get_partdata(gwf.modelgrid, HorizontalCase.releasepts_mp7)
-    mp7_name = get_model_name(name, "mp7")
-    pg = flopy.modpath.ParticleGroup(
-        particlegroupname="G1",
-        particledata=partdata,
-        filename=f"{mp7_name}.sloc",
-    )
-    mp = flopy.modpath.Modpath7(
-        modelname=mp7_name,
-        flowmodel=gwf,
-        exe_name=mp7,
-        model_ws=ws,
-        headfilename=f"{gwf.name}.hds",
-        budgetfilename=f"{gwf.name}.bud",
-    )
-    mpbas = flopy.modpath.Modpath7Bas(
-        mp,
-        porosity=HorizontalCase.porosity,
-    )
-    mpsim = flopy.modpath.Modpath7Sim(
-        mp,
-        simulationtype="pathline",
-        trackingdirection="forward",
-        budgetoutputoption="summary",
-        stoptimeoption="extend",
-        particlegroups=[pg],
-    )
-
-    return mp
-
-
 def build_models(idx, test):
-    gwf_sim = HorizontalCase.get_gwf_sim(test.name, test.workspace, test.targets["mf6"])
+    gwf_sim = build_gwf_sim(test.workspace / "gwf", test.targets["mf6"])
+    gwt_sim = build_gwt_sim(
+        test.workspace / "gwf", test.workspace / "gwt", test.targets["mf6"]
+    )
     prt_sim = build_prt_sim(
-        test.name, test.workspace, test.workspace / "prt", test.targets["mf6"]
+        test.workspace / "gwf", test.workspace / "prt", test.targets["mf6"]
     )
-    mp7_sim = build_mp7_sim(
-        test.name,
-        test.workspace / "mp7",
-        test.targets["mp7"],
-        gwf_sim.get_model(),
-    )
-    return gwf_sim, prt_sim, mp7_sim
+    return gwf_sim, gwt_sim, prt_sim
 
 
 def check_output(idx, test):
-    from flopy.plot.plotutil import to_mp7_pathlines
-
-    name = test.name
-    gwf_ws = test.workspace
-    prt_ws = test.workspace / "prt"
-    mp7_ws = test.workspace / "mp7"
-    gwf_name = get_model_name(name, "gwf")
-    prt_name = get_model_name(name, "prt")
-    mp7_name = get_model_name(name, "mp7")
     gwf_sim = test.sims[0]
+    gwt_sim = test.sims[1]
+    prt_sim = test.sims[2]
+    gwf_ws = test.workspace / "gwf"
+    gwt_ws = test.workspace / "gwt"
+    prt_ws = test.workspace / "prt"
     gwf = gwf_sim.get_model(gwf_name)
-    mg = gwf.modelgrid
+    gwt = gwt_sim.get_model(gwt_name)
+    prt = prt_sim.get_model(prt_name)
+    grid = gwf.modelgrid
 
-    # check mf6 output files exist
-    gwf_budget_file = f"{gwf_name}.bud"
-    gwf_head_file = f"{gwf_name}.hds"
-    prt_track_file = f"{prt_name}.trk"
-    prt_track_csv_file = f"{prt_name}.trk.csv"
-    prp_track_file = f"{prt_name}.prp.trk"
-    prp_track_csv_file = f"{prt_name}.prp.trk.csv"
-    mp7_pathline_file = f"{mp7_name}.mppth"
-
-    # load mf6 pathline results
-    mf6_pls = pd.read_csv(prt_ws / prt_track_csv_file, na_filter=False)
-
-    # load mp7 pathline results
-    plf = PathlineFile(mp7_ws / mp7_pathline_file)
-    mp7_pls = pd.DataFrame(
-        plf.get_destination_pathline_data(range(mg.nnodes), to_recarray=True)
+    # check cumulative budget from list file
+    prt_lst = flopy.utils.Mf6ListBudget(
+        prt_ws / prt_listfile, budgetkey="MASS BUDGET FOR ENTIRE MODEL"
     )
-    # convert zero-based to one-based indexing in mp7 results
-    mp7_pls["particlegroup"] = mp7_pls["particlegroup"] + 1
-    mp7_pls["node"] = mp7_pls["node"] + 1
-    mp7_pls["k"] = mp7_pls["k"] + 1
-
-    # extract head, budget, and specific discharge results from GWF model
-    hds = HeadFile(gwf_ws / gwf_head_file).get_data()
-    bud = gwf.output.budget()
-    spdis = bud.get_data(text="DATA-SPDIS")[0]
-    qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(spdis, gwf)
-
-    assert (gwf_ws / gwf_budget_file).is_file()
-    assert (gwf_ws / gwf_head_file).is_file()
-    assert (prt_ws / prt_track_file).is_file()
-    assert (prt_ws / prt_track_csv_file).is_file()
-    assert (prt_ws / prp_track_file).is_file()
-    assert (prt_ws / prp_track_csv_file).is_file()
-
-    # check mp7 output files exist
-    assert (mp7_ws / mp7_pathline_file).is_file()
-
-    # make sure pathline df has "name" (boundname) column and default values
-    assert "name" in mf6_pls
-    assert has_default_boundnames(mf6_pls)
-
-    # make sure all mf6 pathline data have correct model and PRP index (1)
-    assert all_equal(mf6_pls["imdl"], 1)
-    assert all_equal(mf6_pls["iprp"], 1)
-
-    # check budget data were written to mf6 prt list file
-    check_budget_data(
-        prt_ws / f"{name}_prt.lst", HorizontalCase.perlen, HorizontalCase.nper
+    for key in [
+        "STORAGE_IN",
+        "PRP_IN",
+        "TERMINATION_IN",
+        "STORAGE_OUT",
+        "PRP_OUT",
+        "TERMINATION_OUT",
+    ]:
+        assert key in prt_lst.get_record_names()
+    prt_bud_cum = prt_lst.get_data()
+    prp_in = next(
+        iter([term[1] for term in prt_bud_cum if term[2].decode() == "PRP_IN"])
     )
-
-    # check cell-by-cell particle mass flows
-    prt_budget_file = prt_ws / f"{prt_name}.bud"
-    prt_bud = flopy.utils.CellBudgetFile(prt_budget_file, precision="double")
-    prt_bud_data = prt_bud.get_data(kstpkper=(0, 0))
-    assert len(prt_bud_data) == 2
-    flowja = prt_bud.get_data(text="FLOW-JA-FACE")[0][0, 0, :]
-    prp = prt_bud.get_data(text="PRP")[0].squeeze()
-    assert flowja.shape == (28,)
-    assert prp.shape == (9,)
-    frf, fff, flf = get_structured_faceflows(
-        flowja,
-        grb_file=gwf_ws / f"{gwf_name}.dis.grb",
-        verbose=True,
+    prp_out = next(
+        iter([term[1] for term in prt_bud_cum if term[2].decode() == "PRP_OUT"])
     )
-    assert not fff.any()
-    assert not flf.any()
-    assert frf.any()
-    assert all(v == 9 for v in frf[:-1])
-
-    # check mf6 prt particle track data were written to binary/CSV files
-    # and that different formats are equal
-    for track_csv in [prt_ws / prt_track_csv_file, prt_ws / prp_track_csv_file]:
-        check_track_data(
-            track_bin=prt_ws / prt_track_file,
-            track_hdr=prt_ws / Path(prt_track_file.replace(".trk", ".trk.hdr")),
-            track_csv=track_csv,
+    term_in = next(
+        iter([term[1] for term in prt_bud_cum if term[2].decode() == "TERMINATION_IN"])
+    )
+    term_out = next(
+        iter([term[1] for term in prt_bud_cum if term[2].decode() == "TERMINATION_OUT"])
+    )
+    pct_dscr = next(
+        iter(
+            [
+                term[1]
+                for term in prt_bud_cum
+                if term[2].decode() == "PERCENT_DISCREPANCY"
+            ]
         )
+    )
+    assert np.isclose(prp_out, 0.0)
+    assert np.isclose(term_in, 0.0)
+    assert np.isclose(pct_dscr, 0.0)
+    assert np.isclose(prp_in + term_out, 0.0)
 
-    # convert mf6 pathlines to mp7 format
-    mf6_pls = to_mp7_pathlines(mf6_pls)
+    # check cell by cell budget from binary budget file
+    prt_pls = pd.read_csv(prt_ws / prt_trackcsvfile, na_filter=False)
+    prt_bud = flopy.utils.CellBudgetFile(prt_ws / prt_budgetfile, precision="double")
+    prp_bud = prt_bud.get_data(text="PRP")
+    assert len(prp_bud) == nstp
+    assert len(prp_bud[0]["q"]) == prt_pls.irpt.unique().size
+    # expect positive mass flow on release in first time step
+    assert np.all(prp_bud[0]["q"] > 0)
+    # and none in all subsequent steps
+    for i in range(1, nstp):
+        assert np.all(prp_bud[i]["q"] == 0)
 
-    # sort both dataframes by particleid and time
-    mf6_pls.sort_values(by=["particleid", "time"], inplace=True)
-    mp7_pls.sort_values(by=["particleid", "time"], inplace=True)
-
-    # drop columns for which there is no direct correspondence between mf6 and mp7
-    del mf6_pls["sequencenumber"]
-    del mf6_pls["particleidloc"]
-    del mf6_pls["xloc"]
-    del mf6_pls["yloc"]
-    del mf6_pls["zloc"]
-    del mp7_pls["sequencenumber"]
-    del mp7_pls["particleidloc"]
-    del mp7_pls["xloc"]
-    del mp7_pls["yloc"]
-    del mp7_pls["zloc"]
-
-    # compare mf6 / mp7 pathline data
-    assert mf6_pls.shape == mp7_pls.shape
-    assert np.allclose(mf6_pls, mp7_pls, atol=1e-3)
+    # TODO check storage and termination terms once added to binary budget file
 
 
 def plot_output(idx, test):
-    name = test.name
-    gwf_ws = test.workspace
-    prt_ws = test.workspace / "prt"
-    mp7_ws = test.workspace / "mp7"
-    gwf_name = get_model_name(name, "gwf")
-    prt_name = get_model_name(name, "prt")
-    mp7_name = get_model_name(name, "mp7")
     gwf_sim = test.sims[0]
+    gwt_sim = test.sims[1]
+    prt_sim = test.sims[2]
+    gwf_ws = test.workspace / "gwf"
+    gwt_ws = test.workspace / "gwt"
+    prt_ws = test.workspace / "prt"
     gwf = gwf_sim.get_model(gwf_name)
-    mg = gwf.modelgrid
+    gwt = gwt_sim.get_model(gwt_name)
+    prt = prt_sim.get_model(prt_name)
+    grid = gwf.modelgrid
 
-    # check mf6 output files exist
-    gwf_head_file = f"{gwf_name}.hds"
-    prt_track_csv_file = f"{prt_name}.trk.csv"
-    mp7_pathline_file = f"{mp7_name}.mppth"
-
-    # load mf6 pathline results
-    mf6_pls = pd.read_csv(prt_ws / prt_track_csv_file, na_filter=False)
-
-    # load mp7 pathline results
-    plf = PathlineFile(mp7_ws / mp7_pathline_file)
-    mp7_pls = pd.DataFrame(
-        plf.get_destination_pathline_data(range(mg.nnodes), to_recarray=True)
-    )
-    # convert zero-based to one-based indexing in mp7 results
-    mp7_pls["particlegroup"] = mp7_pls["particlegroup"] + 1
-    mp7_pls["node"] = mp7_pls["node"] + 1
-    mp7_pls["k"] = mp7_pls["k"] + 1
-
-    # extract head, budget, and specific discharge results from GWF model
+    # get head, budget, and spdis from GWF model
     hds = HeadFile(gwf_ws / gwf_head_file).get_data()
     bud = gwf.output.budget()
     spdis = bud.get_data(text="DATA-SPDIS")[0]
     qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(spdis, gwf)
 
-    # set up plot
-    fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(10, 10))
-    for a in ax:
-        a.set_aspect("equal")
-
-    # plot mf6 pathlines in map view
-    pmv = flopy.plot.PlotMapView(modelgrid=mg, ax=ax[0])
-    pmv.plot_grid()
-    pmv.plot_array(hds[0], alpha=0.1)
-    pmv.plot_vector(qx, qy, normalize=True, color="white")
-    mf6_plines = mf6_pls.groupby(["iprp", "irpt", "trelease"])
-    for ipl, ((iprp, irpt, trelease), pl) in enumerate(mf6_plines):
-        pl.plot(
-            title="MF6 pathlines",
-            kind="line",
-            x="x",
-            y="y",
-            ax=ax[0],
-            legend=False,
-            color=cm.plasma(ipl / len(mf6_plines)),
-        )
-
-    # plot mp7 pathlines in map view
-    pmv = flopy.plot.PlotMapView(modelgrid=mg, ax=ax[1])
-    pmv.plot_grid()
-    pmv.plot_array(hds[0], alpha=0.1)
-    pmv.plot_vector(qx, qy, normalize=True, color="white")
-    mp7_plines = mp7_pls.groupby(["particleid"])
-    for ipl, (pid, pl) in enumerate(mp7_plines):
-        pl.plot(
-            title="MP7 pathlines",
-            kind="line",
-            x="x",
-            y="y",
-            ax=ax[1],
-            legend=False,
-            color=cm.plasma(ipl / len(mp7_plines)),
-        )
-
-    # view/save plot
+    # get concentration from GWT model
+    cobj = gwt.output.concentration()
+    conc = cobj.get_alldata()
+    pl = flopy.plot.PlotMapView(model=gwf)
+    pl.ax.set_title("Concentration")
+    pl.plot_grid(lw=0.5, alpha=0.5)
+    pl.plot_array(hds[0], alpha=0.1)
+    pl.contour_array(
+        conc[99, 0],
+        colors="blue",
+        linestyles="-",
+    )
     plt.show()
-    plt.savefig(prt_ws / f"test_{simname}.png")
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_prt_faceflows.py
+++ b/autotest/test_prt_faceflows.py
@@ -1,0 +1,383 @@
+"""
+Test mass flows between adjacent cell faces in a
+simple horizontal steady-state flow system. The
+grid is a 1x1x10 horizontal line with 10 columns.
+Particles are released from the left-most cell.
+Pathlines are compared against a MODPATH 7 model.
+"""
+
+from pathlib import Path
+
+import flopy
+import matplotlib.cm as cm
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from flopy.mf6.utils.postprocessing import get_structured_faceflows
+from flopy.utils import PathlineFile
+from flopy.utils.binaryfile import HeadFile
+from framework import TestFramework
+from prt_test_utils import (
+    HorizontalCase,
+    all_equal,
+    check_budget_data,
+    check_track_data,
+    get_model_name,
+    get_partdata,
+    has_default_boundnames,
+)
+
+simname = "prtffs"
+cases = [simname]
+
+
+def build_prt_sim(name, gwf_ws, prt_ws, mf6):
+    # create simulation
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name,
+        exe_name=mf6,
+        version="mf6",
+        sim_ws=prt_ws,
+    )
+
+    # create tdis package
+    flopy.mf6.modflow.mftdis.ModflowTdis(
+        sim,
+        pname="tdis",
+        time_units="DAYS",
+        nper=HorizontalCase.nper,
+        perioddata=[
+            (HorizontalCase.perlen, HorizontalCase.nstp, HorizontalCase.tsmult)
+        ],
+    )
+
+    # create prt model
+    prt_name = get_model_name(name, "prt")
+    prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name, save_flows=True)
+
+    # create prt discretization
+    flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
+        prt,
+        pname="dis",
+        nlay=HorizontalCase.nlay,
+        nrow=HorizontalCase.nrow,
+        ncol=HorizontalCase.ncol,
+    )
+
+    # create mip package
+    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=HorizontalCase.porosity)
+
+    # convert mp7 to prt release points and check against expectation
+    partdata = get_partdata(prt.modelgrid, HorizontalCase.releasepts_mp7)
+    coords = partdata.to_coords(prt.modelgrid)
+    releasepts = [(i, 0, 0, 0, c[0], c[1], c[2]) for i, c in enumerate(coords)]
+
+    # create prp package
+    prp_track_file = f"{prt_name}.prp.trk"
+    prp_track_csv_file = f"{prt_name}.prp.trk.csv"
+    flopy.mf6.ModflowPrtprp(
+        prt,
+        pname="prp1",
+        filename=f"{prt_name}_1.prp",
+        nreleasepts=len(releasepts),
+        packagedata=releasepts,
+        perioddata={0: ["FIRST"]},
+        track_filerecord=[prp_track_file],
+        trackcsv_filerecord=[prp_track_csv_file],
+        stop_at_weak_sink=False,
+        boundnames=True,
+        extend_tracking=True,
+    )
+
+    # create output control package
+    prt_budget_file = f"{prt_name}.bud"
+    prt_track_file = f"{prt_name}.trk"
+    prt_track_csv_file = f"{prt_name}.trk.csv"
+    flopy.mf6.ModflowPrtoc(
+        prt,
+        pname="oc",
+        budget_filerecord=[prt_budget_file],
+        track_filerecord=[prt_track_file],
+        trackcsv_filerecord=[prt_track_csv_file],
+        saverecord=[("BUDGET", "ALL")],
+    )
+
+    # create the flow model interface
+    gwf_name = get_model_name(name, "gwf")
+    gwf_budget_file = gwf_ws / f"{gwf_name}.bud"
+    gwf_head_file = gwf_ws / f"{gwf_name}.hds"
+    flopy.mf6.ModflowPrtfmi(
+        prt,
+        packagedata=[
+            ("GWFHEAD", gwf_head_file),
+            ("GWFBUDGET", gwf_budget_file),
+        ],
+    )
+
+    # add explicit model solution
+    ems = flopy.mf6.ModflowEms(
+        sim,
+        pname="ems",
+        filename=f"{prt_name}.ems",
+    )
+    sim.register_solution_package(ems, [prt.name])
+
+    return sim
+
+
+def build_mp7_sim(name, ws, mp7, gwf):
+    partdata = get_partdata(gwf.modelgrid, HorizontalCase.releasepts_mp7)
+    mp7_name = get_model_name(name, "mp7")
+    pg = flopy.modpath.ParticleGroup(
+        particlegroupname="G1",
+        particledata=partdata,
+        filename=f"{mp7_name}.sloc",
+    )
+    mp = flopy.modpath.Modpath7(
+        modelname=mp7_name,
+        flowmodel=gwf,
+        exe_name=mp7,
+        model_ws=ws,
+        headfilename=f"{gwf.name}.hds",
+        budgetfilename=f"{gwf.name}.bud",
+    )
+    mpbas = flopy.modpath.Modpath7Bas(
+        mp,
+        porosity=HorizontalCase.porosity,
+    )
+    mpsim = flopy.modpath.Modpath7Sim(
+        mp,
+        simulationtype="pathline",
+        trackingdirection="forward",
+        budgetoutputoption="summary",
+        stoptimeoption="extend",
+        particlegroups=[pg],
+    )
+
+    return mp
+
+
+def build_models(idx, test):
+    gwf_sim = HorizontalCase.get_gwf_sim(test.name, test.workspace, test.targets["mf6"])
+    prt_sim = build_prt_sim(
+        test.name, test.workspace, test.workspace / "prt", test.targets["mf6"]
+    )
+    mp7_sim = build_mp7_sim(
+        test.name,
+        test.workspace / "mp7",
+        test.targets["mp7"],
+        gwf_sim.get_model(),
+    )
+    return gwf_sim, prt_sim, mp7_sim
+
+
+def check_output(idx, test):
+    from flopy.plot.plotutil import to_mp7_pathlines
+
+    name = test.name
+    gwf_ws = test.workspace
+    prt_ws = test.workspace / "prt"
+    mp7_ws = test.workspace / "mp7"
+    gwf_name = get_model_name(name, "gwf")
+    prt_name = get_model_name(name, "prt")
+    mp7_name = get_model_name(name, "mp7")
+    gwf_sim = test.sims[0]
+    gwf = gwf_sim.get_model(gwf_name)
+    mg = gwf.modelgrid
+
+    # check mf6 output files exist
+    gwf_budget_file = f"{gwf_name}.bud"
+    gwf_head_file = f"{gwf_name}.hds"
+    prt_track_file = f"{prt_name}.trk"
+    prt_track_csv_file = f"{prt_name}.trk.csv"
+    prp_track_file = f"{prt_name}.prp.trk"
+    prp_track_csv_file = f"{prt_name}.prp.trk.csv"
+    mp7_pathline_file = f"{mp7_name}.mppth"
+
+    # load mf6 pathline results
+    mf6_pls = pd.read_csv(prt_ws / prt_track_csv_file, na_filter=False)
+
+    # load mp7 pathline results
+    plf = PathlineFile(mp7_ws / mp7_pathline_file)
+    mp7_pls = pd.DataFrame(
+        plf.get_destination_pathline_data(range(mg.nnodes), to_recarray=True)
+    )
+    # convert zero-based to one-based indexing in mp7 results
+    mp7_pls["particlegroup"] = mp7_pls["particlegroup"] + 1
+    mp7_pls["node"] = mp7_pls["node"] + 1
+    mp7_pls["k"] = mp7_pls["k"] + 1
+
+    # extract head, budget, and specific discharge results from GWF model
+    hds = HeadFile(gwf_ws / gwf_head_file).get_data()
+    bud = gwf.output.budget()
+    spdis = bud.get_data(text="DATA-SPDIS")[0]
+    qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(spdis, gwf)
+
+    assert (gwf_ws / gwf_budget_file).is_file()
+    assert (gwf_ws / gwf_head_file).is_file()
+    assert (prt_ws / prt_track_file).is_file()
+    assert (prt_ws / prt_track_csv_file).is_file()
+    assert (prt_ws / prp_track_file).is_file()
+    assert (prt_ws / prp_track_csv_file).is_file()
+
+    # check mp7 output files exist
+    assert (mp7_ws / mp7_pathline_file).is_file()
+
+    # make sure pathline df has "name" (boundname) column and default values
+    assert "name" in mf6_pls
+    assert has_default_boundnames(mf6_pls)
+
+    # make sure all mf6 pathline data have correct model and PRP index (1)
+    assert all_equal(mf6_pls["imdl"], 1)
+    assert all_equal(mf6_pls["iprp"], 1)
+
+    # check budget data were written to mf6 prt list file
+    check_budget_data(
+        prt_ws / f"{name}_prt.lst", HorizontalCase.perlen, HorizontalCase.nper
+    )
+
+    # check cell-by-cell particle mass flows
+    prt_budget_file = prt_ws / f"{prt_name}.bud"
+    prt_bud = flopy.utils.CellBudgetFile(prt_budget_file, precision="double")
+    prt_bud_data = prt_bud.get_data(kstpkper=(0, 0))
+    assert len(prt_bud_data) == 2
+    flowja = prt_bud.get_data(text="FLOW-JA-FACE")[0][0, 0, :]
+    prp = prt_bud.get_data(text="PRP")[0].squeeze()
+    assert flowja.shape == (28,)
+    assert prp.shape == (9,)
+    frf, fff, flf = get_structured_faceflows(
+        flowja,
+        grb_file=gwf_ws / f"{gwf_name}.dis.grb",
+        verbose=True,
+    )
+    assert not fff.any()
+    assert not flf.any()
+    assert frf.any()
+    assert all(v == 9 for v in frf[:-1])
+
+    # check mf6 prt particle track data were written to binary/CSV files
+    # and that different formats are equal
+    for track_csv in [prt_ws / prt_track_csv_file, prt_ws / prp_track_csv_file]:
+        check_track_data(
+            track_bin=prt_ws / prt_track_file,
+            track_hdr=prt_ws / Path(prt_track_file.replace(".trk", ".trk.hdr")),
+            track_csv=track_csv,
+        )
+
+    # convert mf6 pathlines to mp7 format
+    mf6_pls = to_mp7_pathlines(mf6_pls)
+
+    # sort both dataframes by particleid and time
+    mf6_pls.sort_values(by=["particleid", "time"], inplace=True)
+    mp7_pls.sort_values(by=["particleid", "time"], inplace=True)
+
+    # drop columns for which there is no direct correspondence between mf6 and mp7
+    del mf6_pls["sequencenumber"]
+    del mf6_pls["particleidloc"]
+    del mf6_pls["xloc"]
+    del mf6_pls["yloc"]
+    del mf6_pls["zloc"]
+    del mp7_pls["sequencenumber"]
+    del mp7_pls["particleidloc"]
+    del mp7_pls["xloc"]
+    del mp7_pls["yloc"]
+    del mp7_pls["zloc"]
+
+    # compare mf6 / mp7 pathline data
+    assert mf6_pls.shape == mp7_pls.shape
+    assert np.allclose(mf6_pls, mp7_pls, atol=1e-3)
+
+
+def plot_output(idx, test):
+    name = test.name
+    gwf_ws = test.workspace
+    prt_ws = test.workspace / "prt"
+    mp7_ws = test.workspace / "mp7"
+    gwf_name = get_model_name(name, "gwf")
+    prt_name = get_model_name(name, "prt")
+    mp7_name = get_model_name(name, "mp7")
+    gwf_sim = test.sims[0]
+    gwf = gwf_sim.get_model(gwf_name)
+    mg = gwf.modelgrid
+
+    # check mf6 output files exist
+    gwf_head_file = f"{gwf_name}.hds"
+    prt_track_csv_file = f"{prt_name}.trk.csv"
+    mp7_pathline_file = f"{mp7_name}.mppth"
+
+    # load mf6 pathline results
+    mf6_pls = pd.read_csv(prt_ws / prt_track_csv_file, na_filter=False)
+
+    # load mp7 pathline results
+    plf = PathlineFile(mp7_ws / mp7_pathline_file)
+    mp7_pls = pd.DataFrame(
+        plf.get_destination_pathline_data(range(mg.nnodes), to_recarray=True)
+    )
+    # convert zero-based to one-based indexing in mp7 results
+    mp7_pls["particlegroup"] = mp7_pls["particlegroup"] + 1
+    mp7_pls["node"] = mp7_pls["node"] + 1
+    mp7_pls["k"] = mp7_pls["k"] + 1
+
+    # extract head, budget, and specific discharge results from GWF model
+    hds = HeadFile(gwf_ws / gwf_head_file).get_data()
+    bud = gwf.output.budget()
+    spdis = bud.get_data(text="DATA-SPDIS")[0]
+    qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(spdis, gwf)
+
+    # set up plot
+    fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(10, 10))
+    for a in ax:
+        a.set_aspect("equal")
+
+    # plot mf6 pathlines in map view
+    pmv = flopy.plot.PlotMapView(modelgrid=mg, ax=ax[0])
+    pmv.plot_grid()
+    pmv.plot_array(hds[0], alpha=0.1)
+    pmv.plot_vector(qx, qy, normalize=True, color="white")
+    mf6_plines = mf6_pls.groupby(["iprp", "irpt", "trelease"])
+    for ipl, ((iprp, irpt, trelease), pl) in enumerate(mf6_plines):
+        pl.plot(
+            title="MF6 pathlines",
+            kind="line",
+            x="x",
+            y="y",
+            ax=ax[0],
+            legend=False,
+            color=cm.plasma(ipl / len(mf6_plines)),
+        )
+
+    # plot mp7 pathlines in map view
+    pmv = flopy.plot.PlotMapView(modelgrid=mg, ax=ax[1])
+    pmv.plot_grid()
+    pmv.plot_array(hds[0], alpha=0.1)
+    pmv.plot_vector(qx, qy, normalize=True, color="white")
+    mp7_plines = mp7_pls.groupby(["particleid"])
+    for ipl, (pid, pl) in enumerate(mp7_plines):
+        pl.plot(
+            title="MP7 pathlines",
+            kind="line",
+            x="x",
+            y="y",
+            ax=ax[1],
+            legend=False,
+            color=cm.plasma(ipl / len(mp7_plines)),
+        )
+
+    # view/save plot
+    plt.show()
+    plt.savefig(prt_ws / f"test_{simname}.png")
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
+        targets=targets,
+        compare=None,
+    )
+    test.run()

--- a/autotest/test_prt_libmf6_budget.py
+++ b/autotest/test_prt_libmf6_budget.py
@@ -8,26 +8,24 @@ from pathlib import Path
 import pytest
 from framework import TestFramework
 from modflow_devtools.markers import requires_pkg
-from prt_test_utils import HorizontalCase
-from test_prt_budget import build_prt_sim, check_output
+from test_prt_budget import build_gwf_sim, build_gwt_sim, build_prt_sim, check_output
 
 simname = "prt_libmf6"
 cases = [simname]
 
 
 def build_models(idx, test):
-    # build MODFLOW 6 files
-    ws = test.workspace
-    name = cases[idx]
-
-    gwf_sim = HorizontalCase.get_gwf_sim(test.name, test.workspace, test.targets["mf6"])
+    gwf_sim = build_gwf_sim(test.workspace / "gwf", test.targets["libmf6"])
+    gwt_sim = build_gwt_sim(
+        test.workspace / "gwf", test.workspace / "gwt", test.targets["libmf6"]
+    )
     prt_sim = build_prt_sim(
         test.workspace / "gwf",
         test.workspace / "prt",
         test.targets["libmf6"],
     )
 
-    return gwf_sim, prt_sim
+    return gwf_sim, gwt_sim, prt_sim
 
 
 def api_func(exe, idx, model_ws=None):
@@ -96,5 +94,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         build=lambda t: build_models(idx, t),
         api_func=lambda exe, ws: api_func(exe, idx, ws),
         check=lambda t: check_output(idx, t),
+        compare=None,
     )
     test.run()

--- a/autotest/test_prt_libmf6_budget.py
+++ b/autotest/test_prt_libmf6_budget.py
@@ -8,7 +8,8 @@ from pathlib import Path
 import pytest
 from framework import TestFramework
 from modflow_devtools.markers import requires_pkg
-from test_prt_budget import HorizontalCase, build_mp7_sim, build_prt_sim, check_output
+from prt_test_utils import HorizontalCase
+from test_prt_budget import build_prt_sim, check_output
 
 simname = "prt_libmf6"
 cases = [simname]
@@ -21,19 +22,12 @@ def build_models(idx, test):
 
     gwf_sim = HorizontalCase.get_gwf_sim(test.name, test.workspace, test.targets["mf6"])
     prt_sim = build_prt_sim(
-        test.name,
-        test.workspace,
+        test.workspace / "gwf",
         test.workspace / "prt",
         test.targets["libmf6"],
     )
-    mp7_sim = build_mp7_sim(
-        test.name,
-        test.workspace / "mp7",
-        test.targets["mp7"],
-        gwf_sim.get_model(),
-    )
 
-    return gwf_sim, prt_sim, mp7_sim
+    return gwf_sim, prt_sim
 
 
 def api_func(exe, idx, model_ws=None):

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -35,9 +35,9 @@ module PrtModule
   public :: PRT_NBASEPKG, PRT_NMULTIPKG
   public :: PRT_BASEPKG, PRT_MULTIPKG
 
-  integer(I4B), parameter :: NBDITEMS = 1
+  integer(I4B), parameter :: NBDITEMS = 2
   character(len=LENBUDTXT), dimension(NBDITEMS) :: budtxt
-  data budtxt/'         STORAGE'/
+  data budtxt/'         STORAGE', '     TERMINATION'/
 
   !> @brief Particle tracking (PRT) model
   type, extends(NumericalModelType) :: PrtModelType
@@ -60,6 +60,9 @@ module PrtModule
     real(DP), dimension(:), pointer, contiguous :: masssto => null() !< particle mass storage in cells, new value
     real(DP), dimension(:), pointer, contiguous :: massstoold => null() !< particle mass storage in cells, old value
     real(DP), dimension(:), pointer, contiguous :: ratesto => null() !< particle mass storage rate in cells
+    real(DP), dimension(:), pointer, contiguous :: massterm => null() !< particle mass terminating in cells, new value
+    real(DP), dimension(:), pointer, contiguous :: masstermold => null() !< particle mass terminating in cells, old value
+    real(DP), dimension(:), pointer, contiguous :: rateterm => null() !< particle mass termination rate in cells
   contains
     ! Override BaseModelType procs
     procedure :: model_df => prt_df
@@ -82,7 +85,7 @@ module PrtModule
     procedure, private :: prt_ot_printflow
     procedure, private :: prt_ot_dv
     procedure, private :: prt_ot_bdsummary
-    procedure, private :: prt_cq_sto
+    procedure, private :: prt_cq_sto_term
     procedure, private :: create_packages
     procedure, private :: create_bndpkgs
     procedure, private :: log_namfile_options
@@ -128,7 +131,7 @@ contains
     use MemoryHelperModule, only: create_mem_path
     use MemoryManagerExtModule, only: mem_set_value
     use SimVariablesModule, only: idm_context
-    use PrtNamInputModule, only: PrtNamParamFoundType
+    use GwfNamInputModule, only: GwfNamParamFoundType
     ! dummy
     character(len=*), intent(in) :: filename
     integer(I4B), intent(in) :: id
@@ -138,7 +141,7 @@ contains
     class(BaseModelType), pointer :: model
     character(len=LENMEMPATH) :: input_mempath
     character(len=LINELENGTH) :: lst_fname
-    type(PrtNamParamFoundType) :: found
+    type(GwfNamParamFoundType) :: found
 
     ! Allocate a new PRT Model (this)
     allocate (this)
@@ -251,13 +254,13 @@ contains
 
     ! Select tracking events
     call this%tracks%select_events( &
-      this%oc%trackrelease, &
-      this%oc%trackfeatexit, &
-      this%oc%tracktimestep, &
-      this%oc%trackterminate, &
-      this%oc%trackweaksink, &
-      this%oc%trackusertime, &
-      this%oc%tracksubfexit)
+      release=this%oc%trackrelease, &
+      featexit=this%oc%trackfeatexit, &
+      timestep=this%oc%tracktimestep, &
+      terminate=this%oc%trackterminate, &
+      weaksink=this%oc%trackweaksink, &
+      usertime=this%oc%trackusertime, &
+      subfexit=this%oc%tracksubfexit)
 
     ! Set up boundary pkgs and pkg-scoped track files
     nprp = 0
@@ -267,7 +270,6 @@ contains
       type is (PrtPrpType)
         nprp = nprp + 1
         call packobj%prp_set_pointers(this%ibound, this%mip%izone)
-        call packobj%bnd_ar()
         call packobj%bnd_ar()
         if (packobj%itrkout > 0) then
           call this%tracks%init_file( &
@@ -357,9 +359,10 @@ contains
     irestore = 0
     if (iFailedStepRetry > 0) irestore = 1
 
-    ! Copy masssto into massstoold
+    ! Copy look-behind masses
     do n = 1, this%dis%nodes
       this%massstoold(n) = this%masssto(n)
+      this%masstermold(n) = this%massterm(n)
     end do
 
     ! Advance fmi
@@ -416,8 +419,8 @@ contains
       this%flowja(i) = this%flowja(i) * tled
     end do
 
-    ! Particle mass storage
-    call this%prt_cq_sto()
+    ! Particle mass storage and termination terms
+    call this%prt_cq_sto_term()
 
     ! Go through packages and call cq routines. Just a formality.
     do ip = 1, this%bndlist%Count()
@@ -426,16 +429,17 @@ contains
     end do
 
     ! Finalize calculation of flowja by adding face flows to the diagonal.
-    !    This results in the flow residual being stored in the diagonal
-    !    position for each cell.
+    ! This results in the flow residual being stored in the diagonal
+    ! position for each cell.
     call csr_diagsum(this%dis%con%ia, this%flowja)
   end subroutine prt_cq
 
   !> @brief Calculate particle mass storage
-  subroutine prt_cq_sto(this)
+  subroutine prt_cq_sto_term(this)
     ! modules
     use TdisModule, only: delt
     use PrtPrpModule, only: PrtPrpType
+    use ParticleModule, only: ACTIVE
     ! dummy
     class(PrtModelType) :: this
     ! local
@@ -446,7 +450,7 @@ contains
     integer(I4B) :: idiag
     integer(I4B) :: istatus
     real(DP) :: tled
-    real(DP) :: rate
+    real(DP) :: ratesto, rateterm
 
     ! Reciprocal of time step size.
     tled = DONE / delt
@@ -455,6 +459,8 @@ contains
     do n = 1, this%dis%nodes
       this%masssto(n) = DZERO
       this%ratesto(n) = DZERO
+      this%massterm(n) = DZERO
+      this%rateterm(n) = DZERO
     end do
     do ip = 1, this%bndlist%Count()
       packobj => GetBndFromList(this%bndlist, ip)
@@ -462,22 +468,25 @@ contains
       type is (PrtPrpType)
         do np = 1, packobj%nparticles
           istatus = packobj%particles%istatus(np)
-          ! this may need to change if istatus flags change
-          if ((istatus > 0) .and. (istatus /= 8)) then
+          if (istatus == ACTIVE) then
             n = packobj%particles%idomain(np, 2)
-            ! Each particle currently assigned unit mass
-            this%masssto(n) = this%masssto(n) + DONE
+            this%masssto(n) = this%masssto(n) + DONE ! unit mass
+          else if (istatus > ACTIVE) then
+            n = packobj%particles%idomain(np, 2)
+            this%massterm(n) = this%massterm(n) + DONE ! unit mass
           end if
         end do
       end select
     end do
     do n = 1, this%dis%nodes
-      rate = -(this%masssto(n) - this%massstoold(n)) * tled
-      this%ratesto(n) = rate
+      ratesto = -(this%masssto(n) - this%massstoold(n)) * tled
+      rateterm = -(this%massterm(n) - this%masstermold(n)) * tled
+      this%ratesto(n) = ratesto
+      this%rateterm(n) = rateterm
       idiag = this%dis%con%ia(n)
-      this%flowja(idiag) = this%flowja(idiag) + rate
+      this%flowja(idiag) = this%flowja(idiag) + ratesto + rateterm
     end do
-  end subroutine prt_cq_sto
+  end subroutine prt_cq_sto_term
 
   !> @brief Calculate flows and budget
   !!
@@ -504,16 +513,25 @@ contains
     !    should be added here to this%budget.  In a subsequent exchange call,
     !    exchange flows might also be added.
     call this%budget%reset()
+
+    ! storage term
     call rate_accumulator(this%ratesto, rin, rout)
     call this%budget%addentry(rin, rout, delt, budtxt(1), &
                               isuppress_output, '             PRT')
+
+    ! termination term
+    call rate_accumulator(this%rateterm, rin, rout)
+    call this%budget%addentry(rin, rout, delt, budtxt(2), &
+                              isuppress_output, '             PRT')
+
     do ip = 1, this%bndlist%Count()
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_bd(this%budget)
     end do
   end subroutine prt_bd
 
-  !> @brief Print and/or save model output
+  !> @brief Print and/or save model output.
+  ! Note that particle tracking output is handled elsewhere.
   subroutine prt_ot(this)
     use TdisModule, only: tdis_ot, endofperiod
     ! dummy
@@ -525,8 +543,6 @@ contains
     integer(I4B) :: icbcun
     integer(I4B) :: ibudfl
     integer(I4B) :: ipflag
-
-    ! Note: particle tracking output is handled elsewhere
 
     ! Set write and print flags
     idvsave = 0
@@ -769,6 +785,9 @@ contains
     call mem_deallocate(this%masssto)
     call mem_deallocate(this%massstoold)
     call mem_deallocate(this%ratesto)
+    call mem_deallocate(this%massterm)
+    call mem_deallocate(this%masstermold)
+    call mem_deallocate(this%rateterm)
 
     call this%tracks%destroy()
     deallocate (this%events)
@@ -823,6 +842,12 @@ contains
                       'MASSSTOOLD', this%memoryPath)
     call mem_allocate(this%ratesto, this%dis%nodes, &
                       'RATESTO', this%memoryPath)
+    call mem_allocate(this%massterm, this%dis%nodes, &
+                      'MASSTERM', this%memoryPath)
+    call mem_allocate(this%masstermold, this%dis%nodes, &
+                      'MASSTERMOLD', this%memoryPath)
+    call mem_allocate(this%rateterm, this%dis%nodes, &
+                      'RATETERM', this%memoryPath)
     ! explicit model, so these must be manually allocated
     call mem_allocate(this%x, this%dis%nodes, 'X', this%memoryPath)
     call mem_allocate(this%rhs, this%dis%nodes, 'RHS', this%memoryPath)
@@ -831,6 +856,9 @@ contains
       this%masssto(n) = DZERO
       this%massstoold(n) = DZERO
       this%ratesto(n) = DZERO
+      this%massterm(n) = DZERO
+      this%masstermold(n) = DZERO
+      this%rateterm(n) = DZERO
       this%x(n) = DZERO
       this%rhs(n) = DZERO
       this%ibound(n) = 1
@@ -1145,11 +1173,21 @@ contains
 
   !> @brief Write model namfile options to list file
   subroutine log_namfile_options(this, found)
-    use PrtNamInputModule, only: PrtNamParamFoundType
+    use GwfNamInputModule, only: GwfNamParamFoundType
     class(PrtModelType) :: this
-    type(PrtNamParamFoundType), intent(in) :: found
+    type(GwfNamParamFoundType), intent(in) :: found
 
     write (this%iout, '(1x,a)') 'NAMEFILE OPTIONS:'
+
+    if (found%newton) then
+      write (this%iout, '(4x,a)') &
+        'NEWTON-RAPHSON method enabled for the model.'
+      if (found%under_relaxation) then
+        write (this%iout, '(4x,a,a)') &
+          'NEWTON-RAPHSON UNDER-RELAXATION based on the bottom ', &
+          'elevation of the model will be applied to the model.'
+      end if
+    end if
 
     if (found%print_input) then
       write (this%iout, '(4x,a)') 'STRESS PACKAGE INPUT WILL BE PRINTED '// &


### PR DESCRIPTION
Add a particle termination term to the PRT list file to balance the cumulative particle mass budget. Previously mass stayed in storage at the end of the simulation. For now all particles (mass) are assigned to this new term at termination, later we anticipate assigning to boundaries in the same way budget is reported for transport models, but we will still need a budget term for non-boundary termination.

Expand testing, separating the old test case which only checked face flows from a new one which checks the budget in the list file and binary budget file.

First in a series of PRT budget fixes/enhancements. Generally aiming to follow the pattern in transport. Thinking of splitting this into the following chunks

- add termination term to list budget. minimum to be at least balanced / useful (this PR)
- add storage, termination and boundary terms to cell-by-cell budget
- add equivalent to transport SSM (SSP?) for stress package budget reporting. later, extend this for release thru boundaries.
- add advanced packages like transport. will be needed anyway to track particles thru advanced packages later on.