### PR TITLE
refactor(prt): rename particle idomain -> itrdomain

### DIFF
--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -535,11 +535,11 @@ contains
     end if
 
     particle%ttrack = particle%trelease
-    particle%idomain(1) = 0
+    particle%itrdomain(1) = 0
     particle%iboundary(1) = 0
-    particle%idomain(2) = ic
+    particle%itrdomain(2) = ic
     particle%iboundary(2) = 0
-    particle%idomain(3) = 0
+    particle%itrdomain(3) = 0
     particle%iboundary(3) = 0
     particle%ifrctrn = this%ifrctrn
     particle%iexmeth = this%iexmeth

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -464,7 +464,7 @@ contains
           istatus = packobj%particles%istatus(np)
           ! this may need to change if istatus flags change
           if ((istatus > 0) .and. (istatus /= 8)) then
-            n = packobj%particles%idomain(np, 2)
+            n = packobj%particles%itrdomain(np, 2)
             ! Each particle currently assigned unit mass
             this%masssto(n) = this%masssto(n) + DONE
           end if

--- a/src/Solution/ParticleTracker/Method/MethodCellPollock.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCellPollock.f90
@@ -69,7 +69,7 @@ contains
       events=this%events, &
       tracktimes=this%tracktimes)
     submethod => method_subcell_plck
-    particle%idomain(next_level) = 1
+    particle%itrdomain(next_level) = 1
   end subroutine load_mcp
 
   !> @brief Having exited the lone subcell, pass the particle to the cell face

--- a/src/Solution/ParticleTracker/Method/MethodCellPollockQuad.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCellPollockQuad.f90
@@ -81,7 +81,7 @@ contains
     select type (cell => this%cell)
     type is (CellRectQuadType)
       exitFace = particle%iboundary(3)
-      isc = particle%idomain(3)
+      isc = particle%itrdomain(3)
       npolyverts = cell%defn%npolyverts
 
       ! exitFace uses MODPATH 7 iface convention here
@@ -93,12 +93,12 @@ contains
         select case (isc)
         case (1)
           ! W face, subcell 1 --> E face, subcell 4  (cell interior)
-          particle%idomain(3) = 4
+          particle%itrdomain(3) = 4
           particle%iboundary(3) = 2
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (2)
           ! W face, subcell 2 --> E face, subcell 3 (cell interior)
-          particle%idomain(3) = 3
+          particle%itrdomain(3) = 3
           particle%iboundary(3) = 2
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (3)
@@ -122,12 +122,12 @@ contains
           infaceoff = -1
         case (3)
           ! E face, subcell 3 --> W face, subcell 2 (cell interior)
-          particle%idomain(3) = 2
+          particle%itrdomain(3) = 2
           particle%iboundary(3) = 1
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (4)
           ! E face, subcell 4 --> W face subcell 1 (cell interior)
-          particle%idomain(3) = 1
+          particle%itrdomain(3) = 1
           particle%iboundary(3) = 1
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         end select
@@ -135,7 +135,7 @@ contains
         select case (isc)
         case (1)
           ! S face, subcell 1 --> N face, subcell 2 (cell interior)
-          particle%idomain(3) = 2
+          particle%itrdomain(3) = 2
           particle%iboundary(3) = 4
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (2)
@@ -148,7 +148,7 @@ contains
           infaceoff = -1
         case (4)
           ! S face, subcell 4 --> N face, subcell 3 (cell interior)
-          particle%idomain(3) = 3
+          particle%itrdomain(3) = 3
           particle%iboundary(3) = 4
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         end select
@@ -160,12 +160,12 @@ contains
           infaceoff = -1
         case (2)
           ! N face, subcell 2 --> S face, subcell 1 (cell interior)
-          particle%idomain(3) = 1
+          particle%itrdomain(3) = 1
           particle%iboundary(3) = 3
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (3)
           ! N face, subcell 3 --> S face, subcell 4 (cell interior)
-          particle%idomain(3) = 4
+          particle%itrdomain(3) = 4
           particle%iboundary(3) = 3
           inface = 0 ! want Domain(2) unchanged; Boundary(2) = 0
         case (4)
@@ -251,7 +251,7 @@ contains
       factor = factor / cell%defn%porosity
       npolyverts = cell%defn%npolyverts
 
-      isc = particle%idomain(3)
+      isc = particle%itrdomain(3)
       ! Subcells 1, 2, 3, and 4 are Pollock's subcells A, B, C, and D,
       ! respectively
 
@@ -277,7 +277,7 @@ contains
         end if
 
         subcell%isubcell = isc
-        particle%idomain(3) = isc
+        particle%itrdomain(3) = isc
       end if
       dx = 5d-1 * dx
       dy = 5d-1 * dy

