### PR TITLE
fix(par): specific discharge for parallel simulations

### DIFF
--- a/autotest/test_gwt_adv03_gwtgwt.py
+++ b/autotest/test_gwt_adv03_gwtgwt.py
@@ -1,0 +1,322 @@
+"""
+Test gwt-gwt coupling for advection without dispersion.
+"""
+
+import os
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = ["adv03_gwtgwt"]
+scheme = "tvd"
+
+# solver settings
+nouter, ninner = 100, 300
+hclose, rclose, relax = 1e-6, 1e-6, 1.0
+
+g_delr = 1.0
+
+
+def get_gwf_model(sim, gwfname, gwfpath, modelshape, chdspd=None, welspd=None):
+    nlay, nrow, ncol, xshift, yshift = modelshape
+    delr = g_delr
+    delc = 1.0
+    top = 1.0
+    botm = [0.0]
+    strt = 1.0
+    hk = 1.0
+    laytyp = 0
+
+    gwf = flopy.mf6.ModflowGwf(
+        sim,
+        modelname=gwfname,
+        save_flows=True,
+    )
+
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        xorigin=xshift,
+        yorigin=yshift,
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
+
+    # node property flow
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf,
+        icelltype=laytyp,
+        k=hk,
+        save_specific_discharge=False,
+    )
+
+    # chd files
+    if chdspd is not None:
+        chd = flopy.mf6.modflow.mfgwfchd.ModflowGwfchd(
+            gwf,
+            # maxbound=len(c),
+            stress_period_data=chdspd,
+            save_flows=False,
+            pname="CHD-1",
+        )
+
+    # wel files
+    if welspd is not None:
+        wel = flopy.mf6.ModflowGwfwel(
+            gwf,
+            print_input=True,
+            print_flows=True,
+            # maxbound=len(w),
+            stress_period_data=welspd,
+            save_flows=False,
+            auxiliary="CONCENTRATION",
+            pname="WEL-1",
+        )
+
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=f"{gwfname}.cbc",
+        head_filerecord=f"{gwfname}.hds",
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
+        printrecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
+    )
+    gwf.set_model_relative_path(gwfpath)
+    return gwf
+
+
+def get_gwt_model(sim, gwtname, gwtpath, modelshape, scheme, sourcerecarray=None):
+    nlay, nrow, ncol, xshift, yshift = modelshape
+    delr = g_delr
+    delc = 1.0
+    top = 1.0
+    botm = [0.0]
+    strt = 1.0
+    hk = 1.0
+    laytyp = 0
+
+    gwt = flopy.mf6.MFModel(
+        sim,
+        model_type="gwt6",
+        modelname=gwtname,
+    )
+    gwt.name_file.save_flows = True
+
+    dis = flopy.mf6.ModflowGwtdis(
+        gwt,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        xorigin=xshift,
+        yorigin=yshift,
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0)
+
+    # advection
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme=scheme)
+
+    # mass storage and transfer
+    mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
+
+    # sources
+    ssm = flopy.mf6.ModflowGwtssm(gwt, sources=sourcerecarray)
+
+    # output control
+    oc = flopy.mf6.ModflowGwtoc(
+        gwt,
+        budget_filerecord=f"{gwtname}.cbc",
+        concentration_filerecord=f"{gwtname}.ucn",
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
+        printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
+    )
+
+    gwt.set_model_relative_path(gwtpath)
+    return gwt
+
+
+def build_models(idx, test):
+    # temporal discretization
+    nper = 1
+    perlen = [5.0]
+    nstp = [20]
+    tsmult = [1.0]
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+    # build MODFLOW 6 files
+    ws = test.workspace
+    sim = flopy.mf6.MFSimulation(sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws)
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc, pname="sim.tdis"
+    )
+
+    # grid information
+    nlay, nrow, ncol = 1, 2, 50
+
+    # Create gwf1 model
+    welspd = {0: [[(0, 0, 0), 1.0, 1.0], [(0, 1, 0), 1.0, 1.0]]}
+    chdspd = None
+    gwf1 = get_gwf_model(
+        sim,
+        "flow1",
+        "flow1",
+        (nlay, nrow, ncol, 0.0, 0.0),
+        chdspd=chdspd,
+        welspd=welspd,
+    )
+
+    # Create gwf2 model
+    welspd = None
+    chdspd = {0: [[(0, 0, ncol - 1), 0.0000000], [(0, 1, ncol - 1), 0.0000000]]}
+    gwf2 = get_gwf_model(
+        sim,
+        "flow2",
+        "flow2",
+        (nlay, nrow, ncol, ncol * g_delr, 0.0),
+        chdspd=chdspd,
+        welspd=welspd,
+    )
+
+    # gwf-gwf with interface model enabled
+    gwfgwf_data = [
+        [(0, 0, ncol - 1), (0, 0, 0), 1, 0.5, 0.5, 1.0, 0.0, 1.0],
+        [(0, 1, ncol - 1), (0, 1, 0), 1, 0.5, 0.5, 1.0, 0.0, 1.0],
+    ]
+    gwfgwf = flopy.mf6.ModflowGwfgwf(
+        sim,
+        exgtype="GWF6-GWF6",
+        nexg=len(gwfgwf_data),
+        exgmnamea=gwf1.name,
+        exgmnameb=gwf2.name,
+        exchangedata=gwfgwf_data,
+        auxiliary=["ANGLDEGX", "CDIST"],
+        filename="flow1_flow2.gwfgwf",
+    )
+
+    # create iterative model solution and register the gwf model with it
+    imsgwf = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="CG",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename="flow.ims",
+    )
+    sim.register_ims_package(imsgwf, [gwf1.name, gwf2.name])
+
+    # Create gwt model
+    sourcerecarray = [("WEL-1", "AUX", "CONCENTRATION")]
+    gwt1 = get_gwt_model(
+        sim,
+        "transport1",
+        "transport1",
+        (nlay, nrow, ncol, 0.0, 0.0),
+        scheme,
+        sourcerecarray=sourcerecarray,
+    )
+
+    # Create gwt model
+    sourcerecarray = None
+    gwt2 = get_gwt_model(
+        sim,
+        "transport2",
+        "transport2",
+        (nlay, nrow, ncol, ncol * g_delr, 0.0),
+        scheme,
+        sourcerecarray=sourcerecarray,
+    )
+
+    # Create GWT GWT exchange
+    gwt1gwt2 = flopy.mf6.ModflowGwtgwt(
+        sim,
+        exgtype="GWT6-GWT6",
+        gwfmodelname1=gwf1.name,
+        gwfmodelname2=gwf2.name,
+        adv_scheme=scheme,
+        nexg=len(gwfgwf_data),
+        exgmnamea=gwt1.name,
+        exgmnameb=gwt2.name,
+        exchangedata=gwfgwf_data,
+        auxiliary=["ANGLDEGX", "CDIST"],
+        filename="transport1_transport2.gwtgwt",
+    )
+
+    # GWF GWT exchange
+    gwfgwt1 = flopy.mf6.ModflowGwfgwt(
+        sim,
+        exgtype="GWF6-GWT6",
+        exgmnamea="flow1",
+        exgmnameb="transport1",
+        filename="flow1_transport1.gwfgwt",
+    )
+    gwfgwt2 = flopy.mf6.ModflowGwfgwt(
+        sim,
+        exgtype="GWF6-GWT6",
+        exgmnamea="flow2",
+        exgmnameb="transport2",
+        filename="flow2_transport2.gwfgwt",
+    )
+
+    # create iterative model solution and register the gwt model with it
+    imsgwt = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename="transport.ims",
+    )
+    sim.register_ims_package(imsgwt, [gwt1.name, gwt2.name])
+
+    return sim, None
+
+
+def check_output(idx, test):
+    # for now, just check that simulation finishes correctly
+    return
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.developmode
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+    )
+    test.run()

