### PR TITLE
fix(ci): install gfortran for mac extended build

### DIFF
--- a/.github/actions/test-extended/action.yml
+++ b/.github/actions/test-extended/action.yml
@@ -16,7 +16,6 @@ runs:
         nf-config --all
 
     - name: Install netcdf
-      if: runner.os == 'macOS'
       shell: bash
       run: |
         brew install netcdf-fortran


### PR DESCRIPTION
I don't remember why we weren't installing on mac in the first place