### PR TITLE
refactor(prt): consolidate cell exit event raising logic

### DIFF
--- a/src/Solution/ParticleTracker/Method/MethodCellPollock.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCellPollock.f90
@@ -151,8 +151,6 @@ contains
                               sinrot, cosrot, invert=.true.)
       call particle%reset_transform()
     end select
-
-    if (particle%iboundary(LEVEL_FEATURE) > 0) call this%cellexit(particle)
   end subroutine apply_mcp
 
   !> @brief Loads the lone rectangular subcell from the rectangular cell

--- a/src/Solution/ParticleTracker/Method/MethodCellTernary.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCellTernary.f90
@@ -242,8 +242,6 @@ contains
       call particle%transform(xO, yO, invert=.true.)
       call particle%reset_transform()
     end select
-
-    if (particle%iboundary(LEVEL_FEATURE) > 0) call this%cellexit(particle)
   end subroutine apply_mct
 
   !> @brief Loads a triangular subcell from the polygonal cell


### PR DESCRIPTION
Override `try_pass` in the cell-level method and raise a cell exit event there instead of separately in the various cell-level methods. Fix a recently introduced issue where cell exits weren't raised by the quad pollock method.