--- a/autotest/test_gwt_adv03_gwtgwt.py
+++ b/autotest/test_gwt_adv03_gwtgwt.py
@@ -60,7 +60,6 @@ def get_gwf_model(sim, gwfname, gwfpath, modelshape, chdspd=None, welspd=None):
     if chdspd is not None:
         chd = flopy.mf6.modflow.mfgwfchd.ModflowGwfchd(
             gwf,
-            # maxbound=len(c),
             stress_period_data=chdspd,
             save_flows=False,
             pname="CHD-1",
@@ -72,7 +71,6 @@ def get_gwf_model(sim, gwfname, gwfpath, modelshape, chdspd=None, welspd=None):
             gwf,
             print_input=True,
             print_flows=True,
-            # maxbound=len(w),
             stress_period_data=welspd,
             save_flows=False,
             auxiliary="CONCENTRATION",

--- a/autotest/test_gwt_adv03_gwtgwt.py
+++ b/autotest/test_gwt_adv03_gwtgwt.py
@@ -2,10 +2,7 @@
 Test gwt-gwt coupling for advection without dispersion.
 """
 
-import os
-
 import flopy
-import numpy as np
 import pytest
 from framework import TestFramework
 

--- a/autotest/test_par_gwt_adv03.py
+++ b/autotest/test_par_gwt_adv03.py
@@ -1,0 +1,28 @@
+"""
+This test reuses the simulation data and config in
+test_gwt_adv03_gwtgwt.py and runs it in parallel mode.
+"""
+
+import pytest
+from framework import TestFramework
+
+cases = ["par_adv03_gwtgwt"]
+
+
+@pytest.mark.parallel
+@pytest.mark.developmode
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    from test_gwt_adv03_gwtgwt import build_models, check_output
+
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        compare=None,
+        parallel=True,
+        ncpus=2,
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -88,3 +88,8 @@ section = "fixes"
 subsection = "solution"
 description = "Fixes a bug first included in version 6.4.2 that has changed the convergence check of the numerical solution. In cases where the linear solver failed to converge, or when it did converge but the STRICT option was active and convergence did not occur on the first iteration, the solution was erroneously considered for overall convergence."
 
+[[items]]
+section = "fixes"
+subsection = "parallel"
+description = "Fixes a memory exception that has occurred when running parallel solute transport on Windows without the dispersion package. The bug has no effect on the simulation results other than permature termination in some cases."
+

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -91,5 +91,5 @@ description = "Fixes a bug first included in version 6.4.2 that has changed the 
 [[items]]
 section = "fixes"
 subsection = "parallel"
-description = "Fixes a memory exception that has occurred when running parallel solute transport on Windows without the dispersion package. The bug has no effect on the simulation results other than permature termination in some cases."
+description = "Fixes a memory exception that has occurred when running parallel solute transport on Windows without the dispersion package. This has no effect on the simulation results other than causing a premature termination in some cases."
 

--- a/src/Distributed/MpiMessageBuilder.f90
+++ b/src/Distributed/MpiMessageBuilder.f90
@@ -828,17 +828,18 @@ contains
 
   subroutine check_map_int1d(mem, map)
     type(MemoryType), pointer :: mem
-    integer, dimension(:), pointer :: map
+    integer, dimension(:), pointer :: map !< ZERO-based map (for creating mpi types)
     ! local
     logical(LGP) :: is_valid
-    integer(I4B) :: min_val, max_val
+    integer(I4B) :: min_idx, max_idx
 
-    if (.not. associated(map) .or. size(map) == 0) return ! nothing to check
+    if (.not. associated(map)) return
+    if (size(map) == 0) return ! nothing to check
 
     ! bounds check
-    min_val = minloc(map, dim=1)
-    max_val = maxloc(map, dim=1)
-    is_valid = max_val <= size(mem%aint1d) .and. min_val > 0
+    min_idx = minval(map) + 1
+    max_idx = maxval(map) + 1
+    is_valid = max_idx <= size(mem%aint1d) .and. min_idx > 0
     if (.not. is_valid) then
       write (*, '(/,4x,4a)') &
         'Error: invalid map in MPI datatype for ', &
@@ -852,16 +853,17 @@ contains
   !< terminates on error.
   subroutine check_map_dbl1d(mem, map)
     type(MemoryType), pointer :: mem !< memory type
-    integer, dimension(:), pointer :: map !< index map or null
+    integer, dimension(:), pointer :: map !< ZERO-based map (for creating mpi types)
     ! local
     logical(LGP) :: is_valid
-    integer(I4B) :: min_val, max_val
+    integer(I4B) :: min_idx, max_idx
 
-    if (.not. associated(map) .or. size(map) == 0) return ! nothing to check
+    if (.not. associated(map)) return
+    if (size(map) == 0) return ! nothing to check
 
-    min_val = minloc(map, dim=1)
-    max_val = maxloc(map, dim=1)
-    is_valid = max_val <= size(mem%adbl1d) .and. min_val > 0
+    min_idx = minval(map) + 1
+    max_idx = maxval(map) + 1
+    is_valid = max_idx <= size(mem%adbl1d) .and. min_idx > 0
     if (.not. is_valid) then
       write (*, '(/,4x,4a)') &
         'Error: invalid map in MPI datatype for ', &
@@ -873,16 +875,17 @@ contains
 
   subroutine check_map_dbl2d(mem, map)
     type(MemoryType), pointer :: mem
-    integer, dimension(:), pointer :: map
+    integer, dimension(:), pointer :: map !< ZERO-based map (for creating mpi types)
     ! local
     logical(LGP) :: is_valid
-    integer(I4B) :: min_val, max_val
+    integer(I4B) :: min_idx, max_idx
 
-    if (.not. associated(map) .or. size(map) == 0) return ! nothing to check
+    if (.not. associated(map)) return
+    if (size(map) == 0) return ! nothing to check
 
-    min_val = minloc(map, dim=1)
-    max_val = maxloc(map, dim=1)
-    is_valid = max_val <= size(mem%adbl2d, dim=2) .and. min_val > 0
+    min_idx = minval(map) + 1
+    max_idx = maxval(map) + 1
+    is_valid = max_idx <= size(mem%adbl2d, 2) .and. min_idx > 0
     if (.not. is_valid) then
       write (*, '(/,4x,4a)') &
         'Error: invalid map in MPI datatype for ', &

--- a/src/Distributed/MpiMessageBuilder.f90
+++ b/src/Distributed/MpiMessageBuilder.f90
@@ -1,5 +1,7 @@
 module MpiMessageBuilderModule
   use KindModule, only: I4B, LGP
+  use ConstantsModule, only: LINELENGTH
+  use SimModule, only: ustop
   use MemoryTypeModule, only: MemoryType
   use STLVecIntModule
   use VirtualBaseModule
@@ -699,6 +701,15 @@ contains
       call ustop()
     end if
 
+    ! sanity check on index maps
+    if (associated(mt%aint1d)) then
+      call check_map_int1d(mt, el_map)
+    else if (associated(mt%adbl1d)) then
+      call check_map_dbl1d(mt, el_map)
+    else if (associated(mt%adbl2d)) then
+      call check_map_dbl2d(mt, el_map)
+    end if
+
   end subroutine get_mpi_datatype
 
   !> @brief Local routine to free elemental mpi data types representing
@@ -814,5 +825,69 @@ contains
     call MPI_Type_commit(el_type, ierr)
 
   end subroutine get_mpitype_for_dbl2d
+
+  subroutine check_map_int1d(mem, map)
+    type(MemoryType), pointer :: mem
+    integer, dimension(:), pointer :: map
+    ! local
+    logical(LGP) :: is_valid
+    integer(I4B) :: min_val, max_val
+
+    if (.not. associated(map)) return ! nothing to check
+
+    ! bounds check
+    min_val = minloc(map, dim=1)
+    max_val = maxloc(map, dim=1)
+    is_valid = max_val <= size(mem%aint1d) .and. min_val > 0
+    if (.not. is_valid) then
+      write (*, '(/,4x,4a)') &
+        'Error: invalid map in MPI datatype for ', &
+        trim(mem%name), ' in ', trim(mem%path)
+      call ustop()
+    end if
+
+  end subroutine check_map_int1d
+
+  subroutine check_map_dbl1d(mem, map)
+    type(MemoryType), pointer :: mem
+    integer, dimension(:), pointer :: map
+    ! local
+    logical(LGP) :: is_valid
+    integer(I4B) :: min_val, max_val
+
+    if (.not. associated(map)) return ! nothing to check
+
+    min_val = minloc(map, dim=1)
+    max_val = maxloc(map, dim=1)
+    is_valid = max_val <= size(mem%adbl1d) .and. min_val > 0
+    if (.not. is_valid) then
+      write (*, '(/,4x,4a)') &
+        'Error: invalid map in MPI datatype for ', &
+        trim(mem%name), ' in ', trim(mem%path)
+      call ustop()
+    end if
+
+  end subroutine check_map_dbl1d
+
+  subroutine check_map_dbl2d(mem, map)
+    type(MemoryType), pointer :: mem
+    integer, dimension(:), pointer :: map
+    ! local
+    logical(LGP) :: is_valid
+    integer(I4B) :: min_val, max_val
+
+    if (.not. associated(map)) return ! nothing to check
+
+    min_val = minloc(map, dim=1)
+    max_val = maxloc(map, dim=1)
+    is_valid = max_val <= size(mem%adbl2d, dim=2) .and. min_val > 0
+    if (.not. is_valid) then
+      write (*, '(/,4x,4a)') &
+        'Error: invalid map in MPI datatype for ', &
+        trim(mem%name), ' in ', trim(mem%path)
+      call ustop()
+    end if
+
+  end subroutine check_map_dbl2d
 
 end module MpiMessageBuilderModule

--- a/src/Distributed/MpiMessageBuilder.f90
+++ b/src/Distributed/MpiMessageBuilder.f90
@@ -701,15 +701,6 @@ contains
       call ustop()
     end if
 
-    ! sanity check on index maps
-    if (associated(mt%aint1d)) then
-      call check_map_int1d(mt, el_map)
-    else if (associated(mt%adbl1d)) then
-      call check_map_dbl1d(mt, el_map)
-    else if (associated(mt%adbl2d)) then
-      call check_map_dbl2d(mt, el_map)
-    end if
-
   end subroutine get_mpi_datatype
 
   !> @brief Local routine to free elemental mpi data types representing
@@ -761,6 +752,9 @@ contains
     ! local
     integer :: ierr
 
+    ! sanity check on map
+    call check_map_int1d(mem, el_map)
+
     call MPI_Get_address(mem%aint1d, el_displ, ierr)
     if (associated(el_map)) then
       call MPI_Type_create_indexed_block( &
@@ -793,6 +787,9 @@ contains
     ! local
     integer :: ierr
 
+    ! sanity check on map
+    call check_map_dbl1d(mem, el_map)
+
     call MPI_Get_address(mem%adbl1d, el_displ, ierr)
     if (associated(el_map)) then
       call MPI_Type_create_indexed_block( &
@@ -812,6 +809,9 @@ contains
     ! local
     integer :: ierr
     integer :: entry_type
+
+    ! sanity check on map
+    call check_map_dbl2d(mem, el_map)
 
     call MPI_Get_address(mem%adbl2d, el_displ, ierr)
     if (associated(el_map)) then
@@ -833,7 +833,7 @@ contains
     logical(LGP) :: is_valid
     integer(I4B) :: min_val, max_val
 
-    if (.not. associated(map)) return ! nothing to check
+    if (.not. associated(map) .or. size(map) == 0) return ! nothing to check
 
     ! bounds check
     min_val = minloc(map, dim=1)
@@ -848,14 +848,16 @@ contains
 
   end subroutine check_map_int1d
 
+  !> @brief Bounds check for index maps,
+  !< terminates on error.
   subroutine check_map_dbl1d(mem, map)
-    type(MemoryType), pointer :: mem
-    integer, dimension(:), pointer :: map
+    type(MemoryType), pointer :: mem !< memory type
+    integer, dimension(:), pointer :: map !< index map or null
     ! local
     logical(LGP) :: is_valid
     integer(I4B) :: min_val, max_val
 
-    if (.not. associated(map)) return ! nothing to check
+    if (.not. associated(map) .or. size(map) == 0) return ! nothing to check
 
     min_val = minloc(map, dim=1)
     max_val = maxloc(map, dim=1)
@@ -876,7 +878,7 @@ contains
     logical(LGP) :: is_valid
     integer(I4B) :: min_val, max_val
 
-    if (.not. associated(map)) return ! nothing to check
+    if (.not. associated(map) .or. size(map) == 0) return ! nothing to check
 
     min_val = minloc(map, dim=1)
     max_val = maxloc(map, dim=1)

--- a/src/Distributed/VirtualGwtModel.f90
+++ b/src/Distributed/VirtualGwtModel.f90
@@ -21,6 +21,7 @@ module VirtualGwtModelModule
     type(VirtualDbl1dType), pointer :: dsp_ath2 => null()
     type(VirtualDbl1dType), pointer :: dsp_atv => null()
     ! FMI
+    type(VirtualIntType), pointer :: fmi_igwfspdis => null()
     type(VirtualDbl1dType), pointer :: fmi_gwfhead => null()
     type(VirtualDbl1dType), pointer :: fmi_gwfsat => null()
     type(VirtualDbl2dType), pointer :: fmi_gwfspdis => null()
@@ -86,6 +87,7 @@ contains
     call this%set(this%dsp_ath1%base(), 'ATH1', 'DSP', MAP_NODE_TYPE)
     call this%set(this%dsp_ath2%base(), 'ATH2', 'DSP', MAP_NODE_TYPE)
     call this%set(this%dsp_atv%base(), 'ATV', 'DSP', MAP_NODE_TYPE)
+    call this%set(this%fmi_igwfspdis%base(), 'IGWFSPDIS', 'FMI', MAP_ALL_TYPE)
     call this%set(this%fmi_gwfhead%base(), 'GWFHEAD', 'FMI', MAP_NODE_TYPE)
     call this%set(this%fmi_gwfsat%base(), 'GWFSAT', 'FMI', MAP_NODE_TYPE)
     call this%set(this%fmi_gwfspdis%base(), 'GWFSPDIS', 'FMI', MAP_NODE_TYPE)
@@ -120,6 +122,7 @@ contains
       nr_nodes = this%element_maps(MAP_NODE_TYPE)%nr_virt_elems
       nr_conns = this%element_maps(MAP_CONN_TYPE)%nr_virt_elems
 
+      call this%map(this%fmi_igwfspdis%base(), (/STG_BFR_CON_AR/))
       call this%map(this%x%base(), nr_nodes, &
                     (/STG_BFR_CON_AR, STG_BFR_EXG_AD, STG_BFR_EXG_CF/))
       call this%map(this%ibound%base(), nr_nodes, (/STG_BFR_CON_AR/))
@@ -136,14 +139,23 @@ contains
         call this%map(this%dsp_atv%base(), nr_nodes, (/STG_BFR_CON_AR/))
       end if
 
-      call this%map(this%fmi_gwfhead%base(), nr_nodes, (/STG_BFR_EXG_AD/))
-      call this%map(this%fmi_gwfsat%base(), nr_nodes, (/STG_BFR_EXG_AD/))
-      call this%map(this%fmi_gwfspdis%base(), 3, nr_nodes, (/STG_BFR_EXG_AD/))
-      call this%map(this%fmi_gwfflowja%base(), nr_conns, (/STG_BFR_EXG_AD/))
-
       if (this%indsp%get() > 0 .and. this%inmst%get() > 0) then
         call this%map(this%mst_thetam%base(), nr_nodes, (/STG_AFT_CON_AR/))
       end if
+
+    else if (stage == STG_AFT_CON_AR) then
+
+      nr_nodes = this%element_maps(MAP_NODE_TYPE)%nr_virt_elems
+      nr_conns = this%element_maps(MAP_CONN_TYPE)%nr_virt_elems
+
+      call this%map(this%fmi_gwfhead%base(), nr_nodes, (/STG_BFR_EXG_AD/))
+      call this%map(this%fmi_gwfsat%base(), nr_nodes, (/STG_BFR_EXG_AD/))
+      if (this%fmi_igwfspdis%get() > 0) then
+        call this%map(this%fmi_gwfspdis%base(), 3, nr_nodes, (/STG_BFR_EXG_AD/))
+      else
+        call this%map(this%fmi_gwfspdis%base(), 3, 0, (/STG_NEVER/))
+      end if
+      call this%map(this%fmi_gwfflowja%base(), nr_conns, (/STG_BFR_EXG_AD/))
 
     end if
 
@@ -160,6 +172,7 @@ contains
     allocate (this%dsp_ath1)
     allocate (this%dsp_ath2)
     allocate (this%dsp_atv)
+    allocate (this%fmi_igwfspdis)
     allocate (this%fmi_gwfhead)
     allocate (this%fmi_gwfsat)
     allocate (this%fmi_gwfspdis)
@@ -181,6 +194,7 @@ contains
     deallocate (this%dsp_ath1)
     deallocate (this%dsp_ath2)
     deallocate (this%dsp_atv)
+    deallocate (this%fmi_igwfspdis)
     deallocate (this%fmi_gwfhead)
     deallocate (this%fmi_gwfsat)
     deallocate (this%fmi_gwfspdis)

--- a/src/Exchange/exg-gwfgwe.f90
+++ b/src/Exchange/exg-gwfgwe.f90
@@ -269,6 +269,7 @@ contains
     call mem_checkin(gwemodel%fmi%gwfspdis, &
                      'GWFSPDIS', gwemodel%fmi%memoryPath, &
                      'SPDIS', gwfmodel%npf%memoryPath)
+    gwemodel%fmi%igwfspdis = gwfmodel%npf%icalcspdis
     !
     ! -- setup pointers to the flow storage rates. GWF strg arrays are
     !    available after the gwf_ar routine is called.

--- a/src/Exchange/exg-gwfgwt.f90
+++ b/src/Exchange/exg-gwfgwt.f90
@@ -272,6 +272,7 @@ contains
     call mem_checkin(gwtmodel%fmi%gwfspdis, &
                      'GWFSPDIS', gwtmodel%fmi%memoryPath, &
                      'SPDIS', gwfmodel%npf%memoryPath)
+    gwtmodel%fmi%igwfspdis = gwfmodel%npf%icalcspdis
     !
     ! -- setup pointers to the flow storage rates. GWF strg arrays are
     !    available after the gwf_ar routine is called.

--- a/src/Model/ModelUtilities/FlowModelInterface.f90
+++ b/src/Model/ModelUtilities/FlowModelInterface.f90
@@ -34,6 +34,7 @@ module FlowModelInterfaceModule
     integer(I4B), pointer :: idryinactive => null() !< mark cells with an additional flag to exclude from deactivation (gwe will simulate conduction through dry cells)
     real(DP), dimension(:), pointer, contiguous :: gwfstrgss => null() !< pointer to flow model QSTOSS
     real(DP), dimension(:), pointer, contiguous :: gwfstrgsy => null() !< pointer to flow model QSTOSY
+    integer(I4B), pointer :: igwfspdis => null() !< indicates if gwfspdis is available
     integer(I4B), pointer :: igwfstrgss => null() !< indicates if gwfstrgss is available
     integer(I4B), pointer :: igwfstrgsy => null() !< indicates if gwfstrgsy is available
     integer(I4B), pointer :: iubud => null() !< unit number GWF budget file
@@ -179,6 +180,7 @@ contains
     ! -- deallocate scalars
     call mem_deallocate(this%flows_from_file)
     call mem_deallocate(this%iflowsupdated)
+    call mem_deallocate(this%igwfspdis)
     call mem_deallocate(this%igwfstrgss)
     call mem_deallocate(this%igwfstrgsy)
     call mem_deallocate(this%iubud)
@@ -208,6 +210,7 @@ contains
     ! -- Allocate
     call mem_allocate(this%flows_from_file, 'FLOWS_FROM_FILE', this%memoryPath)
     call mem_allocate(this%iflowsupdated, 'IFLOWSUPDATED', this%memoryPath)
+    call mem_allocate(this%igwfspdis, 'IGWFSPDIS', this%memoryPath)
     call mem_allocate(this%igwfstrgss, 'IGWFSTRGSS', this%memoryPath)
     call mem_allocate(this%igwfstrgsy, 'IGWFSTRGSY', this%memoryPath)
     call mem_allocate(this%iubud, 'IUBUD', this%memoryPath)
@@ -221,6 +224,7 @@ contains
     ! -- Initialize
     this%flows_from_file = .true.
     this%iflowsupdated = 1
+    this%igwfspdis = 0
     this%igwfstrgss = 0
     this%igwfstrgsy = 0
     this%iubud = 0
@@ -857,6 +861,7 @@ contains
         found_flowja = .true.
       case ('DATA-SPDIS')
         found_dataspdis = .true.
+        this%igwfspdis = 1
       case ('DATA-SAT')
         found_datasat = .true.
       case ('STO-SS')


### PR DESCRIPTION
When specific discharge is not calculated by NPF, it cannot be synchronized across parallel processes. This PR adds a flag to indicate if the data is available or not.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
