### PR TITLE
fix(sfr): clarify definition of parameter `rtp` in SFR documentation

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -77,3 +77,10 @@ description = "Previously the NOCHECK option was used to directly set the intern
 section = "features"
 subsection = "solution"
 description = "Added a developer option DEV\\_CYCLE\\_DETECTION\\_WINDOW to the PRT Model's Particle Release (PRP) Package. When enabled, this feature maintains a history of recent cell transitions, the size of which is configurable. If a cycle is detected, the program will terminate with an error. A cycle is identified as a duplicate particle event within a single application of the tracking loop, respective to certain particle and cell properties, e.g., exiting through the same cell face twice. This option defaults to 0, disabling cycle detection by default."
+
+[[items]]
+section = "fixes"
+subsection = "internal"
+description = "Clarified the definition of the rtp parameter in the SFR PACKAGEDATA block."
+
+

--- a/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
@@ -423,8 +423,8 @@ shape
 tagged false
 in_record true
 reader urword
-longname reach bottom
-description real value that defines the bottom elevation of the reach.
+longname reach top elevation
+description real value that defines the top elevation of the streambed of a reach.
 
 block packagedata
 name rbth

--- a/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
@@ -423,7 +423,7 @@ shape
 tagged false
 in_record true
 reader urword
-longname reach top elevation
+longname reach streambed top elevation
 description real value that defines the top elevation of the streambed of a reach.
 
 block packagedata

--- a/src/Model/GroundWaterFlow/gwf-sfr.f90
+++ b/src/Model/GroundWaterFlow/gwf-sfr.f90
@@ -3988,7 +3988,7 @@ contains
     !
     ! Add density contributions, if active
     if (this%idense /= 0) then
-      call this%sfr_calculate_density_exchange(n, hsfr, hgwf, cond, tp, &
+      call this%sfr_calculate_density_exchange(n, hsfr, hgwf, cond, bt, &
                                                qgwf, gwfhcof0, gwfrhs0)
     end if
     !

--- a/src/Model/GroundWaterFlow/gwf-sfr.f90
+++ b/src/Model/GroundWaterFlow/gwf-sfr.f90
@@ -1030,7 +1030,7 @@ contains
         this%width(n) = this%parser%GetDouble()
         ! -- get reach slope
         this%slope(n) = this%parser%GetDouble()
-        ! -- get reach stream bottom
+        ! -- get reach stream top elevation
         this%strtop(n) = this%parser%GetDouble()
         ! -- get reach bed thickness
         this%bthick(n) = this%parser%GetDouble()

--- a/src/Model/GroundWaterFlow/gwf-sfr.f90
+++ b/src/Model/GroundWaterFlow/gwf-sfr.f90
@@ -3988,7 +3988,7 @@ contains
     !
     ! Add density contributions, if active
     if (this%idense /= 0) then
-      call this%sfr_calculate_density_exchange(n, hsfr, hgwf, cond, bt, &
+      call this%sfr_calculate_density_exchange(n, hsfr, hgwf, cond, tp, &
                                                qgwf, gwfhcof0, gwfrhs0)
     end if
     !
@@ -5736,7 +5736,7 @@ contains
 
   !> @brief Calculate density terms
   !!
-  !! Method to galculate groundwater-reach density exchange terms for a
+  !! Method to calculate groundwater-reach density exchange terms for a
   !! SFR package reach.
   !!
   !! Member variable used here
@@ -5746,14 +5746,14 @@ contains
   !!                   col 3 is elevation of gwf cell
   !<
   subroutine sfr_calculate_density_exchange(this, n, stage, head, cond, &
-                                            bots, flow, gwfhcof, gwfrhs)
+                                            tops, flow, gwfhcof, gwfrhs)
     ! -- dummy
     class(SfrType), intent(inout) :: this !< SfrType object
     integer(I4B), intent(in) :: n !< reach number
     real(DP), intent(in) :: stage !< reach stage
     real(DP), intent(in) :: head !< head in connected GWF cell
     real(DP), intent(in) :: cond !< reach conductance
-    real(DP), intent(in) :: bots !< bottom elevation of reach
+    real(DP), intent(in) :: tops !< top elevation of streambed
     real(DP), intent(inout) :: flow !< calculated flow, updated here with density terms
     real(DP), intent(inout) :: gwfhcof !< GWF diagonal coefficient, updated here with density terms
     real(DP), intent(inout) :: gwfrhs !< GWF right-hand-side value, updated here with density terms
@@ -5773,23 +5773,23 @@ contains
     logical(LGP) :: head_below_bot
     !
     ! -- Set sfr density to sfr density or gwf density
-    if (stage >= bots) then
+    if (stage >= tops) then
       ss = stage
       stage_below_bot = .false.
       rdensesfr = this%denseterms(1, n) ! sfr rel density
     else
-      ss = bots
+      ss = tops
       stage_below_bot = .true.
       rdensesfr = this%denseterms(2, n) ! gwf rel density
     end if
     !
-    ! -- set hh to head or bots
-    if (head >= bots) then
+    ! -- set hh to head or tops (top elev of streambed)
+    if (head >= tops) then
       hh = head
       head_below_bot = .false.
       rdensegwf = this%denseterms(2, n) ! gwf rel density
     else
-      hh = bots
+      hh = tops
       head_below_bot = .true.
       rdensegwf = this%denseterms(1, n) ! sfr rel density
     end if
@@ -5821,7 +5821,7 @@ contains
         ! -- Add contribution of second density term:
         !      cond * (havg - elevavg) * (densegwf - densesfr) / denseref
         elevgwf = this%denseterms(3, n)
-        elevsfr = bots
+        elevsfr = tops
         elevavg = DHALF * (elevsfr + elevgwf)
         havg = DHALF * (hh + ss)
         d2 = cond * (havg - elevavg) * (rdensegwf - rdensesfr)

--- a/src/Model/GroundWaterFlow/gwf-sfr.f90
+++ b/src/Model/GroundWaterFlow/gwf-sfr.f90
@@ -1030,7 +1030,7 @@ contains
         this%width(n) = this%parser%GetDouble()
         ! -- get reach slope
         this%slope(n) = this%parser%GetDouble()
-        ! -- get reach stream top elevation
+        ! -- get reach streambed top elevation
         this%strtop(n) = this%parser%GetDouble()
         ! -- get reach bed thickness
         this%bthick(n) = this%parser%GetDouble()


### PR DESCRIPTION
The parameter `rtp` in SFR expects top of stream_bed_ elevations (bottom of water column/top of streambed sediment), but documentation was suggesting it expects bottom of streambed (stream top minus streambed thickness), which is wrong.  Clarified documentation and also updated some variable names in source code for clarity.

- [x] Replaced section above with description of pull request
- [x] Fixes issue #2448
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
