### PR TITLE
feat(dis): add get_npolyverts and get_max_npolyverts functions

### DIFF
--- a/src/Model/Discretization/Dis.f90
+++ b/src/Model/Discretization/Dis.f90
@@ -53,6 +53,8 @@ module DisModule
     procedure :: supports_layers
     procedure :: get_ncpl
     procedure :: get_polyverts
+    procedure :: get_npolyverts
+    procedure :: get_max_npolyverts
     procedure :: connection_vector
     procedure :: connection_normal
     ! -- private
@@ -1255,6 +1257,21 @@ contains
       polyverts(:, nverts + 1) = polyverts(:, 1)
     !
   end subroutine
+
+  !> @brief Get the number of cell polygon vertices.
+  function get_npolyverts(this, ic) result(npolyverts)
+    class(DisType), intent(inout) :: this
+    integer(I4B), intent(in) :: ic !< cell number (reduced)
+    integer(I4B) :: npolyverts
+    npolyverts = 4
+  end function get_npolyverts
+
+  !> @brief Get the maximum number of cell polygon vertices.
+  function get_max_npolyverts(this) result(max_npolyverts)
+    class(DisType), intent(inout) :: this
+    integer(I4B) :: max_npolyverts
+    max_npolyverts = 4
+  end function get_max_npolyverts
 
   !> @brief Read an integer array
   !<

--- a/src/Model/Discretization/Dis.f90
+++ b/src/Model/Discretization/Dis.f90
@@ -1259,18 +1259,26 @@ contains
   end subroutine
 
   !> @brief Get the number of cell polygon vertices.
-  function get_npolyverts(this, ic) result(npolyverts)
+  function get_npolyverts(this, ic, closed) result(npolyverts)
     class(DisType), intent(inout) :: this
     integer(I4B), intent(in) :: ic !< cell number (reduced)
+    logical(LGP), intent(in), optional :: closed !< whether to close the polygon, duplicating a vertex
     integer(I4B) :: npolyverts
     npolyverts = 4
+    if (present(closed)) then
+      if (closed) npolyverts = 5
+    end if
   end function get_npolyverts
 
   !> @brief Get the maximum number of cell polygon vertices.
-  function get_max_npolyverts(this) result(max_npolyverts)
+  function get_max_npolyverts(this, closed) result(max_npolyverts)
     class(DisType), intent(inout) :: this
+    logical(LGP), intent(in), optional :: closed !< whether to close the polygon, duplicating a vertex
     integer(I4B) :: max_npolyverts
     max_npolyverts = 4
+    if (present(closed)) then
+      if (closed) max_npolyverts = 5
+    end if
   end function get_max_npolyverts
 
   !> @brief Read an integer array

--- a/src/Model/Discretization/Dis2d.f90
+++ b/src/Model/Discretization/Dis2d.f90
@@ -50,6 +50,8 @@ module Dis2dModule
     procedure :: supports_layers
     procedure :: get_ncpl
     procedure :: get_polyverts
+    procedure :: get_npolyverts
+    procedure :: get_max_npolyverts
     procedure :: connection_vector
     procedure :: connection_normal
     ! -- private
@@ -1138,6 +1140,21 @@ contains
       polyverts(:, nverts + 1) = polyverts(:, 1)
     !
   end subroutine
+
+  !> @brief Get the number of polygon vertices.
+  function get_npolyverts(this, ic) result(npolyverts)
+    class(Dis2dType), intent(inout) :: this
+    integer(I4B), intent(in) :: ic
+    integer(I4B) :: npolyverts
+    npolyverts = 4
+  end function get_npolyverts
+
+  !> @brief Get the maximum number of polygon vertices.
+  function get_max_npolyverts(this) result(max_npolyverts)
+    class(Dis2dType), intent(inout) :: this
+    integer(I4B) :: max_npolyverts
+    max_npolyverts = 4
+  end function get_max_npolyverts
 
   !> @brief Read an integer array
   !< TODO: REMOVE?

