### PR TITLE
fix(ci): install gfortran for mac extended build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,6 +555,13 @@ jobs:
         with:
           path: modflow6
 
+      - name: Setup gfortran
+        if: runner.os != 'Windows'
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: gcc
+          version: 13
+
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.9.0
         with:


### PR DESCRIPTION
I think we must have assumed gfortran would be present on linux/mac but maybe github removed it?