### PR TITLE
fix(dfn2f90): tolerate whitespace in dfn file names/paths

### DIFF
--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -1001,7 +1001,7 @@ if __name__ == "__main__":
     verbose = args.verbose
 
     if isinstance(dfn, list):
-        dfn = [Path(p) for p in dfn]
+        dfn = [Path(str(p).strip()) for p in dfn]
     elif isinstance(dfn, (str, Path)):
         dfn = [Path(dfn)]
     else:


### PR DESCRIPTION
Pixi's [cross-platform shell](https://pixi.sh/latest/workspace/advanced_tasks/#our-task-runner-deno_task_shell) supports a limited bash-like environment in which `cat`, `xargs`, etc are available. The task `update-fortran-definitions` uses these, but on Windows the arguments received from `xargs` by the `dfn2f90.py` script have trailing newlines. I found this change necessary to use `update-fortran-definitions` on Windows.