--- a/src/Model/Discretization/Dis2d.f90
+++ b/src/Model/Discretization/Dis2d.f90
@@ -1142,18 +1142,26 @@ contains
   end subroutine
 
   !> @brief Get the number of polygon vertices.
-  function get_npolyverts(this, ic) result(npolyverts)
+  function get_npolyverts(this, ic, closed) result(npolyverts)
     class(Dis2dType), intent(inout) :: this
     integer(I4B), intent(in) :: ic
+    logical(LGP), intent(in), optional :: closed !< whether to close the polygon, duplicating a vertex
     integer(I4B) :: npolyverts
     npolyverts = 4
+    if (present(closed)) then
+      if (closed) npolyverts = 5
+    end if
   end function get_npolyverts
 
   !> @brief Get the maximum number of polygon vertices.
-  function get_max_npolyverts(this) result(max_npolyverts)
+  function get_max_npolyverts(this, closed) result(max_npolyverts)
     class(Dis2dType), intent(inout) :: this
+    logical(LGP), intent(in), optional :: closed !< whether to close the polygon, duplicating a vertex
     integer(I4B) :: max_npolyverts
     max_npolyverts = 4
+    if (present(closed)) then
+      if (closed) max_npolyverts = 5
+    end if
   end function get_max_npolyverts
 
   !> @brief Read an integer array

--- a/src/Model/Discretization/Disv.f90
+++ b/src/Model/Discretization/Disv.f90
@@ -56,6 +56,8 @@ module DisvModule
     procedure :: supports_layers
     procedure :: get_ncpl
     procedure :: get_polyverts
+    procedure :: get_npolyverts
+    procedure :: get_max_npolyverts
     ! -- private
     procedure :: source_options
     procedure :: source_dimensions
@@ -1465,6 +1467,33 @@ contains
       polyverts(:, nverts + 1) = polyverts(:, 1)
     !
   end subroutine
+
+  !> @brief Get the number of cell polygon vertices.
+  function get_npolyverts(this, ic) result(npolyverts)
+    class(DisvType), intent(inout) :: this
+    integer(I4B), intent(in) :: ic !< cell number (reduced)
+    integer(I4B) :: npolyverts
+    ! local
+    integer(I4B) :: ncpl, icu, icu2d
+
+    ncpl = this%get_ncpl()
+    icu = this%get_nodeuser(ic)
+    icu2d = icu - ((icu - 1) / ncpl) * ncpl
+    npolyverts = this%iavert(icu2d + 1) - this%iavert(icu2d) - 1
+    if (npolyverts .le. 0) npolyverts = npolyverts + size(this%javert)
+  end function get_npolyverts
+
+  !> @brief Get the maximum number of cell polygon vertices.
+  function get_max_npolyverts(this) result(max_npolyverts)
+    class(DisvType), intent(inout) :: this
+    integer(I4B) :: max_npolyverts
+    integer(I4B) :: ic
+
+    max_npolyverts = 0
+    do ic = 1, this%nodes
+      max_npolyverts = max(max_npolyverts, this%get_npolyverts(ic))
+    end do
+  end function get_max_npolyverts
 
   !> @brief Read an integer array
   !<

--- a/src/Model/Discretization/Disv.f90
+++ b/src/Model/Discretization/Disv.f90
@@ -1469,9 +1469,10 @@ contains
   end subroutine
 
   !> @brief Get the number of cell polygon vertices.
-  function get_npolyverts(this, ic) result(npolyverts)
+  function get_npolyverts(this, ic, closed) result(npolyverts)
     class(DisvType), intent(inout) :: this
     integer(I4B), intent(in) :: ic !< cell number (reduced)
+    logical(LGP), intent(in), optional :: closed !< whether to close the polygon, duplicating a vertex
     integer(I4B) :: npolyverts
     ! local
     integer(I4B) :: ncpl, icu, icu2d
@@ -1480,18 +1481,21 @@ contains
     icu = this%get_nodeuser(ic)
     icu2d = icu - ((icu - 1) / ncpl) * ncpl
     npolyverts = this%iavert(icu2d + 1) - this%iavert(icu2d) - 1
