### PR TITLE
fix(prt): balance budget, add termination term

### DIFF
--- a/autotest/test_prt_budget.py
+++ b/autotest/test_prt_budget.py
@@ -1,296 +1,344 @@
 """
-Tests particle mass budget tracking with a very
-simple horizontal steady-state flow system. The
-grid is a 1x1x10 horizontal line with 10 columns.
-Particles are released from the left-most cell.
-Pathlines are compared against a MODPATH 7 model.
+Tests particle mass budget tracking.
 """
 
-from pathlib import Path
-
 import flopy
-import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
-from flopy.mf6.utils.postprocessing import get_structured_faceflows
-from flopy.utils import PathlineFile
-from flopy.utils.binaryfile import HeadFile
 from framework import TestFramework
+from matplotlib import cm
 from prt_test_utils import (
-    HorizontalCase,
-    all_equal,
-    check_budget_data,
-    check_track_data,
     get_model_name,
-    get_partdata,
-    has_default_boundnames,
 )
 
 simname = "prtbud"
 cases = [simname]
 
+# model names
+gwf_name = get_model_name(simname, "gwf")
+gwt_name = get_model_name(simname, "gwt")
+prt_name = get_model_name(simname, "prt")
 
-def build_prt_sim(name, gwf_ws, prt_ws, mf6):
-    # create simulation
-    sim = flopy.mf6.MFSimulation(
-        sim_name=name,
-        exe_name=mf6,
-        version="mf6",
-        sim_ws=prt_ws,
-    )
+# tdis data
+years = 550.0
+year_delt = 365.25
+perlen = year_delt * years
+nstp = 10
+tsmult = 1.0
+tdis_spd = [[perlen, nstp, tsmult]]
+nper = len(tdis_spd)
 
-    # create tdis package
-    flopy.mf6.modflow.mftdis.ModflowTdis(
+# grid data
+nlay, nrow, ncol = 5, 101, 101
+delr, delc = 100.0, 100.0
+top = 1.0
+botm = np.linspace(-10, -100, nlay)
+
+# gwf chd data
+chd_spd = [[(0, i, 0), 1.0, 6, -1] for i in range(nrow)]
+chd_spd += [[(0, i, ncol - 1), 0.0, 6, -1] for i in range(nrow)]
+
+# gwf maw data
+maw_spd = [((2, 50, 50), -5000.0, 0, 0), ((4, 50, 50), -5000.0, 0, 0)]
+
+# gwf output file names
+gwf_budget_file = f"{gwf_name}.bud"
+gwf_head_file = f"{gwf_name}.hds"
+
+# gwt src data
+gwt_srcs = []
+for k in [0, 1, 2, 3]:  # range(nlay):
+    gwt_srcs += [(k, i, 1) for i in range(nrow)]
+src_rate = 4.9779105e-4
+src_spd = []
+for cid in gwt_srcs:
+    src_spd.append([cid, "SRCRATE"])
+src_spd = {0: src_spd}
+src_tsdata = [
+    (0.0, src_rate),
+    (perlen / 100.0, 0.0),
+    (perlen, 0.0),
+]
+
+# prt prp data
+prt_nodes = []
+for k in [0, 1, 2, 3]:
+    prt_nodes += [(k, i, 1) for i in range(nrow)]
+particle_data = flopy.modpath.ParticleData(
+    prt_nodes,
+    drape=0,
+    structured=True,
+)
+
+# prt mip data
+izone = np.zeros((nlay, nrow, ncol), dtype=int)
+well_zone = (1, 2)
+for idx, k in enumerate((2, 4)):
+    izone[k, 50, 50] = well_zone[idx]
+
+# prt oc data
+tracktimes = list(range(0, 72000, 1000))
+
+# prt output file names
+prt_listfile = f"{prt_name}.lst"
+prt_budgetfile = f"{prt_name}.cbb"
+prt_trackfile = f"{prt_name}.trk"
+prt_trackcsvfile = f"{prt_name}.trk.csv"
+
+
+def build_gwf_sim(gwf_ws, mf6):
+    sim = flopy.mf6.MFSimulation(sim_name=gwf_name, sim_ws=gwf_ws, exe_name=mf6)
+    tdis = flopy.mf6.ModflowTdis(sim, nper=1, perioddata=tdis_spd)
+    ims = flopy.mf6.ModflowIms(sim, linear_acceleration="bicgstab", complexity="simple")
+    gwf = flopy.mf6.ModflowGwf(
         sim,
-        pname="tdis",
-        time_units="DAYS",
-        nper=HorizontalCase.nper,
-        perioddata=[
-            (HorizontalCase.perlen, HorizontalCase.nstp, HorizontalCase.tsmult)
+        modelname=gwf_name,
+        save_flows=True,
+        newtonoptions="newton under_relaxation",
+    )
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf, nlay=nlay, nrow=nrow, ncol=ncol, delr=100, delc=100, top=top, botm=botm
+    )
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf, icelltype=1, save_specific_discharge=True, save_saturation=True, k=100.0
+    )
+    sto = flopy.mf6.ModflowGwfsto(
+        gwf, iconvert=1, steady_state={0: False}, transient={0: True}
+    )
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=0.0)
+    chd = flopy.mf6.ModflowGwfchd(
+        gwf,
+        auxiliary=["iface", "iflowface"],
+        maxbound=len(chd_spd),
+        stress_period_data=chd_spd,
+        pname="chd",
+    )
+    maw = flopy.mf6.ModflowGwfwel(
+        gwf,
+        auxiliary=["iface", "iflowface"],
+        maxbound=len(maw_spd),
+        stress_period_data=maw_spd,
+    )
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=gwf_head_file,
+        budget_filerecord=gwf_budget_file,
+        printrecord=[("budget", "all")],
+        saverecord=[("head", "all"), ("budget", "all")],
+    )
+    return sim
+
+
+def build_gwt_sim(gwf_ws, gwt_ws, mf6):
+    sim = flopy.mf6.MFSimulation(sim_name=gwt_name, sim_ws=gwt_ws, exe_name=mf6)
+    tdis = flopy.mf6.modflow.mftdis.ModflowTdis(sim, nper=nper, perioddata=tdis_spd)
+    gwt = flopy.mf6.ModflowGwt(sim, modelname=gwt_name, print_input=True)
+    dis = flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
+        gwt,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+    ic = flopy.mf6.ModflowGwtic(gwt, strt=0)
+    mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="TVD")
+    dsp = flopy.mf6.ModflowGwtdsp(
+        gwt,
+        xt3d_off=True,
+        alh=250.0,
+        ath1=25.0,
+        ath2=25.0,
+    )
+    ssm = flopy.mf6.ModflowGwtssm(gwt)
+    src = flopy.mf6.ModflowGwtsrc(
+        gwt,
+        stress_period_data=src_spd,
+        timeseries={
+            "timeseries": src_tsdata,
+            "time_series_namerecord": "SRCRATE",
+            "interpolation_methodrecord": "STEPWISE",
+        },
+    )
+    oc = flopy.mf6.ModflowGwtoc(
+        gwt,
+        budget_filerecord=f"{gwt_name}.cbb",
+        concentration_filerecord=f"{gwt_name}.ucn",
+        saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
+        printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "ALL")],
+    )
+    fmi = flopy.mf6.ModflowGwtfmi(
+        gwt,
+        packagedata=[
+            ("GWFHEAD", gwf_ws / gwf_head_file),
+            ("GWFBUDGET", gwf_ws / gwf_budget_file),
         ],
     )
