### PR TITLE
fix(prt): consistent behavior at top of partly saturated cells

### DIFF
--- a/src/Model/ParticleTracking/prt-fmi.f90
+++ b/src/Model/ParticleTracking/prt-fmi.f90
@@ -273,30 +273,12 @@ contains
     integer(I4B), intent(in) :: iface !< face number
     logical(LGP) :: is_net_out_boundary
     ! local
-    integer(I4B) :: bit_pos
     integer(I4B) :: ioffset
 
     is_net_out_boundary = .false.
-    if (ic <= 0 .or. ic > this%dis%nodes) then
-      print *, 'Invalid cell number: ', ic
-      print *, 'Expected a value in range [1, ', this%dis%nodes, ']'
-      call pstop(1)
-    end if
-    if (iface <= 0) then
-      print *, 'Invalid face number: ', iface
-      print *, 'Expected a value in range [1, ', this%max_faces, ']'
-      call pstop(1)
-    end if
-    bit_pos = iface - 1 ! bit position 0-based
-    if (bit_pos < 0 .or. bit_pos > 31) then
-      print *, 'Invalid bitmask position: ', iface
-      print *, 'Expected a value in range [0, 31]'
-      call pstop(1)
-    end if
-    if (.not. btest(this%BoundaryFaces(ic), bit_pos)) return
+    if (.not. this%is_boundary_face(ic, iface)) return
     ioffset = (ic - 1) * this%max_faces
-    if (this%BoundaryFlows(ioffset + iface) < DZERO) &
-      is_net_out_boundary = .true.
+    if (this%BoundaryFlows(ioffset + iface) < DZERO) is_net_out_boundary = .true.
   end function is_net_out_boundary_face
 
 end module PrtFmiModule

--- a/src/Solution/ParticleTracker/Method/MethodCellTernary.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCellTernary.f90
@@ -251,28 +251,11 @@ contains
     type(ParticleType), pointer, intent(inout) :: particle
     class(SubcellTriType), intent(inout) :: subcell
     ! local
-    integer(I4B) :: ic
-    integer(I4B) :: isc
-    integer(I4B) :: iv0
-    real(DP) :: x0
-    real(DP) :: y0
-    real(DP) :: x1
-    real(DP) :: y1
-    real(DP) :: x2
-    real(DP) :: y2
-    real(DP) :: x1rel
-    real(DP) :: y1rel
-    real(DP) :: x2rel
-    real(DP) :: y2rel
-    real(DP) :: xi
-    real(DP) :: yi
-    real(DP) :: di2
-    real(DP) :: d02
-    real(DP) :: d12
-    real(DP) :: di1
-    real(DP) :: d01
-    real(DP) :: alphai
-    real(DP) :: betai
+    integer(I4B) :: ic, isc, iv0
+    real(DP) :: x0, y0, x1, y1, x2, y2, xi, yi
+    real(DP) :: x1rel, y1rel, x2rel, y2rel
+    real(DP) :: di2, d02, d12, di1, d01
+    real(DP) :: alphai, betai
 
     select type (cell => this%cell)
     type is (CellPolyType)

--- a/src/Solution/ParticleTracker/Method/MethodDis.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDis.f90
@@ -276,17 +276,17 @@ contains
     ! local
     type(CellRectType), pointer :: cell
     integer(I4B) :: iface
-    logical(LGP) :: at_boundary, no_neighbors
+    logical(LGP) :: at_bnd_face, no_neighbors
 
     select type (c => this%cell)
     type is (CellRectType)
       cell => c
       iface = particle%iboundary(LEVEL_FEATURE)
       no_neighbors = cell%defn%facenbr(iface) == 0
-      at_boundary = this%fmi%is_net_out_boundary_face(cell%defn%icell, iface)
+      at_bnd_face = this%fmi%is_net_out_boundary_face(cell%defn%icell, iface)
 
       ! todo AMP: reconsider when multiple models supported
-      if (no_neighbors .or. at_boundary) then
+      if (no_neighbors .or. at_bnd_face) then
         call this%terminate(particle, status=TERM_BOUNDARY)
         return
       end if

--- a/src/Solution/ParticleTracker/Method/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDisv.f90
@@ -214,17 +214,17 @@ contains
     ! local
     type(CellPolyType), pointer :: cell
     integer(I4B) :: iface
-    logical(LGP) :: at_boundary, no_neighbors
+    logical(LGP) :: at_bnd_face, no_neighbors
 
     select type (c => this%cell)
     type is (CellPolyType)
       cell => c
       iface = particle%iboundary(LEVEL_FEATURE)
       no_neighbors = cell%defn%facenbr(iface) == 0
-      at_boundary = this%fmi%is_net_out_boundary_face(cell%defn%icell, iface)
+      at_bnd_face = this%fmi%is_net_out_boundary_face(cell%defn%icell, iface)
 
       ! todo AMP: reconsider when multiple models supported
-      if (no_neighbors .or. at_boundary) then
+      if (no_neighbors .or. at_bnd_face) then
         call this%terminate(particle, status=TERM_BOUNDARY)
         return
       end if


### PR DESCRIPTION
Discussion has been had regarding behavior at the water table. This may be refined in future.

Behavior just introduced in #2478 and #2495 keeps particles immobile/active at the water table if they reach it from below with `DRY_TRACKING_METHOD DROP` or `STAY`, while with `STOP` particles would terminate on reaching the water table. This is in hindsight overfitting to the expected Keating result at the expense of design aims

It seems more correct to interpret `DRY_TRACKING_METHOD` as only applying to particles which are dry after the flow solution is available, before the particle track is solved for the time step. Trying to find distinct interpretations in various contexts *within* the tracking method, e.g. if a particle obtains a valid exit solution through the "top" (i.e. water table) of a partially saturated cell, could explode the scope of the dry tracking method option so seems best avoided

With this, particles terminate if they reach the water table from below. This is consistent with MP7. `DRY_TRACKING_METHOD` applies only if the water table drops below them during the simulation, or if particles are released above the water table into a Newton flow system.

This does imply accepting some particles will stop early in Keating for some compilers and optimization options; numerical noise in the flow solution will try to send some of them back upwards after they drop to the water table, so they fall straight to water and terminate. Most will keep doing the "waterfall"/cascade down the sides of the perched aquifer as we expect. Maybe the flow system can be tweaked to fix the noisy flows and get them all to cooperate?

Separately, recent commits got a face numbering calculation in `MethodCell.f90` wrong in the general case, but in such a way as to happen to work for the rectilinear case

Also miscellaneous cleanup