### PR TITLE
build: update meson build to generate static mf6 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,11 +175,13 @@ jobs:
         working-directory: ntldd
         run: |
           echo "Checking dependencies with ntldd..."
+          set +e
           ./ntldd.exe ../bin/mf6.exe > mf6.dependencies.txt
 
           dep_count=$(grep -vc "KERNEL32.dll" mf6.dependencies.txt)
           echo "Number of dependencies: $dep_count"
 
+          set -e
           if [ "$dep_count" -eq 0 ]; then
             echo mf6.exe is statically linked
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,9 +153,14 @@ jobs:
 
       - name: Confirm modflow6 has no dependencies
         if: runner.os == 'Linux'
-        continue-on-error: true
         run: |
           ldd bin/mf6
+          if ldd bin/mf6; then
+              echo mf6 is dynamically linked
+              exit 1
+          else
+              echo mf6 is statically linked
+          fi
 
   smoke_test:
     name: Smoke test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,10 +151,20 @@ jobs:
       - name: Unit test MF6
         run: pixi run test builddir
 
-      - name: Confirm modflow6 has no dependencies
+      - name: Confirm modflow6 has no dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
           if ldd bin/mf6; then
+              echo mf6 is dynamically linked
+              exit 1
+          else
+              echo mf6 is statically linked
+          fi
+
+      - name: Confirm modflow6 has no dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          if ntldd bin/mf6; then
               echo mf6 is dynamically linked
               exit 1
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,12 +176,11 @@ jobs:
         run: |
           echo "Checking dependencies with ntldd..."
           ./ntldd.exe ../bin/mf6.exe > mf6.dependencies.txt
-          cat mf6.dependencies.txt
-          if ./ntldd.exe ../bin/mf6.exe; then
+          if grep -v -c "KERNEL32.dll" mf6.dependencies.txt; then
+              echo mf6.exe is statically linked
+          else
               echo mf6.exe is dynamically linked
               exit 1
-          else
-              echo mf6.exe is statically linked
           fi
 
   smoke_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         run: |
           curl -LO "https://www.dependencywalker.com/depends22_x64.zip"
           7z x depends22_x64.zip
-          .\depends.exe /c /ot:depends.txt bin/mf6.exe
+           depends22_x64/depends.exe /c /ot:depends.txt bin/mf6.exe
           cat depends.txt          
 
   smoke_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           pixi-version: v0.41.4
 
       - name: Setup static MF6
-        run: pixi run setup -Dwerror=true -Dstatic_gfortran builddir
+        run: pixi run setup -Dwerror=true -Dstatic_gfortran=true builddir
 
       - name: Build MF6
         run: pixi run build builddir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,27 +162,19 @@ jobs:
               echo mf6 is statically linked
           fi
 
-      - name: Setup MSYS2 and install ntldd
+      - name: Clone ntldd repository and build
         if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: UCRT64
-          update: true
-          # The ntldd package needs to be installed for the target msystem
-          install: mingw-w64-ucrt-x86_64-ntldd-git
-
-      - name: Perform build and use ntldd
-        if: runner.os == 'Windows'
-        # The shell is automatically set to the MSYS2 environment
-        # so you can use standard bash commands and utilities.
-        shell: msys2 {0}
         run: |
-          echo "Building your project..."
-          # Replace the next lines with your actual build commands
-          g++ -o my_program.exe my_program.cpp
+          git clone https://github.com/LRN/ntldd.git
+          cd ntldd
+          ./makeldd.sh
 
+      - name: Confirm modflow6 has no dependencies (Windows)
+        if: runner.os == 'Windows'
+        working-directory: ntldd
+        run: |
           echo "Checking dependencies with ntldd..."
-          if ntldd bin/mf6.exe; then
+          if ntldd ../bin/mf6.exe; then
               echo mf6.exe is dynamically linked
               exit 1
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,8 @@ jobs:
         working-directory: ntldd
         run: |
           echo "Checking dependencies with ntldd..."