-
-    # create prt model
-    prt_name = get_model_name(name, "prt")
-    prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name, save_flows=True)
-
-    # create prt discretization
-    flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
-        prt,
-        pname="dis",
-        nlay=HorizontalCase.nlay,
-        nrow=HorizontalCase.nrow,
-        ncol=HorizontalCase.ncol,
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        pname="ims",
+        filename=f"{gwt_name}.ims",
+        print_option="summary",
+        inner_maximum=300,
+        linear_acceleration="bicgstab",
+        inner_dvclose=1e-9,
     )
+    sim.register_solution_package(ims, [gwt.name])
+    return sim
 
-    # create mip package
-    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=HorizontalCase.porosity)
 
-    # convert mp7 to prt release points and check against expectation
-    partdata = get_partdata(prt.modelgrid, HorizontalCase.releasepts_mp7)
-    coords = partdata.to_coords(prt.modelgrid)
-    releasepts = [(i, 0, 0, 0, c[0], c[1], c[2]) for i, c in enumerate(coords)]
-
-    # create prp package
-    prp_track_file = f"{prt_name}.prp.trk"
-    prp_track_csv_file = f"{prt_name}.prp.trk.csv"
-    flopy.mf6.ModflowPrtprp(
+def build_prt_sim(gwf_ws, prt_ws, mf6):
+    sim = flopy.mf6.MFSimulation(sim_name=prt_name, sim_ws=prt_ws, exe_name=mf6)
+    tdis = flopy.mf6.modflow.mftdis.ModflowTdis(sim, nper=nper, perioddata=tdis_spd)
+    prt = flopy.mf6.ModflowPrt(
+        sim, modelname=prt_name, print_input=True, save_flows=True
+    )
+    dis = flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
         prt,
-        pname="prp1",
-        filename=f"{prt_name}_1.prp",
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+    mip = flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=0.1, izone=izone)
+    releasepts = list(particle_data.to_prp(prt.modelgrid))
+    prp = flopy.mf6.ModflowPrtprp(
+        prt,
         nreleasepts=len(releasepts),
         packagedata=releasepts,
         perioddata={0: ["FIRST"]},
-        track_filerecord=[prp_track_file],
-        trackcsv_filerecord=[prp_track_csv_file],
-        stop_at_weak_sink=False,
-        boundnames=True,
-        extend_tracking=True,
+        exit_solve_tolerance=1e-5,
+        extend_tracking=False,
+        print_input=True,
     )
