### PR TITLE
refactor(prt): reference/rename max poly verts constant

### DIFF
--- a/src/Model/ParticleTracking/prt-fmi.f90
+++ b/src/Model/ParticleTracking/prt-fmi.f90
@@ -7,7 +7,7 @@ module PrtFmiModule
   use FlowModelInterfaceModule, only: FlowModelInterfaceType
   use BaseDisModule, only: DisBaseType
   use BudgetObjectModule, only: BudgetObjectType
-  use CellModule, only: MAX_POLY_CELLS
+  use CellModule, only: MAX_POLY_VERTS
 
   implicit none
   private
@@ -148,7 +148,7 @@ contains
     allocate (this%StorageFlows(this%dis%nodes))
     allocate (this%SourceFlows(this%dis%nodes))
     allocate (this%SinkFlows(this%dis%nodes))
-    allocate (this%BoundaryFlows(this%dis%nodes * MAX_POLY_CELLS))
+    allocate (this%BoundaryFlows(this%dis%nodes * MAX_POLY_VERTS))
 
   end subroutine prtfmi_df
 
@@ -196,11 +196,11 @@ contains
         iflowface = 0
         if (iauxiflowface > 0) then
           iflowface = NINT(this%gwfpackages(ip)%auxvar(iauxiflowface, ib))
-          ! this maps bot -2 -> 9, top -1 -> 10; see note re: max faces below
-          if (iflowface < 0) iflowface = iflowface + MAX_POLY_CELLS + 1
+          ! maps bot -2 -> MAX_POLY_VERTS - 1, top -1 -> MAX_POLY_VERTS
+          if (iflowface < 0) iflowface = iflowface + MAX_POLY_VERTS + 1
         end if
         if (iflowface .gt. 0) then
-          ioffset = (i - 1) * MAX_POLY_CELLS
+          ioffset = (i - 1) * MAX_POLY_VERTS
           this%BoundaryFlows(ioffset + iflowface) = &
             this%BoundaryFlows(ioffset + iflowface) + qbnd
         else if (qbnd .gt. DZERO) then

--- a/src/Solution/ParticleTracker/Domain/Cell.f90
+++ b/src/Solution/ParticleTracker/Domain/Cell.f90
@@ -6,7 +6,7 @@ module CellModule
   private
   public :: CellType
 
-  integer(I4B), public, parameter :: MAX_POLY_CELLS = 10
+  integer(I4B), public, parameter :: MAX_POLY_VERTS = 10
 
   !> @brief Base type for grid cells of a concrete type. Contains
   !! a cell-definition which is information shared by cell types.

--- a/src/Solution/ParticleTracker/Method/MethodDis.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDis.f90
@@ -514,7 +514,7 @@ contains
     ! local
     integer(I4B) :: ioffset
 
-    ioffset = (defn%icell - 1) * MAX_POLY_CELLS
+    ioffset = (defn%icell - 1) * MAX_POLY_VERTS
     defn%faceflow(1) = defn%faceflow(1) + &
                        this%fmi%BoundaryFlows(ioffset + 1)
     defn%faceflow(2) = defn%faceflow(2) + &
@@ -525,9 +525,9 @@ contains
                        this%fmi%BoundaryFlows(ioffset + 4)
     defn%faceflow(5) = defn%faceflow(1)
     defn%faceflow(6) = defn%faceflow(6) + &
-                       this%fmi%BoundaryFlows(ioffset + 9)
+                       this%fmi%BoundaryFlows(ioffset + MAX_POLY_VERTS - 1)
     defn%faceflow(7) = defn%faceflow(7) + &
-                       this%fmi%BoundaryFlows(ioffset + 10)
+                       this%fmi%BoundaryFlows(ioffset + MAX_POLY_VERTS)
   end subroutine load_boundary_flows_to_defn
 
 end module MethodDisModule


### PR DESCRIPTION
Noticed in review of #2446, `MAX_POLY_CELLS` was not used everywhere, the value (10) was hardcoded in a few places. This is the maximum number of vertices (also lateral faces) in a cell polygon so rename it `MAX_POLY_VERTS`, and reference it where needed.

Also noticed 2 routines no longer used (now replaced by cell conversion routines in `CellUtil.f90`), remove them.