### PR TITLE
fix(prt): stop only at assigned boundary faces with outflow

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -96,4 +96,4 @@ description = "Fixes a memory exception that has occurred when running parallel 
 [[item]]
 section = "fixes"
 subsection = "solution"
-description = "The PRT Model has previously been aware of boundary cell flows but not boundary faces. When an internal boundary face is assigned (an IFLOWFACE adjacent to another active cell), this can lead to cycles (infinite loops) in the particle's pathline, as the two adjacent cells fail to agree on the flow through their shared face. The PRT Model will now terminate particles at assigned boundary faces whether they are internal or external."
+description = "The PRT Model has previously been aware of boundary cell flows but not boundary faces. When an internal boundary face is assigned (an IFLOWFACE adjacent to another active cell), this can lead to cycles (infinite loops) in the particle's pathline, as the two adjacent cells fail to agree on the flow through their shared face. The PRT Model will now terminate particles at assigned boundary faces, whether they are internal or external, if the net boundary flow through the face is out of the cell."

--- a/src/Solution/ParticleTracker/Method/MethodDis.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDis.f90
@@ -295,7 +295,7 @@ contains
       cell => c
       iface = particle%iboundary(LEVEL_FEATURE)
       no_neighbors = cell%defn%facenbr(iface) == 0
-      at_boundary = this%fmi%is_boundary_face(cell%defn%icell, iface)
+      at_boundary = this%fmi%is_net_out_boundary_face(cell%defn%icell, iface)
 
       ! todo AMP: reconsider when multiple models supported
       if (no_neighbors .or. at_boundary) then

--- a/src/Solution/ParticleTracker/Method/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDisv.f90
@@ -232,7 +232,7 @@ contains
       cell => c
       iface = particle%iboundary(LEVEL_FEATURE)
       no_neighbors = cell%defn%facenbr(iface) == 0
-      at_boundary = this%fmi%is_boundary_face(cell%defn%icell, iface)
+      at_boundary = this%fmi%is_net_out_boundary_face(cell%defn%icell, iface)
 
       ! todo AMP: reconsider when multiple models supported
       if (no_neighbors .or. at_boundary) then


### PR DESCRIPTION
Revise #2475. Only stop if the boundary flow through a face is out of the cell. Inwards flow at boundaries is not a termination condition (e.g. recharge, EVT). Caught by PRT/MP7 example 1, motivating addition of a [snapshot test](https://github.com/MODFLOW-ORG/modflow6-examples/pull/290). CI is subject to chicken/egg problems which will resolve shortly