-
-    # create output control package
-    prt_budget_file = f"{prt_name}.bud"
-    prt_budgetcsv_file = f"{prt_name}.bud.csv"
-    prt_track_file = f"{prt_name}.trk"
-    prt_track_csv_file = f"{prt_name}.trk.csv"
-    flopy.mf6.ModflowPrtoc(
+    oc = flopy.mf6.ModflowPrtoc(
         prt,
-        pname="oc",
-        budget_filerecord=[prt_budget_file],
-        budgetcsv_filerecord=[prt_budgetcsv_file],
-        track_filerecord=[prt_track_file],
-        trackcsv_filerecord=[prt_track_csv_file],
+        budget_filerecord=[prt_budgetfile],
+        track_filerecord=[prt_trackfile],
+        trackcsv_filerecord=[prt_trackcsvfile],
+        ntracktimes=len(tracktimes),
+        tracktimes=[(t,) for t in tracktimes],
+        printrecord=[("BUDGET", "ALL")],
         saverecord=[("BUDGET", "ALL")],
     )
-
-    # create the flow model interface
-    gwf_name = get_model_name(name, "gwf")
-    gwf_budget_file = gwf_ws / f"{gwf_name}.bud"
-    gwf_head_file = gwf_ws / f"{gwf_name}.hds"
-    flopy.mf6.ModflowPrtfmi(
+    fmi = flopy.mf6.ModflowPrtfmi(
         prt,
         packagedata=[
-            ("GWFHEAD", gwf_head_file),
-            ("GWFBUDGET", gwf_budget_file),
+            ("GWFHEAD", gwf_ws / gwf_head_file),
+            ("GWFBUDGET", gwf_ws / gwf_budget_file),
         ],
     )
-
-    # add explicit model solution
     ems = flopy.mf6.ModflowEms(
         sim,
         pname="ems",
         filename=f"{prt_name}.ems",
     )
     sim.register_solution_package(ems, [prt.name])
-
     return sim
 
 
-def build_mp7_sim(name, ws, mp7, gwf):
-    partdata = get_partdata(gwf.modelgrid, HorizontalCase.releasepts_mp7)
-    mp7_name = get_model_name(name, "mp7")
-    pg = flopy.modpath.ParticleGroup(
-        particlegroupname="G1",
-        particledata=partdata,
-        filename=f"{mp7_name}.sloc",
-    )
-    mp = flopy.modpath.Modpath7(
-        modelname=mp7_name,
-        flowmodel=gwf,
-        exe_name=mp7,
-        model_ws=ws,
-        headfilename=f"{gwf.name}.hds",
-        budgetfilename=f"{gwf.name}.bud",
-    )
-    mpbas = flopy.modpath.Modpath7Bas(
-        mp,
-        porosity=HorizontalCase.porosity,
-    )
-    mpsim = flopy.modpath.Modpath7Sim(
-        mp,
-        simulationtype="pathline",
-        trackingdirection="forward",
-        budgetoutputoption="summary",
-        stoptimeoption="extend",
-        particlegroups=[pg],
-    )
-
-    return mp
-
-
 def build_models(idx, test):
-    gwf_sim = HorizontalCase.get_gwf_sim(test.name, test.workspace, test.targets["mf6"])
+    gwf_sim = build_gwf_sim(test.workspace / "gwf", test.targets["mf6"])
+    gwt_sim = build_gwt_sim(
+        test.workspace / "gwf", test.workspace / "gwt", test.targets["mf6"]
+    )
     prt_sim = build_prt_sim(
-        test.name, test.workspace, test.workspace / "prt", test.targets["mf6"]
+        test.workspace / "gwf", test.workspace / "prt", test.targets["mf6"]
     )
-    mp7_sim = build_mp7_sim(
-        test.name,
-        test.workspace / "mp7",
-        test.targets["mp7"],
-        gwf_sim.get_model(),
+    return gwf_sim, gwt_sim, prt_sim
+
+
+def check_cumulative_prt_budget(path, nparticles):
+    prt_lst = flopy.utils.Mf6ListBudget(path, budgetkey="MASS BUDGET FOR ENTIRE MODEL")
+
+    expected_terms = [
+        "PRP_IN",
+        "PRP_OUT",
+        "STORAGE_IN",
+        "STORAGE_OUT",
+        "TERMINATION_IN",
+        "TERMINATION_OUT",
+    ]
+    actual_terms = prt_lst.get_record_names()
+    for term in expected_terms:
+        assert term in actual_terms
+
+    prt_bud_cum = prt_lst.get_data()
+
+    def get_budget_term(term_name):
+        matches = [term[1] for term in prt_bud_cum if term[2].decode() == term_name]
+        assert len(matches) == 1
+        return matches[0]
+
+    prp_in = get_budget_term("PRP_IN")
+    prp_out = get_budget_term("PRP_OUT")
+    sto_in = get_budget_term("STORAGE_IN")
+    sto_out = get_budget_term("STORAGE_OUT")
+    term_in = get_budget_term("TERMINATION_IN")
+    term_out = get_budget_term("TERMINATION_OUT")
+    pct_dscr = get_budget_term("PERCENT_DISCREPANCY")
+
+    assert np.isclose(prp_in, nparticles)  # all particles released
+    assert np.isclose(prp_out, 0.0)  # no mass out of prp term
+    assert sto_in >= 0.0
+    assert np.isclose(sto_in, -sto_out)  # storage budget balance
+    assert np.isclose(term_in, 0.0)  # no mass into termination term
+    assert np.isclose(term_out, -nparticles)  # all particles terminated
+    assert np.isclose(pct_dscr, 0.0, atol=1e-6)  # overall budget balance
+    assert np.isclose(
+        prp_in + sto_in + term_in, -(prp_out + sto_out + term_out), rtol=1e-6
     )
-    return gwf_sim, prt_sim, mp7_sim
+
+
+def check_cell_by_cell_budget(path, nparticles):
+    prt_bud = flopy.utils.CellBudgetFile(path, precision="double")
+    prp_bud = prt_bud.get_data(text="PRP")
+    sto_bud = prt_bud.get_data(text="STORAGE")
+    trm_bud = prt_bud.get_data(text="TERMINATION")
+
+    assert len(prp_bud) == nstp
+    assert len(sto_bud) == nstp - 1
+    assert len(trm_bud) == nstp - 1
+
+    rls_bud = prp_bud[0]
+
+    assert len(rls_bud) == nparticles  # correct number of particles released
+    assert set(rls_bud["node2"]) == set(range(1, nparticles + 1))  # all released
+    assert np.all(rls_bud["q"] > 0)  # all cell release rates positive (sparse data)
+    # cell release rates in first time step
+    for i, record in enumerate(prp_bud[0]):
+        ic, ip, rate = record["node"], record["node2"], record["q"]
+        assert ic > 0  # valid cell number
+        assert ip == i + 1  # valid particle id
+        assert np.isclose(rate, 1 / (perlen / nstp))
+    # expect no further release
+    for step in range(1, nstp):
+        assert len(prp_bud[step]) == 0 or np.all(prp_bud[step]["q"] == 0)
+
+    # 2nd time step, all particles in storage
+    assert sum(sto_bud[0]["q"]) == nparticles
+
+    # expect all particles terminated by end of simulation
+    assert sum([sum(trm_bud[i]["q"]) for i in range(len(trm_bud))]) == nparticles
 
 
 def check_output(idx, test):
-    from flopy.plot.plotutil import to_mp7_pathlines
-
-    name = test.name
-    gwf_ws = test.workspace
     prt_ws = test.workspace / "prt"
-    mp7_ws = test.workspace / "mp7"
-    gwf_name = get_model_name(name, "gwf")
-    prt_name = get_model_name(name, "prt")
-    mp7_name = get_model_name(name, "mp7")
-    gwf_sim = test.sims[0]
-    gwf = gwf_sim.get_model(gwf_name)
-    mg = gwf.modelgrid
+    prt_pls = pd.read_csv(prt_ws / prt_trackcsvfile, na_filter=False)
 
-    # check mf6 output files exist
-    gwf_budget_file = f"{gwf_name}.bud"
-    gwf_head_file = f"{gwf_name}.hds"
-    prt_budgetcsv_file = f"{prt_name}.bud.csv"
-    prt_track_file = f"{prt_name}.trk"
-    prt_track_csv_file = f"{prt_name}.trk.csv"
-    prp_track_file = f"{prt_name}.prp.trk"
-    prp_track_csv_file = f"{prt_name}.prp.trk.csv"
-    mp7_pathline_file = f"{mp7_name}.mppth"
+    nparticles = prt_pls.irpt.unique().size
+    assert len(prt_nodes) == nparticles
 
-    # load mf6 pathline results
-    mf6_pls = pd.read_csv(prt_ws / prt_track_csv_file, na_filter=False)
-
-    # load mp7 pathline results
-    plf = PathlineFile(mp7_ws / mp7_pathline_file)
-    mp7_pls = pd.DataFrame(
-        plf.get_destination_pathline_data(range(mg.nnodes), to_recarray=True)
-    )
-    # convert zero-based to one-based indexing in mp7 results
-    mp7_pls["particlegroup"] = mp7_pls["particlegroup"] + 1
-    mp7_pls["node"] = mp7_pls["node"] + 1
-    mp7_pls["k"] = mp7_pls["k"] + 1
-
-    # extract head, budget, and specific discharge results from GWF model
-    hds = HeadFile(gwf_ws / gwf_head_file).get_data()
-    bud = gwf.output.budget()
-    spdis = bud.get_data(text="DATA-SPDIS")[0]
-    qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(spdis, gwf)
-
-    assert (gwf_ws / gwf_budget_file).is_file()
-    assert (gwf_ws / gwf_head_file).is_file()
-    assert (prt_ws / prt_budgetcsv_file).is_file()
-    assert (prt_ws / prt_track_file).is_file()
-    assert (prt_ws / prt_track_csv_file).is_file()
-    assert (prt_ws / prp_track_file).is_file()
-    assert (prt_ws / prp_track_csv_file).is_file()
-
-    # check mp7 output files exist
-    assert (mp7_ws / mp7_pathline_file).is_file()
-
-    # make sure pathline df has "name" (boundname) column and default values
-    assert "name" in mf6_pls
-    assert has_default_boundnames(mf6_pls)
-
-    # make sure all mf6 pathline data have correct model and PRP index (1)
-    assert all_equal(mf6_pls["imdl"], 1)
-    assert all_equal(mf6_pls["iprp"], 1)
-
-    # check budget data were written to mf6 prt list file
-    check_budget_data(
-        prt_ws / f"{name}_prt.lst", HorizontalCase.perlen, HorizontalCase.nper
-    )
-
-    # check cell-by-cell particle mass flows
-    prt_budget_file = prt_ws / f"{prt_name}.bud"
-    prt_bud = flopy.utils.CellBudgetFile(prt_budget_file, precision="double")
-    prt_bud_data = prt_bud.get_data(kstpkper=(0, 0))
-    assert len(prt_bud_data) == 2
-    flowja = prt_bud.get_data(text="FLOW-JA-FACE")[0][0, 0, :]
-    prp = prt_bud.get_data(text="PRP")[0].squeeze()
-    assert flowja.shape == (28,)
-    assert prp.shape == (9,)
-    frf, fff, flf = get_structured_faceflows(
-        flowja,
-        grb_file=gwf_ws / f"{gwf_name}.dis.grb",
-        verbose=True,
-    )
-    assert not fff.any()
-    assert not flf.any()
-    assert frf.any()
-    assert all(v == 9 for v in frf[:-1])
-
-    # check mf6 prt particle track data were written to binary/CSV files
-    # and that different formats are equal
-    for track_csv in [prt_ws / prt_track_csv_file, prt_ws / prp_track_csv_file]:
-        check_track_data(
-            track_bin=prt_ws / prt_track_file,
-            track_hdr=prt_ws / Path(prt_track_file.replace(".trk", ".trk.hdr")),
-            track_csv=track_csv,
-        )
-
-    # convert mf6 pathlines to mp7 format
-    mf6_pls = to_mp7_pathlines(mf6_pls)
-
-    # sort both dataframes by particleid and time
-    mf6_pls.sort_values(by=["particleid", "time"], inplace=True)
-    mp7_pls.sort_values(by=["particleid", "time"], inplace=True)
-
-    # drop columns for which there is no direct correspondence between mf6 and mp7
-    del mf6_pls["sequencenumber"]
-    del mf6_pls["particleidloc"]
-    del mf6_pls["xloc"]
-    del mf6_pls["yloc"]
-    del mf6_pls["zloc"]
-    del mp7_pls["sequencenumber"]
-    del mp7_pls["particleidloc"]
-    del mp7_pls["xloc"]
-    del mp7_pls["yloc"]
-    del mp7_pls["zloc"]
-
-    # compare mf6 / mp7 pathline data
-    assert mf6_pls.shape == mp7_pls.shape
-    assert np.allclose(mf6_pls, mp7_pls, atol=1e-3)
+    check_cumulative_prt_budget(prt_ws / prt_listfile, nparticles)
+    check_cell_by_cell_budget(prt_ws / prt_budgetfile, nparticles)
 
 
 def plot_output(idx, test):
@@ -314,7 +362,7 @@ def plot_output(idx, test):
     mf6_pls = pd.read_csv(prt_ws / prt_track_csv_file, na_filter=False)
 
     # load mp7 pathline results
-    plf = PathlineFile(mp7_ws / mp7_pathline_file)
+    plf = flopy.utils.PathlineFile(mp7_ws / mp7_pathline_file)
     mp7_pls = pd.DataFrame(
         plf.get_destination_pathline_data(range(mg.nnodes), to_recarray=True)
     )
@@ -324,7 +372,7 @@ def plot_output(idx, test):
     mp7_pls["k"] = mp7_pls["k"] + 1
 
     # extract head, budget, and specific discharge results from GWF model
-    hds = HeadFile(gwf_ws / gwf_head_file).get_data()
+    hds = flopy.utils.HeadFile(gwf_ws / gwf_head_file).get_data()
     bud = gwf.output.budget()
     spdis = bud.get_data(text="DATA-SPDIS")[0]
     qx, qy, qz = flopy.utils.postprocessing.get_specific_discharge(spdis, gwf)

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -58,3 +58,6 @@ section = "fixes"
 subsection = "solution"
 description = "Setting PRECONDITIONER\\_DROP\\_TOLERANCE in the IMS Linear block to a positive value in cases where the level of fill (PRECONDITIONER\\_LEVELS) equals 0, erroneously activated the (M)ILUT preconditioner. Now, in such cases a warning is written, the (M)ILU preconditioner is selected, and the configured drop tolerance will be ignored."
 
+[[items]]
+subsection = "model"
+description = "Balanced the PRT model mass budget with a new term to accumulate mass of terminated particles. Previously particle mass remained in storage regardless of particle status, leaving the particle mass budget unbalanced at the end of the simulation. Also, report cell-by-cell mass storage in the binary budget file; only cumulative mass storage was reported in the list file previously."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -59,5 +59,6 @@ subsection = "solution"
 description = "Setting PRECONDITIONER\\_DROP\\_TOLERANCE in the IMS Linear block to a positive value in cases where the level of fill (PRECONDITIONER\\_LEVELS) equals 0, erroneously activated the (M)ILUT preconditioner. Now, in such cases a warning is written, the (M)ILU preconditioner is selected, and the configured drop tolerance will be ignored."
 
 [[items]]
+section = "fixes"
 subsection = "model"
 description = "Balanced the PRT model mass budget with a new term to accumulate mass of terminated particles. Previously particle mass remained in storage regardless of particle status, leaving the particle mass budget unbalanced at the end of the simulation. Also, report cell-by-cell mass storage in the binary budget file; only cumulative mass storage was reported in the list file previously."

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -4,7 +4,7 @@ module PrtModule
   use InputOutputModule, only: ParseLine, upcase, lowcase
   use ConstantsModule, only: LENFTYPE, LENMEMPATH, DZERO, DONE, &
                              LENPAKLOC, LENPACKAGETYPE, LENBUDTXT, MNORMAL, &
-                             LINELENGTH
+                             LINELENGTH, LENAUXNAME
   use VersionModule, only: write_listfile_header
   use NumericalModelModule, only: NumericalModelType
   use BaseModelModule, only: BaseModelType
@@ -18,7 +18,7 @@ module PrtModule
   use PrtOcModule, only: PrtOcType
   use BudgetModule, only: BudgetType
   use ListModule, only: ListType
-  use ParticleModule, only: ParticleType, create_particle, TERM_UNRELEASED
+  use ParticleModule, only: ParticleType, create_particle, ACTIVE, TERM_UNRELEASED
   use ParticleEventsModule, only: ParticleEventDispatcherType, &
                                   ParticleEventConsumerType
   use ParticleTracksModule, only: ParticleTracksType, &
@@ -26,6 +26,8 @@ module PrtModule
   use SimModule, only: count_errors, store_error, store_error_filename
   use MemoryManagerModule, only: mem_allocate
   use MethodModule, only: MethodType, LEVEL_FEATURE
+  use HashTableModule, only: HashTableType, hash_table_cr, hash_table_da
+  use ArrayHandlersModule, only: ExpandArray
 
   implicit none
 
@@ -35,9 +37,9 @@ module PrtModule
   public :: PRT_NBASEPKG, PRT_NMULTIPKG
   public :: PRT_BASEPKG, PRT_MULTIPKG
 
-  integer(I4B), parameter :: NBDITEMS = 1
+  integer(I4B), parameter :: NBDITEMS = 2
   character(len=LENBUDTXT), dimension(NBDITEMS) :: budtxt
-  data budtxt/'         STORAGE'/
+  data budtxt/'         STORAGE', '     TERMINATION'/
 
   !> @brief Particle tracking (PRT) model
   type, extends(NumericalModelType) :: PrtModelType
@@ -60,6 +62,10 @@ module PrtModule
     real(DP), dimension(:), pointer, contiguous :: masssto => null() !< particle mass storage in cells, new value
     real(DP), dimension(:), pointer, contiguous :: massstoold => null() !< particle mass storage in cells, old value
     real(DP), dimension(:), pointer, contiguous :: ratesto => null() !< particle mass storage rate in cells
+    real(DP), dimension(:), pointer, contiguous :: masstrm => null() !< particle mass terminating in cells, new value
+    real(DP), dimension(:), pointer, contiguous :: masstrmold => null() !< particle mass terminating in cells, old value
+    real(DP), dimension(:), pointer, contiguous :: ratetrm => null() !< particle mass termination rate in cells
+    type(HashTableType), pointer :: trm_ids => null() !< terminated particle ids
   contains
     ! Override BaseModelType procs
     procedure :: model_df => prt_df
@@ -82,7 +88,7 @@ module PrtModule
     procedure, private :: prt_ot_printflow
     procedure, private :: prt_ot_dv
     procedure, private :: prt_ot_bdsummary
-    procedure, private :: prt_cq_sto
+    procedure, private :: prt_cq_budterms
     procedure, private :: create_packages
     procedure, private :: create_bndpkgs
     procedure, private :: log_namfile_options
@@ -183,6 +189,9 @@ contains
 
     ! Create model packages
     call this%create_packages()
+
+    ! Create hash table for terminated particle ids
+    call hash_table_cr(this%trm_ids)
 
     ! Log options
     if (this%iout > 0) then
@@ -358,9 +367,10 @@ contains
     irestore = 0
     if (iFailedStepRetry > 0) irestore = 1
 
-    ! Copy masssto into massstoold
+    ! Update look-behind mass
     do n = 1, this%dis%nodes
       this%massstoold(n) = this%masssto(n)
+      this%masstrmold(n) = this%masstrm(n)
     end do
 
     ! Advance fmi
@@ -376,11 +386,11 @@ contains
     end do
     !
     ! Initialize the flowja array.  Flowja is calculated each time,
-    !    even if output is suppressed.  (Flowja represents flow of particle
-    !    mass and is positive into a cell.  Currently, each particle is assigned
-    !    unit mass.)  Flowja is updated continually as particles are tracked
-    !    over the time step and at the end of the time step.  The diagonal
-    !    position of the flowja array will contain the flow residual.
+    ! even if output is suppressed.  (Flowja represents flow of particle
+    ! mass and is positive into a cell.  Currently, each particle is assigned
+    ! unit mass.)  Flowja is updated continually as particles are tracked
+    ! over the time step and at the end of the time step.  The diagonal
+    ! position of the flowja array will contain the flow residual.
     do i = 1, this%dis%nja
       this%flowja(i) = DZERO
     end do
@@ -403,22 +413,22 @@ contains
     real(DP) :: tled
 
     ! Flowja is calculated each time, even if output is suppressed.
-    !    Flowja represents flow of particle mass and is positive into a cell.
-    !    Currently, each particle is assigned unit mass.
+    ! Flowja represents flow of particle mass and is positive into a cell.
+    ! Currently, each particle is assigned unit mass.
     !
     ! Reciprocal of time step size.
     tled = DONE / delt
     !
     ! Flowja was updated continually as particles were tracked over the
-    !    time step.  At this point, flowja contains the net particle mass
-    !    exchanged between cells during the time step.  To convert these to
-    !    flow rates (particle mass per time), divide by the time step size.
+    ! time step.  At this point, flowja contains the net particle mass
+    ! exchanged between cells during the time step.  To convert these to
+    ! flow rates (particle mass per time), divide by the time step size.
     do i = 1, this%dis%nja
       this%flowja(i) = this%flowja(i) * tled
     end do
 
-    ! Particle mass storage
-    call this%prt_cq_sto()
+    ! Particle mass budget terms
+    call this%prt_cq_budterms()
 
     ! Go through packages and call cq routines. Just a formality.
     do ip = 1, this%bndlist%Count()
@@ -427,13 +437,13 @@ contains
     end do
 
     ! Finalize calculation of flowja by adding face flows to the diagonal.
-    !    This results in the flow residual being stored in the diagonal
-    !    position for each cell.
+    ! This results in the flow residual being stored in the diagonal
+    ! position for each cell.
     call csr_diagsum(this%dis%con%ia, this%flowja)
   end subroutine prt_cq
 
-  !> @brief Calculate particle mass storage
-  subroutine prt_cq_sto(this)
+  !> @brief Calculate particle mass budget terms
+  subroutine prt_cq_budterms(this)
     ! modules
     use TdisModule, only: delt
     use PrtPrpModule, only: PrtPrpType
@@ -445,40 +455,66 @@ contains
     integer(I4B) :: n
     integer(I4B) :: np
     integer(I4B) :: idiag
+    integer(I4B) :: iprp
     integer(I4B) :: istatus
     real(DP) :: tled
-    real(DP) :: rate
+    real(DP) :: ratesto, ratetrm
+    character(len=:), allocatable :: particle_id
+    type(ParticleType), pointer :: particle
+
+    call create_particle(particle)
 
     ! Reciprocal of time step size.
     tled = DONE / delt
 
-    ! Particle mass storage rate
+    ! Reset mass and rate arrays
     do n = 1, this%dis%nodes
       this%masssto(n) = DZERO
+      this%masstrm(n) = DZERO
       this%ratesto(n) = DZERO
+      this%ratetrm(n) = DZERO
     end do
+
+    ! Loop over PRP packages and assign particle mass to the
+    ! appropriate budget term based on the particle status.
+    iprp = 0
     do ip = 1, this%bndlist%Count()
       packobj => GetBndFromList(this%bndlist, ip)
       select type (packobj)
       type is (PrtPrpType)
         do np = 1, packobj%nparticles
+          call packobj%particles%get(particle, this%id, iprp, np)
           istatus = packobj%particles%istatus(np)
-          ! this may need to change if istatus flags change
-          if ((istatus > 0) .and. (istatus /= TERM_UNRELEASED)) then
+          particle_id = particle%get_id()
+          if (istatus == ACTIVE) then
+            ! calculate storage mass
             n = packobj%particles%itrdomain(np, LEVEL_FEATURE)
-            ! Each particle currently assigned unit mass
-            this%masssto(n) = this%masssto(n) + DONE
+            this%masssto(n) = this%masssto(n) + DONE ! unit mass
+          else if (istatus > ACTIVE) then
+            if (this%trm_ids%get(particle_id) /= 0) cycle
+            ! calculate terminating mass
+            n = packobj%particles%itrdomain(np, LEVEL_FEATURE)
+            this%masstrm(n) = this%masstrm(n) + DONE ! unit mass
+            call this%trm_ids%add(particle_id, 1) ! mark id terminated
           end if
         end do
       end select
     end do
+
+    ! Calculate rates and update flowja
     do n = 1, this%dis%nodes
-      rate = -(this%masssto(n) - this%massstoold(n)) * tled
-      this%ratesto(n) = rate
+      ratesto = -(this%masssto(n) - this%massstoold(n)) * tled
+      ratetrm = -this%masstrm(n) * tled
+      this%ratesto(n) = ratesto
+      this%ratetrm(n) = ratetrm
       idiag = this%dis%con%ia(n)
-      this%flowja(idiag) = this%flowja(idiag) + rate
+      this%flowja(idiag) = this%flowja(idiag) + ratesto
     end do
-  end subroutine prt_cq_sto
+
+    call particle%destroy()
+    deallocate (particle)
+
+  end subroutine prt_cq_budterms
 
   !> @brief Calculate flows and budget
   !!
@@ -500,14 +536,20 @@ contains
     real(DP) :: rin
     real(DP) :: rout
 
-    ! Budget routines (start by resetting).  Sole purpose of this section
-    !    is to add in and outs to model budget.  All ins and out for a model
-    !    should be added here to this%budget.  In a subsequent exchange call,
-    !    exchange flows might also be added.
+    ! Budget routines (start by resetting). Sole purpose of this section
+    ! is to add in and outs to model budget. All ins and out for a model
+    ! should be added here to this%budget. In a subsequent exchange call,
+    ! exchange flows might also be added.
     call this%budget%reset()
+    ! storage term
     call rate_accumulator(this%ratesto, rin, rout)
     call this%budget%addentry(rin, rout, delt, budtxt(1), &
                               isuppress_output, '             PRT')
+    ! termination term
+    call rate_accumulator(this%ratetrm, rin, rout)
+    call this%budget%addentry(rin, rout, delt, budtxt(2), &
+                              isuppress_output, '             PRT')
+    ! boundary packages
     do ip = 1, this%bndlist%Count()
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_bd(this%budget)
@@ -541,7 +583,7 @@ contains
     icbcun = this%oc%oc_save_unit('BUDGET')
 
     ! Override ibudfl and idvprint flags for nonconvergence
-    !    and end of period
+    ! and end of period
     ibudfl = this%oc%set_print_flag('BUDGET', 1, endofperiod)
     idvprint = this%oc%set_print_flag('CONCENTRATION', 1, endofperiod)
 
@@ -555,7 +597,7 @@ contains
     call this%prt_ot_bdsummary(ibudfl, ipflag)
 
     ! Timing Output; if any dependent variables or budgets
-    !    are printed, then ipflag is set to 1.
+    ! are printed, then ipflag is set to 1.
     if (ipflag == 1) call tdis_ot(this%iout)
   end subroutine prt_ot
 
@@ -606,6 +648,16 @@ contains
     integer(I4B), intent(in) :: icbcun
     ! local
     integer(I4B) :: ibinun
+    integer(I4B) :: naux
+    real(DP), dimension(0) :: auxrow
+    character(len=LENAUXNAME), dimension(0) :: auxname
+    logical(LGP) :: header_written
+    integer(I4B) :: i, nn
+    real(DP) :: m
+    integer(I4B) :: nsto, ntrm
+    logical(LGP), allocatable :: msto_mask(:), mtrm_mask(:)
+    integer(I4B), allocatable :: msto_nns(:), mtrm_nns(:)
+    real(DP), allocatable :: msto_vals(:), mtrm_vals(:)
 
     ! Set unit number for binary output
     if (this%ipakcb < 0) then
@@ -617,10 +669,63 @@ contains
     end if
     if (icbcfl == 0) ibinun = 0
 
-    ! Write the face flows if requested
-    if (ibinun /= 0) then
-      call this%dis%record_connection_array(flowja, ibinun, this%iout)
-    end if
+    ! Return if nothing to do
+    if (ibinun == 0) return
+
+    ! Write mass face flows
+    call this%dis%record_connection_array(flowja, ibinun, this%iout)
+
+    ! Write mass storage term
+    naux = 0
+    header_written = .false.
+    msto_mask = this%masssto > DZERO
+    msto_vals = pack(this%masssto, msto_mask)
+    msto_nns = [(i, i=1, size(this%masssto))]
+    msto_nns = pack(msto_nns, msto_mask)
+    nsto = size(msto_nns)
+    do i = 1, nsto
+      nn = msto_nns(i)
+      m = msto_vals(i)
+      if (.not. header_written) then
+        call this%dis%record_srcdst_list_header(budtxt(1), &
+                                                'PRT             ', &
+                                                'PRT             ', &
+                                                'PRT             ', &
+                                                'STORAGE         ', &
+                                                naux, auxname, ibinun, &
+                                                nsto, this%iout)
+        header_written = .true.
+      end if
+      call this%dis%record_mf6_list_entry(ibinun, nn, nn, m, &
+                                          0, auxrow, &
+                                          olconv2=.false.)
+    end do
+
+    ! Write mass termination term
+    header_written = .false.
+    mtrm_mask = this%masstrm > DZERO
+    mtrm_vals = pack(this%masstrm, mtrm_mask)
+    mtrm_nns = [(i, i=1, size(this%masstrm))]
+    mtrm_nns = pack(mtrm_nns, mtrm_mask)
+    ntrm = size(mtrm_nns)
+    do i = 1, ntrm
+      nn = mtrm_nns(i)
+      m = mtrm_vals(i)
+      if (.not. header_written) then
+        call this%dis%record_srcdst_list_header(budtxt(2), &
+                                                'PRT             ', &
+                                                'PRT             ', &
+                                                'PRT             ', &
+                                                'TERMINATION     ', &
+                                                naux, auxname, ibinun, &
+                                                ntrm, this%iout)
+        header_written = .true.
+      end if
+      call this%dis%record_mf6_list_entry(ibinun, nn, nn, m, &
+                                          0, auxrow, &
+                                          olconv2=.false.)
+    end do
+
   end subroutine prt_ot_saveflow
 
   !> @brief Print intercell flows
@@ -770,6 +875,9 @@ contains
     call mem_deallocate(this%masssto)
     call mem_deallocate(this%massstoold)
     call mem_deallocate(this%ratesto)
+    call mem_deallocate(this%masstrm)
+    call mem_deallocate(this%masstrmold)
+    call mem_deallocate(this%ratetrm)
 
     call this%tracks%destroy()
     deallocate (this%events)
@@ -824,6 +932,12 @@ contains
                       'MASSSTOOLD', this%memoryPath)
     call mem_allocate(this%ratesto, this%dis%nodes, &
                       'RATESTO', this%memoryPath)
+    call mem_allocate(this%masstrm, this%dis%nodes, &
+                      'MASSTRM', this%memoryPath)
+    call mem_allocate(this%masstrmold, this%dis%nodes, &
+                      'MASSTRMOLD', this%memoryPath)
+    call mem_allocate(this%ratetrm, this%dis%nodes, &
+                      'RATETRM', this%memoryPath)
     ! explicit model, so these must be manually allocated
     call mem_allocate(this%x, this%dis%nodes, 'X', this%memoryPath)
     call mem_allocate(this%rhs, this%dis%nodes, 'RHS', this%memoryPath)
@@ -832,6 +946,9 @@ contains
       this%masssto(n) = DZERO
       this%massstoold(n) = DZERO
       this%ratesto(n) = DZERO
+      this%masstrm(n) = DZERO
+      this%masstrmold(n) = DZERO
+      this%ratetrm(n) = DZERO
       this%x(n) = DZERO
       this%rhs(n) = DZERO
       this%ibound(n) = 1

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -63,7 +63,6 @@ module PrtModule
     real(DP), dimension(:), pointer, contiguous :: massstoold => null() !< particle mass storage in cells, old value
     real(DP), dimension(:), pointer, contiguous :: ratesto => null() !< particle mass storage rate in cells
     real(DP), dimension(:), pointer, contiguous :: masstrm => null() !< particle mass terminating in cells, new value
-    real(DP), dimension(:), pointer, contiguous :: masstrmold => null() !< particle mass terminating in cells, old value
     real(DP), dimension(:), pointer, contiguous :: ratetrm => null() !< particle mass termination rate in cells
     type(HashTableType), pointer :: trm_ids => null() !< terminated particle ids
   contains
@@ -370,7 +369,6 @@ contains
     ! Update look-behind mass
     do n = 1, this%dis%nodes
       this%massstoold(n) = this%masssto(n)
-      this%masstrmold(n) = this%masstrm(n)
     end do
 
     ! Advance fmi
@@ -876,7 +874,6 @@ contains
     call mem_deallocate(this%massstoold)
     call mem_deallocate(this%ratesto)
     call mem_deallocate(this%masstrm)
-    call mem_deallocate(this%masstrmold)
     call mem_deallocate(this%ratetrm)
 
     call this%tracks%destroy()
@@ -934,8 +931,6 @@ contains
                       'RATESTO', this%memoryPath)
     call mem_allocate(this%masstrm, this%dis%nodes, &
                       'MASSTRM', this%memoryPath)
-    call mem_allocate(this%masstrmold, this%dis%nodes, &
-                      'MASSTRMOLD', this%memoryPath)
     call mem_allocate(this%ratetrm, this%dis%nodes, &
                       'RATETRM', this%memoryPath)
     ! explicit model, so these must be manually allocated
@@ -947,7 +942,6 @@ contains
       this%massstoold(n) = DZERO
       this%ratesto(n) = DZERO
       this%masstrm(n) = DZERO
-      this%masstrmold(n) = DZERO
       this%ratetrm(n) = DZERO
       this%x(n) = DZERO
       this%rhs(n) = DZERO

--- a/src/Solution/ParticleTracker/Particle/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle/Particle.f90
@@ -2,7 +2,8 @@ module ParticleModule
 
   use KindModule, only: DP, I4B, LGP
   use ListModule, only: ListType
-  use ConstantsModule, only: DZERO, DONE, LENMEMPATH, LENBOUNDNAME
+  use ConstantsModule, only: DZERO, DONE, LENMEMPATH, LENBOUNDNAME, &
+                             LINELENGTH
   use MemoryManagerModule, only: mem_allocate, mem_deallocate, &
                                  mem_reallocate
   implicit none
@@ -96,6 +97,7 @@ module ParticleModule
     procedure, public :: get_model_coords
     procedure, public :: transform => transform_coords
     procedure, public :: reset_transform
+    procedure, public :: get_id
   end type ParticleType
 
   !> @brief Structure of arrays to store particles.
@@ -401,5 +403,17 @@ contains
     class(ParticleStoreType) :: this
     n = size(this%imdl)
   end function num_stored
+
+  !> @brief Get a string identifier for the particle.
+  function get_id(this) result(str)
+    class(ParticleType), intent(in) :: this
+    character(len=:), allocatable :: str
+    ! local
+    character(len=LINELENGTH) :: temp
+
+    write (temp, '(I0,1a,I0,1a,I0,1a,G0)') &
+      this%imdl, this%iprp, this%irpt, this%trelease
+    str = trim(adjustl(temp))
+  end function get_id
 
 end module ParticleModule


### PR DESCRIPTION
Particle mass previously remained in storage regardless of particle status.

Add a termination budget term and (for now) assign all terminating particle mass to it. This balances the cumulative storage budget. This is first in a sequence of budget reworks. Next planned is an analog to transport's SSM so that mass terminating at assigned boundaries can be reported for the boundary as done for transport models. After that, advanced packages in the same pattern. But even then, a term for non-boundary termination will still be needed.

Also, report the cell-by-cell storage term, only the cumulative was reported up to now.

Incidentally, add a function to get a particle's unique ID (composite key of model ID, PRP ID, release point ID, and release time) as a string. We had this before, and removed it as it went unused, but it's convenient to use here as a hash table key to track which particles have terminated.

This PR includes a new test focused on the cumulative and cell by cell budget reporting, and renames an existing test which was called "budget" but really focused on intercell mass flows.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request