+          ./ntldd.exe ../bin/mf6.exe > mf6.dependencies.txt
+          cat mf6.dependencies.txt
           if ./ntldd.exe ../bin/mf6.exe; then
               echo mf6.exe is dynamically linked
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,9 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           curl -LO "https://www.dependencywalker.com/depends22_x64.zip"
-          7z x depends22_x64.zip
-           depends22_x64/depends.exe /c /ot:depends.txt bin/mf6.exe
+          7z e depends22_x64.zip
+          ls -lh *.exe
+          depends.exe /c /ot:depends.txt bin/mf6.exe
           cat depends.txt          
 
   smoke_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,13 +168,14 @@ jobs:
           git clone https://github.com/LRN/ntldd.git
           cd ntldd
           ./makeldd.sh
+          ls -lha
 
       - name: Confirm modflow6 has no dependencies (Windows)
         if: runner.os == 'Windows'
         working-directory: ntldd
         run: |
           echo "Checking dependencies with ntldd..."
-          if ntldd ../bin/mf6.exe; then
+          if ./ntldd.exe ../bin/mf6.exe; then
               echo mf6.exe is dynamically linked
               exit 1
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,6 @@ jobs:
       - name: Confirm modflow6 has no dependencies
         if: runner.os == 'Linux'
         run: |
-          ldd bin/mf6
           if ldd bin/mf6; then
               echo mf6 is dynamically linked
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: pixi run test builddir
 
   build-static:
-    name: Build
+    name: Static Build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,11 +176,14 @@ jobs:
         run: |
           echo "Checking dependencies with ntldd..."
           ./ntldd.exe ../bin/mf6.exe > mf6.dependencies.txt
-          if grep -v -c "KERNEL32.dll" mf6.dependencies.txt; then
-              echo mf6.exe is statically linked
+
+          dep_count=$(grep -vc "KERNEL32.dll" mf6.dependencies.txt)
+          echo "Number of dependencies: $dep_count"
+          if ! dep_count; then
+            echo mf6.exe is statically linked
           else
-              echo mf6.exe is dynamically linked
-              exit 1
+            echo mf6.exe is dynamically linked
+            echo exit 1
           fi
 
   smoke_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,8 @@ jobs:
 
           dep_count=$(grep -vc "KERNEL32.dll" mf6.dependencies.txt)
           echo "Number of dependencies: $dep_count"
-          if ! dep_count; then
+
+          if [ "$dep_count" -eq 0 ]; then
             echo mf6.exe is statically linked
           else
             echo mf6.exe is dynamically linked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: pixi run test builddir
 
   build-static:
-    name: Static Build
+    name: Static gcc build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
           curl -LO "https://www.dependencywalker.com/depends22_x64.zip"
           7z e depends22_x64.zip
           ls -lh *.exe
-          depends.exe /c /ot:depends.txt bin/mf6.exe
+          ./depends.exe /c /ot:depends.txt bin/mf6.exe
           cat depends.txt          
 
   smoke_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,55 @@ jobs:
       - name: Unit test MF6
         run: pixi run test builddir
 
+  build-static:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+          - os: windows-2022
+    defaults:
+      run:
+        shell: bash
+    env:
+      FC: gfortran
+      FC_V: 13
+    steps:
+      - name: Checkout MF6
+        uses: actions/checkout@v5
+
+      - name: Setup ${{ env.FC }} ${{ env.FC_V }}
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: gcc
+          version: ${{ env.FC_V }}
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.0
+        with:
+          pixi-version: v0.41.4
+
+      - name: Setup static MF6
+        run: pixi run setup -Dwerror=true -Dstatic_gfortran builddir
+
+      - name: Build MF6
+        run: pixi run build builddir
+
+      - name: Show build log
+        if: failure()
+        run: cat builddir/meson-logs/meson-log.txt
+
+      - name: Unit test MF6
+        run: pixi run test builddir
+
+      - name: Confirm modflow6 has no dependencies
+        if: runner.os == 'Linux'
+        continue-on-error: true
+        run: |
+          ldd bin/mf6
+
   smoke_test:
     name: Smoke test
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,10 @@ jobs:
       - name: Confirm modflow6 has no dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          if ntldd bin/mf6; then
