### PR TITLE
fix(prt): fix multiple issues

### DIFF
--- a/src/Model/ParticleTracking/prt-fmi.f90
+++ b/src/Model/ParticleTracking/prt-fmi.f90
@@ -183,7 +183,8 @@ contains
       end if
       do ib = 1, this%gwfpackages(ip)%nbound
         i = this%gwfpackages(ip)%nodelist(ib)
-        if (i <= 0 .or. this%ibound(i) <= 0) cycle
+        if (i <= 0) cycle
+        if (this%ibound(i) <= 0) cycle
         qbnd = this%gwfpackages(ip)%get_flow(ib)
         ! todo, after initial release: default iflowface values for different packages
         iflowface = 0 ! iflowface number

--- a/src/Solution/ParticleTracker/Particle/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle/Particle.f90
@@ -88,10 +88,8 @@ module ParticleModule
     real(DP), public :: zorigin !< z origin for coordinate transformation from model to local
     real(DP), public :: sinrot !< sine of rotation angle for coordinate transformation from model to local
     real(DP), public :: cosrot !< cosine of rotation angle for coordinate transformation from model to local
-
     logical(LGP), public :: transformed !< whether coordinates have been transformed from model to local
     logical(LGP), public :: advancing !< whether particle is still being tracked for current time step
-
     type(ListType), public, pointer :: history !< history of particle positions (for cycle detection)
   contains
     procedure, public :: destroy => destroy_particle


### PR DESCRIPTION
Dumbo fixes, fixes for the fixes

- #2482 broke prt fmi, fortran doesn't short-circuit conditionals
- #2475 and #2492 weren't merged properly, causing non-top assigned boundary faces to be missed for termination
- also make sure we raise a cell exit event before termination if a particle stops at an assigned boundary face

@mnfienen this should finally greenlight your model