--- a/src/Solution/ParticleTracker/Method/MethodCellTernary.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCellTernary.f90
@@ -109,7 +109,7 @@ contains
     integer(I4B) :: inface
 
     exitFace = particle%iboundary(3)
-    isc = particle%idomain(3)
+    isc = particle%itrdomain(3)
 
     select case (exitFace)
     case (0)
@@ -123,14 +123,14 @@ contains
       ! Subcell face --> next subcell in "cycle" (cell interior)
       isc = isc + 1
       if (isc .gt. this%nverts) isc = 1
-      particle%idomain(3) = isc
+      particle%itrdomain(3) = isc
       particle%iboundary(3) = 3
       inface = 0
     case (3)
       ! Subcell face --> preceding subcell in "cycle" (cell interior)
       isc = isc - 1
       if (isc .lt. 1) isc = this%nverts
-      particle%idomain(3) = isc
+      particle%itrdomain(3) = isc
       particle%iboundary(3) = 2
       inface = 0
     case (4)
@@ -280,7 +280,7 @@ contains
     type is (CellPolyType)
       ic = cell%defn%icell
       subcell%icell = ic
-      isc = particle%idomain(3)
+      isc = particle%itrdomain(3)
       if (isc .le. 0) then
         xi = particle%x
         yi = particle%y
@@ -315,7 +315,7 @@ contains
 
           call pstop(1)
         else
-          particle%idomain(3) = isc
+          particle%itrdomain(3) = isc
         end if
       end if
       subcell%isubcell = isc

--- a/src/Solution/ParticleTracker/Method/MethodDis.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDis.f90
@@ -145,7 +145,7 @@ contains
 
     select type (cell => this%cell)
     type is (CellRectType)
-      ic = particle%idomain(next_level)
+      ic = particle%itrdomain(next_level)
       call this%load_celldefn(ic, cell%defn)
       call this%load_cell(ic, cell)
       if (this%fmi%ibdgwfsat0(ic) == 0) then
@@ -211,18 +211,18 @@ contains
       ! as can occur e.g. in wells. terminate
       ! in the previous cell.
       if (ic == particle%icp .and. inface == 7 .and. ilay < particle%ilay) then
-        particle%idomain(2) = particle%icp
+        particle%itrdomain(2) = particle%icp
         particle%izone = particle%izp
         call this%terminate(particle, &
                             status=TERM_BOUNDARY)
         return
       else
-        particle%icp = particle%idomain(2)
+        particle%icp = particle%itrdomain(2)
         particle%izp = particle%izone
       end if
 
       ! update node numbers and layer
-      particle%idomain(2) = ic
+      particle%itrdomain(2) = ic
       particle%icu = icu
       particle%ilay = ilay
 

--- a/src/Solution/ParticleTracker/Method/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDisv.f90
@@ -86,7 +86,7 @@ contains
 
     select type (cell => this%cell)
     type is (CellPolyType)
-      ic = particle%idomain(next_level)
+      ic = particle%itrdomain(next_level)
       call this%load_cell_defn(ic, cell%defn)
       if (this%fmi%ibdgwfsat0(ic) == 0) then
         ! Cell is active but dry, so select and initialize pass-to-bottom
@@ -175,17 +175,17 @@ contains
       ! as can occur e.g. in wells. terminate
       ! in the previous cell.
       if (ic == particle%icp .and. inface == 7 .and. ilay < particle%ilay) then
-        particle%idomain(2) = particle%icp
+        particle%itrdomain(2) = particle%icp
         particle%izone = particle%izp
         call this%terminate(particle, &
                             status=TERM_BOUNDARY)
         return
       else
-        particle%icp = particle%idomain(2)
+        particle%icp = particle%itrdomain(2)
         particle%izp = particle%izone
       end if
 
-      particle%idomain(2) = ic
+      particle%itrdomain(2) = ic
       particle%icu = icu
       particle%ilay = ilay
 
@@ -193,7 +193,7 @@ contains
       call this%map_neighbor(cell%defn, inface, z)
 
       particle%iboundary(2) = inface
-      particle%idomain(3:) = 0
+      particle%itrdomain(3:) = 0
       particle%iboundary(3:) = 0
       particle%z = z
     end select

--- a/src/Solution/ParticleTracker/Method/MethodSubcell.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcell.f90
@@ -35,7 +35,7 @@ contains
     allocate (SubCellExitEventType :: event)
     select type (event)
     type is (SubCellExitEventType)
-      event%isc = particle%idomain(3)
+      event%isc = particle%itrdomain(3)
       event%exit_face = particle%iboundary(3)
     end select
     call this%events%dispatch(particle, event)


### PR DESCRIPTION
Disambiguate particle tracking domain index from the existing grid-related term `idomain` by renaming to `itrdomain`. Split from #2202