-              echo mf6 is dynamically linked
-              exit 1
-          else
-              echo mf6 is statically linked
-          fi
+          curl -LO "https://www.dependencywalker.com/depends22_x64.zip"
+          7z x depends22_x64.zip
+          .\depends.exe /c /ot:depends.txt bin/mf6.exe
+          cat depends.txt          
 
   smoke_test:
     name: Smoke test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
       - name: Confirm modflow6 has no dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          echo "Checking dependencies with ldd..."
           if ldd bin/mf6; then
               echo mf6 is dynamically linked
               exit 1
@@ -161,16 +162,32 @@ jobs:
               echo mf6 is statically linked
           fi
 
-      - name: Confirm modflow6 has no dependencies (Windows)
+      - name: Setup MSYS2 and install ntldd
         if: runner.os == 'Windows'
-        working-directory: bin
-        shell: cmd
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          # The ntldd package needs to be installed for the target msystem
+          install: mingw-w64-ucrt-x86_64-ntldd-git
+
+      - name: Perform build and use ntldd
+        if: runner.os == 'Windows'
+        # The shell is automatically set to the MSYS2 environment
+        # so you can use standard bash commands and utilities.
+        shell: msys2 {0}
         run: |
-          curl -LO "https://www.dependencywalker.com/depends22_x64.zip"
-          tar -xf depends22_x64.zip
-          ls -lh *.exe
-          depends.exe /c /ot:depends.txt mf6.exe
-          cat depends.txt          
+          echo "Building your project..."
+          # Replace the next lines with your actual build commands
+          g++ -o my_program.exe my_program.cpp
+
+          echo "Checking dependencies with ntldd..."
+          if ntldd bin/mf6.exe; then
+              echo mf6.exe is dynamically linked
+              exit 1
+          else
+              echo mf6.exe is statically linked
+          fi
 
   smoke_test:
     name: Smoke test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           pixi-version: v0.41.4
 
       - name: Setup static MF6
-        run: pixi run setup -Dwerror=true -Dstatic_gfortran=true builddir
+        run: pixi run setup -Dwerror=true -Ddefault_library=static builddir
 
       - name: Build MF6
         run: pixi run build builddir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,11 +163,13 @@ jobs:
 
       - name: Confirm modflow6 has no dependencies (Windows)
         if: runner.os == 'Windows'
+        working-directory: bin
+        shell: cmd
         run: |
           curl -LO "https://www.dependencywalker.com/depends22_x64.zip"
-          7z e depends22_x64.zip
+          tar -xf depends22_x64.zip
           ls -lh *.exe
-          ./depends.exe /c /ot:depends.txt bin/mf6.exe
+          depends.exe /c /ot:depends.txt mf6.exe
           cat depends.txt          
 
   smoke_test:

--- a/meson.build
+++ b/meson.build
@@ -223,8 +223,13 @@ if fc_id == 'gcc'
   endif
 endif
 
-is_static_build = get_option('static_gfortran')
-message('Static_build option', is_static_build)
+proj_default_library = get_option('default_library')
+if proj_default_library == 'static'
+  is_static_build = true
+  message('MODFLOW 6 will be statically linked')
+else
+  is_static_build = false
+endif
 if is_static_build
   if is_extended_build or is_parallel_build or is_netcdf_build
     if is_static_build
@@ -286,7 +291,7 @@ buildname = get_option('buildname')
 subdir('src')
 
 if is_static_build
-  message('Cannot build libmf6 if static_gfortran is specified')
+  message('Cannot build libmf6 if default_library is specified')
 else
   subdir('srcbmi')
 endif

--- a/meson.build
+++ b/meson.build
@@ -295,9 +295,11 @@ endif
 subdir('utils/zonebudget')
 
 # add autotest directory
-fs = import('fs')
-if fs.is_dir('autotest')
-  subdir('autotest')
+if not is_static_build
+  fs = import('fs')
+  if fs.is_dir('autotest')
+    subdir('autotest')
+  endif
 endif
 
 # meson tests to evaluate installation success

