### PR TITLE
refactor(prt): support multiple particle event consumers

### DIFF
--- a/src/Solution/ParticleTracker/Particle/ParticleEvents.f90
+++ b/src/Solution/ParticleTracker/Particle/ParticleEvents.f90
@@ -1,5 +1,6 @@
 module ParticleEventsModule
   use KindModule, only: DP, I4B, LGP
+  use ListModule, only: ListType
   use ParticleModule, only: ParticleType
   use ParticleEventModule, only: ParticleEventType, &
                                  ReleaseEventType, &
@@ -18,10 +19,9 @@ module ParticleEventsModule
   end type ParticleEventConsumerType
 
   type, public :: ParticleEventDispatcherType
-    class(ParticleEventConsumerType), pointer :: consumer => null()
+    type(ListType) :: consumers
   contains
     procedure, public :: subscribe
-    procedure, public :: unsubscribe
     procedure, public :: dispatch
     procedure :: destroy
   end type ParticleEventDispatcherType
@@ -40,17 +40,10 @@ contains
   subroutine subscribe(this, consumer)
     class(ParticleEventDispatcherType), intent(inout) :: this
     class(ParticleEventConsumerType), target, intent(inout) :: consumer
-    this%consumer => consumer
+    class(*), pointer :: p
+    p => consumer
+    call this%consumers%Add(p)
   end subroutine subscribe
-
-  !> @brief Unsubscribe the consumer from the dispatcher.
-  subroutine unsubscribe(this)
-    class(ParticleEventDispatcherType), intent(inout) :: this
-    if (associated(this%consumer)) then
-      deallocate (this%consumer)
-      this%consumer => null()
-    end if
-  end subroutine unsubscribe
 
   !> @brief Dispatch an event.
   subroutine dispatch(this, particle, event)
@@ -60,7 +53,8 @@ contains
     type(ParticleType), pointer, intent(inout) :: particle
     class(ParticleEventType), pointer, intent(inout) :: event
     ! local
-    integer(I4B) :: per, stp
+    integer(I4B) :: i, per, stp
+    class(*), pointer :: p
 
     ! If tracking time falls exactly on a boundary between time steps,
     ! report the previous time step for this datum. This is to follow
@@ -90,14 +84,21 @@ contains
     event%ttrack = particle%ttrack
     event%istatus = particle%istatus
     call particle%get_model_coords(event%x, event%y, event%z)
-    call this%consumer%handle_event(particle, event)
+
+    do i = 1, this%consumers%Count()
+      p => this%consumers%GetItem(i)
+      select type (consumer => p)
+      class is (ParticleEventConsumerType)
+        call consumer%handle_event(particle, event)
+      end select
+    end do
     deallocate (event)
   end subroutine dispatch
 
   !> @brief Destroy the dispatcher.
   subroutine destroy(this)
     class(ParticleEventDispatcherType), intent(inout) :: this
-    if (associated(this%consumer)) deallocate (this%consumer)
+    call this%consumers%Clear()
   end subroutine destroy
 
 end module ParticleEventsModule


### PR DESCRIPTION
Allow subscribing multiple consumers to particle event dispatchers. Groundwork for budget accounting. Also remove `unsubscribe` as it's not used/needed