### PR TITLE
fix(prt): terminate at assigned boundary faces

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -96,4 +96,4 @@ description = "Fixes a memory exception that has occurred when running parallel 
 [[item]]
 section = "fixes"
 subsection = "solution"
-description = "The PRT Model has previously been aware of boundary cell flows but not boundary faces. When an internal boundary face is assigned (an IFLOWFACE adjacent to another active cell), this can lead to cycles (infinite loops) in the particle's pathline, as the two adjacent cells do not agree on the flow through their shared face. The PRT Model will now terminate particles at assigned boundary faces whether they are internal or external."
+description = "The PRT Model has previously been aware of boundary cell flows but not boundary faces. When an internal boundary face is assigned (an IFLOWFACE adjacent to another active cell), this can lead to cycles (infinite loops) in the particle's pathline, as the two adjacent cells fail to agree on the flow through their shared face. The PRT Model will now terminate particles at assigned boundary faces whether they are internal or external."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -93,3 +93,7 @@ section = "fixes"
 subsection = "parallel"
 description = "Fixes a memory exception that has occurred when running parallel solute transport on Windows without the dispersion package. This has no effect on the simulation results other than causing a premature termination in some cases."
 
+[[item]]
+section = "fixes"
+subsection = "solution"
+description = "The PRT Model has previously been aware of boundary cell flows but not boundary faces. When an internal boundary face is assigned (an IFLOWFACE adjacent to another active cell), this can lead to cycles (infinite loops) in the particle's pathline, as the two adjacent cells do not agree on the flow through their shared face. The PRT Model will now terminate particles at assigned boundary faces whether they are internal or external."

--- a/src/Solution/ParticleTracker/Method/MethodDis.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDis.f90
@@ -202,14 +202,9 @@ contains
       ipos = idiag + inbr
       ic = dis%con%ja(ipos)
       icu = dis%get_nodeuser(ic)
-      call get_ijk(icu, dis%nrow, dis%ncol, dis%nlay, &
-                   irow, icol, ilay)
+      call get_ijk(icu, dis%nrow, dis%ncol, dis%nlay, irow, icol, ilay)
 
-      ! if returning to a cell through the bottom
-      ! face after previously leaving it through
-      ! that same face, we've entered a cycle
-      ! as can occur e.g. in wells. terminate
-      ! in the previous cell.
+      ! TODO remove this cycle trap as soon as both cycle conditions are fixed!
       if (ic == particle%icp .and. inface == 7 .and. ilay < particle%ilay) then
         particle%itrdomain(LEVEL_FEATURE) = particle%icp
         particle%izone = particle%izp
@@ -292,24 +287,25 @@ contains
     type(ParticleType), pointer, intent(inout) :: particle
     ! local
     type(CellRectType), pointer :: cell
+    integer(I4B) :: iface
+    logical(LGP) :: no_neighbors, at_boundary
 
     select type (c => this%cell)
     type is (CellRectType)
       cell => c
-      ! If the entry face has no neighbors it's a
-      ! boundary face, so terminate the particle.
-      ! todo AMP: reconsider when multiple models supported
-      if (cell%defn%facenbr(particle%iboundary(LEVEL_FEATURE)) .eq. 0) then
-        call this%terminate(particle, &
-                            status=TERM_BOUNDARY)
-      else
-        ! Update old to new cell properties
-        call this%load_particle(cell, particle)
-        if (.not. particle%advancing) return
+      iface = particle%iboundary(LEVEL_FEATURE)
+      no_neighbors = cell%defn%facenbr(iface) == 0
+      at_boundary = this%fmi%is_boundary_face(cell%defn%icell, iface)
 
-        ! Update intercell mass flows
-        call this%update_flowja(cell, particle)
+      ! todo AMP: reconsider when multiple models supported
+      if (no_neighbors .or. at_boundary) then
+        call this%terminate(particle, status=TERM_BOUNDARY)
+        return
       end if
+
+      call this%load_particle(cell, particle)
+      if (.not. particle%advancing) return ! todo: remove after cycles fixed
+      call this%update_flowja(cell, particle)
     end select
   end subroutine pass_dis
 


### PR DESCRIPTION
Previously the particle tracking method was aware of boundary cell flows but not boundary faces. When internal boundary faces were assigned, i.e. an `IFLOWFACE` is adjacent to another active cell, this could lead to cycles, as the two adjacent cells failed to agree on the flow through their shared face.

MODPATH 7 avoids this by ignoring internal boundary faces, treating the cell as if they were not assigned. With this, PRT will terminate particles at all boundary faces, internal or external. An option may be added later to toggle between this and MODPATH behavior (ignoring the internal faces) as prototyped in #2446.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced #2446
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request