-    if (npolyverts .le. 0) npolyverts = npolyverts + size(this%javert)
+    if (present(closed)) then
+      if (closed) npolyverts = npolyverts + 1
+    end if
   end function get_npolyverts
 
   !> @brief Get the maximum number of cell polygon vertices.
-  function get_max_npolyverts(this) result(max_npolyverts)
+  function get_max_npolyverts(this, closed) result(max_npolyverts)
     class(DisvType), intent(inout) :: this
+    logical(LGP), intent(in), optional :: closed !< whether to close the polygon, duplicating a vertex
     integer(I4B) :: max_npolyverts
     integer(I4B) :: ic
 
     max_npolyverts = 0
     do ic = 1, this%nodes
-      max_npolyverts = max(max_npolyverts, this%get_npolyverts(ic))
+      max_npolyverts = max(max_npolyverts, this%get_npolyverts(ic, closed))
     end do
   end function get_max_npolyverts
 

--- a/src/Model/Discretization/Disv.f90
+++ b/src/Model/Discretization/Disv.f90
@@ -1439,7 +1439,6 @@ contains
     icu = this%get_nodeuser(ic)
     icu2d = icu - ((icu - 1) / ncpl) * ncpl
     nverts = this%iavert(icu2d + 1) - this%iavert(icu2d) - 1
-    if (nverts .le. 0) nverts = nverts + size(this%javert)
     !
     ! check closed option
     if (.not. (present(closed))) then

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -48,6 +48,8 @@ module Disv2dModule
     procedure :: connection_normal
     procedure :: connection_vector
     procedure :: get_polyverts
+    procedure :: get_npolyverts
+    procedure :: get_max_npolyverts
     ! -- private
     procedure :: source_options
     procedure :: source_dimensions
@@ -1292,6 +1294,34 @@ contains
       polyverts(:, nverts + 1) = polyverts(:, 1)
     !
   end subroutine
+
+  !> @brief Get the number of cell polygon vertices.
+  function get_npolyverts(this, ic) result(npolyverts)
+    class(Disv2dType), intent(inout) :: this
+    integer(I4B), intent(in) :: ic
+    integer(I4B) :: npolyverts
+    ! local
+    integer(I4B) :: icu, icu2d, nverts
+
+    npolyverts = 0
+    icu = this%get_nodeuser(ic)
+    icu2d = icu - ((icu - 1) / this%nodes) * this%nodes
+    nverts = this%iavert(icu2d + 1) - this%iavert(icu2d) - 1
+    if (nverts > npolyverts) npolyverts = nverts
+  end function get_npolyverts
+
+  !> @brief Get the maximum number of cell polygon vertices.
+  function get_max_npolyverts(this) result(max_npolyverts)
+    class(Disv2dType), intent(inout) :: this
+    integer(I4B) :: max_npolyverts
+    ! local
+    integer(I4B) :: ic
+
+    max_npolyverts = 0
+    do ic = 1, this%nodes
+      max_npolyverts = max(max_npolyverts, this%get_npolyverts(ic))
+    end do
+  end function get_max_npolyverts
 
   !> @brief Record a double precision array
   !!

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -1266,7 +1266,6 @@ contains
     icu = this%get_nodeuser(ic)
     icu2d = icu - ((icu - 1) / this%nodes) * this%nodes
     nverts = this%iavert(icu2d + 1) - this%iavert(icu2d) - 1
-    if (nverts .le. 0) nverts = nverts + size(this%javert)
     !
     ! check closed option
     if (.not. (present(closed))) then

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -1296,9 +1296,10 @@ contains
   end subroutine
 
   !> @brief Get the number of cell polygon vertices.
-  function get_npolyverts(this, ic) result(npolyverts)
+  function get_npolyverts(this, ic, closed) result(npolyverts)
     class(Disv2dType), intent(inout) :: this
     integer(I4B), intent(in) :: ic
+    logical(LGP), intent(in), optional :: closed !< whether to close the polygon, duplicating a vertex
     integer(I4B) :: npolyverts
     ! local
     integer(I4B) :: icu, icu2d, nverts