--- a/meson.build
+++ b/meson.build
@@ -223,6 +223,34 @@ if fc_id == 'gcc'
   endif
 endif
 
+is_static_build = get_option('static_gfortran')
+message('Static_build option', is_static_build)
+if is_static_build
+  if is_extended_build or is_parallel_build or is_netcdf_build
+    if is_static_build
+      is_static_build = false
+      message('Resetting static_build option for extended build')
+    endif
+  else
+    if fc_id != 'gcc'
+      is_static_build = false
+      message('Resetting static_build option for non-gcc compiler')
+    elif system == 'darwin'
+      is_static_build = false
+      message('Resetting static_build option for gcc compiler on darwin')
+    endif
+  endif
+endif
+
+if is_static_build
+  compile_args += '-static'
+  link_args += ['-static', 
+                '-static-libgfortran',
+                '-static-libgcc',
+                '-static-libstdc++',
+              ]
+endif
+
 compile_args += extra_cmp_args
 
 add_project_arguments(fc.get_supported_arguments(compile_args), language: 'fortran')
@@ -256,9 +284,14 @@ endif
 # build mf6 and libmf6
 buildname = get_option('buildname')
 subdir('src')
-subdir('srcbmi')
 
-# build zbud6 and mf5to6 utility programs
+if is_static_build
+  message('Cannot build libmf6 if static_gfortran is specified')
+else
+  subdir('srcbmi')
+endif
+
+# build zbud6 utility program
 subdir('utils/zonebudget')
 
 # add autotest directory

--- a/meson.build
+++ b/meson.build
@@ -226,28 +226,26 @@ endif
 proj_default_library = get_option('default_library')
 if proj_default_library == 'static'
   is_static_build = true
-  message('MODFLOW 6 will be statically linked')
 else
   is_static_build = false
 endif
+
+# test for invalid configurations
 if is_static_build
-  if is_extended_build or is_parallel_build or is_netcdf_build
-    if is_static_build
-      is_static_build = false
-      message('Resetting static_build option for extended build')
-    endif
+  require_shared_libraries = is_extended_build or is_parallel_build or is_netcdf_build
+  if require_shared_libraries
+    assert(false, 'default_library=static not valid for extended build')
   else
     if fc_id != 'gcc'
-      is_static_build = false
-      message('Resetting static_build option for non-gcc compiler')
+      assert(false, 'default_library=static not valid for non-gcc compiler')
     elif system == 'darwin'
-      is_static_build = false
-      message('Resetting static_build option for gcc compiler on darwin')
+      assert(false, 'default_library=static not valid for gcc compiler on darwin')
     endif
   endif
 endif
 
 if is_static_build
+  message('MODFLOW 6 will be statically linked')
   compile_args += '-static'
   link_args += ['-static', 
                 '-static-libgfortran',

--- a/meson.options
+++ b/meson.options
@@ -4,3 +4,4 @@ option('netcdf', type : 'boolean', value : false, description : 'Extended NetCDF
 option('mpich', type : 'boolean', value : false, description : 'Use MPICH version of MPI')
 option('cray', type : 'boolean', value : false, description : 'Extended build on CRAY with MPICH')
 option('buildname', type : 'string', value : 'mf6', description : 'Optional build name')
+option('static_gfortran', type : 'boolean', value : false, description : 'Static gfortran build')

--- a/meson.options
+++ b/meson.options
@@ -4,4 +4,3 @@ option('netcdf', type : 'boolean', value : false, description : 'Extended NetCDF
 option('mpich', type : 'boolean', value : false, description : 'Use MPICH version of MPI')
 option('cray', type : 'boolean', value : false, description : 'Extended build on CRAY with MPICH')
 option('buildname', type : 'string', value : 'mf6', description : 'Optional build name')
-option('static_gfortran', type : 'boolean', value : false, description : 'Static gfortran build')


### PR DESCRIPTION
Update meson.build to build statically linked versions of MODFLOW6 and ZBUD6 on linux and windows. Add GitHub Actions step to test static build.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Added new test or modified an existing test
- [X] Updated meson files, makefiles, and Visual Studio project files for new source files
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
