### PR TITLE
refactor(prt): use logical arrays

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -45,6 +45,7 @@ reader urword
 optional true
 longname whether to use local z coordinates
 description indicates that ``zrpt'' defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user.
+mf6internal localz
 
 block options
 name extend_tracking
@@ -53,6 +54,7 @@ reader urword
 optional true
 longname whether to extend tracking beyond the end of the simulation
 description indicates that particles should be tracked beyond the end of the simulation's final time step (using that time step's flows) until particles terminate or reach a specified stop time.  By default, particles are terminated at the end of the simulation's final time step.
+mf6internal extend
 
 block options
 name track_filerecord
@@ -262,7 +264,7 @@ reader urword
 optional false
 longname force ternary tracking method
 description force use of the ternary tracking method regardless of cell type in DISV grids.
-mf6internal ifrctrn
+mf6internal frctrn
 
 block options
 name release_time_tolerance

--- a/src/Idm/prt-prpidm.f90
+++ b/src/Idm/prt-prpidm.f90
@@ -16,8 +16,8 @@ module PrtPrpInputModule
     logical :: iprpak = .false.
     logical :: iexmeth = .false.
     logical :: extol = .false.
-    logical :: local_z = .false.
-    logical :: extend_tracking = .false.
+    logical :: localz = .false.
+    logical :: extend = .false.
     logical :: track_filerecord = .false.
     logical :: track = .false.
     logical :: fileout = .false.
@@ -37,7 +37,7 @@ module PrtPrpInputModule
     logical :: release_timesfn = .false.
     logical :: timesfile = .false.
     logical :: idrymeth = .false.
-    logical :: ifrctrn = .false.
+    logical :: frctrn = .false.
     logical :: rttol = .false.
     logical :: rtfreq = .false.
     logical :: ichkmeth = .false.
@@ -141,13 +141,13 @@ module PrtPrpInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    prtprp_local_z = InputParamDefinitionType &
+    prtprp_localz = InputParamDefinitionType &
     ( &
     'PRT', & ! component
     'PRP', & ! subcomponent
     'OPTIONS', & ! block
     'LOCAL_Z', & ! tag name
-    'LOCAL_Z', & ! fortran variable
+    'LOCALZ', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'whether to use local z coordinates', & ! longname
@@ -159,13 +159,13 @@ module PrtPrpInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    prtprp_extend_tracking = InputParamDefinitionType &
+    prtprp_extend = InputParamDefinitionType &
     ( &
     'PRT', & ! component
     'PRP', & ! subcomponent
     'OPTIONS', & ! block
     'EXTEND_TRACKING', & ! tag name
-    'EXTEND_TRACKING', & ! fortran variable
+    'EXTEND', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'whether to extend tracking beyond the end of the simulation', & ! longname
@@ -519,13 +519,13 @@ module PrtPrpInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    prtprp_ifrctrn = InputParamDefinitionType &
+    prtprp_frctrn = InputParamDefinitionType &
     ( &
     'PRT', & ! component
     'PRP', & ! subcomponent
     'OPTIONS', & ! block
     'DEV_FORCETERNARY', & ! tag name
-    'IFRCTRN', & ! fortran variable
+    'FRCTRN', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'force ternary tracking method', & ! longname
@@ -903,8 +903,8 @@ module PrtPrpInputModule
     prtprp_iprpak, &
     prtprp_iexmeth, &
     prtprp_extol, &
-    prtprp_local_z, &
-    prtprp_extend_tracking, &
+    prtprp_localz, &
+    prtprp_extend, &
     prtprp_track_filerecord, &
     prtprp_track, &
     prtprp_fileout, &
@@ -924,7 +924,7 @@ module PrtPrpInputModule
     prtprp_release_timesfn, &
     prtprp_timesfile, &
     prtprp_idrymeth, &
-    prtprp_ifrctrn, &
+    prtprp_frctrn, &
     prtprp_rttol, &
     prtprp_rtfreq, &
     prtprp_ichkmeth, &

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -961,7 +961,7 @@ contains
           ! stop time, whichever comes first, unless it's the final
           ! time step and the extend option is on, in which case
           ! it's just the particle stop time.
-          if (endofsimulation .and. particle%iextend > 0) then
+          if (endofsimulation .and. particle%extend) then
             tmax = particle%tstop
           else
             tmax = min(totimc + delt, particle%tstop)
@@ -982,7 +982,7 @@ contains
           ! TODO maybe think about changing that?
           if (particle%istatus <= ACTIVE .and. &
               (particle%ttrack == particle%tstop .or. &
-               (endofsimulation .and. particle%iextend == 0))) &
+               (endofsimulation .and. .not. particle%extend))) &
             call this%method%terminate(particle, status=TERM_TIMEOUT)
           ! Return the particle to the store
           call packobj%particles%put(particle, np)

--- a/src/Solution/ParticleTracker/Method/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDisv.f90
@@ -94,7 +94,7 @@ contains
           events=this%events, &
           tracktimes=this%tracktimes)
         submethod => method_cell_ptb
-      else if (particle%ifrctrn > 0) then
+      else if (particle%frctrn) then
         ! Force the ternary method
         call method_cell_tern%init( &
           fmi=this%fmi, &

--- a/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
@@ -150,7 +150,7 @@ contains
     ! ideally that would be handled at a higher scope but with extended tracking
     ! tmax is not the end of the simulation, it's just a wildly high upper bound.
     if ((statusVX .eq. 2) .and. (statusVY .eq. 2) .and. (statusVZ .eq. 2) .and. &
-        particle%iextend > 0 .and. endofsimulation) then
+        particle%extend .and. endofsimulation) then
       call this%terminate(particle, status=TERM_TIMEOUT)
       return
     end if


### PR DESCRIPTION
Use logical arrays in PRT as enabled by #2473. This involved a few DFN tweaks to work with IDM. Also some cleanup.