@@ -1307,19 +1308,22 @@ contains
     icu = this%get_nodeuser(ic)
     icu2d = icu - ((icu - 1) / this%nodes) * this%nodes
     nverts = this%iavert(icu2d + 1) - this%iavert(icu2d) - 1
-    if (nverts > npolyverts) npolyverts = nverts
+    if (present(closed)) then
+      if (closed) npolyverts = npolyverts + 1
+    end if
   end function get_npolyverts
 
   !> @brief Get the maximum number of cell polygon vertices.
-  function get_max_npolyverts(this) result(max_npolyverts)
+  function get_max_npolyverts(this, closed) result(max_npolyverts)
     class(Disv2dType), intent(inout) :: this
+    logical(LGP), intent(in), optional :: closed !< whether to close the polygon, duplicating a vertex
     integer(I4B) :: max_npolyverts
     ! local
     integer(I4B) :: ic
 
     max_npolyverts = 0
     do ic = 1, this%nodes
-      max_npolyverts = max(max_npolyverts, this%get_npolyverts(ic))
+      max_npolyverts = max(max_npolyverts, this%get_npolyverts(ic, closed))
     end do
   end function get_max_npolyverts
 

--- a/src/Model/ModelUtilities/DiscretizationBase.f90
+++ b/src/Model/ModelUtilities/DiscretizationBase.f90
@@ -690,9 +690,10 @@ contains
   end subroutine get_polyverts
 
   !> @brief Get the number of cell polygon vertices.
-  function get_npolyverts(this, ic) result(npolyverts)
+  function get_npolyverts(this, ic, closed) result(npolyverts)
     class(DisBaseType), intent(inout) :: this
     integer(I4B), intent(in) :: ic !< cell number (reduced)
+    logical(LGP), intent(in), optional :: closed !< whether to close the polygon, duplicating a vertex
     integer(I4B) :: npolyverts
     npolyverts = 0 ! suppress compiler warning
     errmsg = 'Programmer error: get_npolyverts must be overridden'
@@ -700,8 +701,9 @@ contains
   end function get_npolyverts
 
   !> @brief Get the maximum number of cell polygon vertices.
-  function get_max_npolyverts(this) result(max_npolyverts)
+  function get_max_npolyverts(this, closed) result(max_npolyverts)
     class(DisBaseType), intent(inout) :: this
+    logical(LGP), intent(in), optional :: closed !< whether to close the polygon, duplicating a vertex
     integer(I4B) :: max_npolyverts
     max_npolyverts = 0 ! suppress compiler warning
     errmsg = 'Programmer error: get_max_npolyverts must be overridden'

--- a/src/Model/ModelUtilities/DiscretizationBase.f90
+++ b/src/Model/ModelUtilities/DiscretizationBase.f90
@@ -94,6 +94,8 @@ module BaseDisModule
     procedure :: get_ncpl
     procedure :: get_cell_volume
     procedure :: get_polyverts
+    procedure :: get_npolyverts
+    procedure :: get_max_npolyverts
     procedure :: write_grb
     !
     procedure :: read_int_array
@@ -675,8 +677,8 @@ contains
     get_cell_volume = this%area(n) * thick
   end function get_cell_volume
 
-  !> @brief Get a 2D array of polygon vertices, listed in
-  !! clockwise order beginning with the lower left corner.
+  !> @brief Get a 2D array of cell polygon vertices, in
+  !! clockwise order starting with the lower left corner.
   subroutine get_polyverts(this, ic, polyverts, closed)
     class(DisBaseType), intent(inout) :: this
     integer(I4B), intent(in) :: ic !< cell number (reduced)
@@ -685,7 +687,26 @@ contains
 
     errmsg = 'Programmer error: get_polyverts must be overridden'
     call store_error(errmsg, terminate=.true.)
-  end subroutine
+  end subroutine get_polyverts
+
+  !> @brief Get the number of cell polygon vertices.
+  function get_npolyverts(this, ic) result(npolyverts)
+    class(DisBaseType), intent(inout) :: this
+    integer(I4B), intent(in) :: ic !< cell number (reduced)
+    integer(I4B) :: npolyverts
+    npolyverts = 0 ! suppress compiler warning
+    errmsg = 'Programmer error: get_npolyverts must be overridden'
+    call store_error(errmsg, terminate=.true.)
+  end function get_npolyverts
+
+  !> @brief Get the maximum number of cell polygon vertices.
+  function get_max_npolyverts(this) result(max_npolyverts)
+    class(DisBaseType), intent(inout) :: this
+    integer(I4B) :: max_npolyverts
+    max_npolyverts = 0 ! suppress compiler warning
+    errmsg = 'Programmer error: get_max_npolyverts must be overridden'
+    call store_error(errmsg, terminate=.true.)
+  end function get_max_npolyverts
 
   !> @brief Read an integer array
   subroutine read_int_array(this, line, lloc, istart, istop, iout, in, &

--- a/src/Model/ParticleTracking/prt-fmi.f90
+++ b/src/Model/ParticleTracking/prt-fmi.f90
@@ -7,7 +7,6 @@ module PrtFmiModule
   use FlowModelInterfaceModule, only: FlowModelInterfaceType
   use BaseDisModule, only: DisBaseType
   use BudgetObjectModule, only: BudgetObjectType
-  use CellModule, only: MAX_POLY_VERTS
 
   implicit none
   private
@@ -140,15 +139,18 @@ contains
     class(PrtFmiType) :: this
     class(DisBaseType), pointer, intent(in) :: dis
     integer(I4B), intent(in) :: idryinactive
+    ! local
+    integer(I4B) :: max_faces
     !
     ! Call parent class define
     call this%FlowModelInterfaceType%fmi_df(dis, idryinactive)
     !
     ! Allocate arrays
+    max_faces = this%dis%get_max_npolyverts() + 2
     allocate (this%StorageFlows(this%dis%nodes))
     allocate (this%SourceFlows(this%dis%nodes))
     allocate (this%SinkFlows(this%dis%nodes))
-    allocate (this%BoundaryFlows(this%dis%nodes * MAX_POLY_VERTS))
+    allocate (this%BoundaryFlows(this%dis%nodes * max_faces))
 
   end subroutine prtfmi_df
 
@@ -163,7 +165,8 @@ contains
     real(DP) :: qbnd
     character(len=LENAUXNAME) :: auxname
     integer(I4B) :: naux
-    !
+    integer(I4B) :: max_faces
+
     this%StorageFlows = DZERO
     if (this%igwfstrgss /= 0) &
       this%StorageFlows = this%StorageFlows + &
@@ -175,6 +178,7 @@ contains
     this%SourceFlows = DZERO
     this%SinkFlows = DZERO
     this%BoundaryFlows = DZERO
+    max_faces = this%dis%get_max_npolyverts() + 2
     do ip = 1, this%nflowpack
       iauxiflowface = 0
       naux = this%gwfpackages(ip)%naux
@@ -196,11 +200,11 @@ contains
         iflowface = 0
         if (iauxiflowface > 0) then
           iflowface = NINT(this%gwfpackages(ip)%auxvar(iauxiflowface, ib))
-          ! maps bot -2 -> MAX_POLY_VERTS - 1, top -1 -> MAX_POLY_VERTS
-          if (iflowface < 0) iflowface = iflowface + MAX_POLY_VERTS + 1
+          ! maps bot -2 -> max_faces - 1, top -1 -> max_faces
+          if (iflowface < 0) iflowface = iflowface + max_faces + 1
         end if
         if (iflowface .gt. 0) then
-          ioffset = (i - 1) * MAX_POLY_VERTS
+          ioffset = (i - 1) * max_faces
           this%BoundaryFlows(ioffset + iflowface) = &
             this%BoundaryFlows(ioffset + iflowface) + qbnd
         else if (qbnd .gt. DZERO) then

--- a/src/Model/ParticleTracking/prt-fmi.f90
+++ b/src/Model/ParticleTracking/prt-fmi.f90
@@ -17,6 +17,7 @@ module PrtFmiModule
 
   type, extends(FlowModelInterfaceType) :: PrtFmiType
 
+    integer(I4B) :: max_faces !< maximum number of faces for grid cell polygons
     double precision, allocatable, public :: SourceFlows(:) ! cell source flows array
     double precision, allocatable, public :: SinkFlows(:) ! cell sink flows array
     double precision, allocatable, public :: StorageFlows(:) ! cell storage flows array
@@ -139,18 +140,16 @@ contains
     class(PrtFmiType) :: this
     class(DisBaseType), pointer, intent(in) :: dis
     integer(I4B), intent(in) :: idryinactive
-    ! local
-    integer(I4B) :: max_faces
     !
     ! Call parent class define
     call this%FlowModelInterfaceType%fmi_df(dis, idryinactive)
     !
     ! Allocate arrays
-    max_faces = this%dis%get_max_npolyverts() + 2
+    this%max_faces = this%dis%get_max_npolyverts() + 2
     allocate (this%StorageFlows(this%dis%nodes))
     allocate (this%SourceFlows(this%dis%nodes))
     allocate (this%SinkFlows(this%dis%nodes))
-    allocate (this%BoundaryFlows(this%dis%nodes * max_faces))
+    allocate (this%BoundaryFlows(this%dis%nodes * this%max_faces))
 
   end subroutine prtfmi_df
 
@@ -165,7 +164,6 @@ contains
     real(DP) :: qbnd
     character(len=LENAUXNAME) :: auxname
     integer(I4B) :: naux
-    integer(I4B) :: max_faces
 
     this%StorageFlows = DZERO
     if (this%igwfstrgss /= 0) &
@@ -178,7 +176,6 @@ contains
     this%SourceFlows = DZERO
     this%SinkFlows = DZERO
     this%BoundaryFlows = DZERO
-    max_faces = this%dis%get_max_npolyverts() + 2
     do ip = 1, this%nflowpack
       iauxiflowface = 0
       naux = this%gwfpackages(ip)%naux
@@ -201,10 +198,10 @@ contains
         if (iauxiflowface > 0) then
           iflowface = NINT(this%gwfpackages(ip)%auxvar(iauxiflowface, ib))
           ! maps bot -2 -> max_faces - 1, top -1 -> max_faces
-          if (iflowface < 0) iflowface = iflowface + max_faces + 1
+          if (iflowface < 0) iflowface = iflowface + this%max_faces + 1
         end if
         if (iflowface .gt. 0) then
-          ioffset = (i - 1) * max_faces
+          ioffset = (i - 1) * this%max_faces
           this%BoundaryFlows(ioffset + iflowface) = &
             this%BoundaryFlows(ioffset + iflowface) + qbnd
         else if (qbnd .gt. DZERO) then

--- a/src/Solution/ParticleTracker/Domain/Cell.f90
+++ b/src/Solution/ParticleTracker/Domain/Cell.f90
@@ -6,8 +6,6 @@ module CellModule
   private
   public :: CellType
 
-  integer(I4B), public, parameter :: MAX_POLY_VERTS = 10
-
   !> @brief Base type for grid cells of a concrete type. Contains
   !! a cell-definition which is information shared by cell types.
   type, abstract :: CellType

--- a/src/Solution/ParticleTracker/Method/MethodDis.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDis.f90
@@ -515,7 +515,7 @@ contains
     integer(I4B) :: max_faces
     integer(I4B) :: ioffset
 
-    max_faces = this%fmi%dis%get_max_npolyverts() + 2
+    max_faces = this%fmi%max_faces
     ioffset = (defn%icell - 1) * max_faces
     defn%faceflow(1) = defn%faceflow(1) + &
                        this%fmi%BoundaryFlows(ioffset + 1)

--- a/src/Solution/ParticleTracker/Method/MethodDis.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDis.f90
@@ -512,9 +512,11 @@ contains
     class(MethodDisType), intent(inout) :: this
     type(CellDefnType), intent(inout) :: defn
     ! local
+    integer(I4B) :: max_faces
     integer(I4B) :: ioffset
 
-    ioffset = (defn%icell - 1) * MAX_POLY_VERTS
+    max_faces = this%fmi%dis%get_max_npolyverts() + 2
+    ioffset = (defn%icell - 1) * max_faces
     defn%faceflow(1) = defn%faceflow(1) + &
                        this%fmi%BoundaryFlows(ioffset + 1)
     defn%faceflow(2) = defn%faceflow(2) + &
@@ -525,9 +527,9 @@ contains
                        this%fmi%BoundaryFlows(ioffset + 4)
     defn%faceflow(5) = defn%faceflow(1)
     defn%faceflow(6) = defn%faceflow(6) + &
-                       this%fmi%BoundaryFlows(ioffset + MAX_POLY_VERTS - 1)
+                       this%fmi%BoundaryFlows(ioffset + max_faces - 1)
     defn%faceflow(7) = defn%faceflow(7) + &
-                       this%fmi%BoundaryFlows(ioffset + MAX_POLY_VERTS)
+                       this%fmi%BoundaryFlows(ioffset + max_faces)
   end subroutine load_boundary_flows_to_defn
 
 end module MethodDisModule

--- a/src/Solution/ParticleTracker/Method/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDisv.f90
@@ -526,7 +526,7 @@ contains
 
     ic = defn%icell
     npolyverts = defn%npolyverts
-    max_faces = this%fmi%dis%get_max_npolyverts() + 2
+    max_faces = this%fmi%max_faces
     ioffset = (ic - 1) * max_faces
     do iv = 1, npolyverts
       defn%faceflow(iv) = &

--- a/src/Solution/ParticleTracker/Method/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDisv.f90
@@ -6,7 +6,6 @@ module MethodDisvModule
   use MethodModule, only: MethodType, LEVEL_FEATURE, LEVEL_SUBFEATURE
   use MethodModelModule, only: MethodModelType
   use MethodCellPoolModule
-  use CellModule, only: MAX_POLY_VERTS
   use CellDefnModule
   use CellPolyModule
   use ParticleModule
@@ -467,8 +466,7 @@ contains
     class(MethodDisvType), intent(inout) :: this
     type(CellDefnType), intent(inout) :: defn
     ! local
-    integer(I4B) :: nfaces
-    integer(I4B) :: nslots
+    integer(I4B) :: nfaces, nslots
 
     ! expand faceflow array if needed
     nfaces = defn%npolyverts + 3
@@ -522,16 +520,14 @@ contains
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     type(CellDefnType), intent(inout) :: defn
+
     ! local
-    integer(I4B) :: ic
-    integer(I4B) :: npolyverts
-    integer(I4B) :: ioffset
-    integer(I4B) :: iv
+    integer(I4B) :: ic, iv, ioffset, npolyverts, max_faces
 
     ic = defn%icell
     npolyverts = defn%npolyverts
-
-    ioffset = (ic - 1) * MAX_POLY_VERTS
+    max_faces = this%fmi%dis%get_max_npolyverts() + 2
+    ioffset = (ic - 1) * max_faces
     do iv = 1, npolyverts
       defn%faceflow(iv) = &
         defn%faceflow(iv) + &
@@ -540,10 +536,10 @@ contains
     defn%faceflow(npolyverts + 1) = defn%faceflow(1)
     defn%faceflow(npolyverts + 2) = &
       defn%faceflow(npolyverts + 2) + &
-      this%fmi%BoundaryFlows(ioffset + MAX_POLY_VERTS - 1)
+      this%fmi%BoundaryFlows(ioffset + max_faces - 1)
     defn%faceflow(npolyverts + 3) = &
       defn%faceflow(npolyverts + 3) + &
-      this%fmi%BoundaryFlows(ioffset + MAX_POLY_VERTS)
+      this%fmi%BoundaryFlows(ioffset + max_faces)
 
   end subroutine load_boundary_flows_to_defn_poly
 


### PR DESCRIPTION
Add two new functions to the discretization types, for counting cell vertices and getting the maximum cell vertex count in the grid, respectively. Use the latter in PRT to avoid hard-coding an upper limit and save space on array allocations. Followup to #2470, originally suggested in #2446.