### PR TITLE
chore: support prerelease attribute in dfns, guard prerelease features

### DIFF
--- a/autotest/test_gwt_dvscale.py
+++ b/autotest/test_gwt_dvscale.py
@@ -249,6 +249,7 @@ def check_results(test):
     )
 
 
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dvscale_fail.py
+++ b/autotest/test_gwt_dvscale_fail.py
@@ -1,6 +1,6 @@
 """
 Test the dependent_variable_scale option to make sure modflow fails if the option
-is not specified for all gwt/gwe models in the same IMS solution. Tested for for a
+is not specified for all gwt/gwe models in the same IMS solution. Tested for a
 one-dimensional model grid of square cells.
 """
 
@@ -221,6 +221,7 @@ def build_models(idx, test):
     return sim, None
 
 
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_src02_ha.py
+++ b/autotest/test_gwt_src02_ha.py
@@ -246,6 +246,7 @@ def check_output(idx, test):
     assert np.array_equal(nodes, nodes_ans), "src nodes not based on saturation"
 
 
+@pytest.mark.developmode # TODO remove for 6.7.0
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
@@ -98,6 +98,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 # --------------------- chf disv1d dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
@@ -109,6 +109,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 block options
 name ncf_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwe-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-disu.dfn
@@ -108,6 +108,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 # --------------------- gwe disu dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
@@ -109,6 +109,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 block options
 name ncf_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwe-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-nam.dfn
@@ -41,6 +41,7 @@ optional true
 longname flag to scale X and RHS
 description flag to scale X and RHS to avoid very large positive or negative dependent variable values
 mf6internal idv_scale
+prerelease true
 
 block options
 name nc_mesh2d_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
@@ -109,6 +109,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 block options
 name ncf_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
@@ -108,6 +108,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 # --------------------- gwf disu dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
@@ -109,6 +109,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 block options
 name ncf_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
@@ -109,6 +109,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 block options
 name ncf_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
@@ -108,6 +108,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 # --------------------- gwt disu dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
@@ -109,6 +109,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 block options
 name ncf_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwt-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-nam.dfn
@@ -41,6 +41,7 @@ optional true
 longname flag to scale X and RHS
 description flag to scale X and RHS to avoid very large positive or negative dependent variable values
 mf6internal idv_scale
+prerelease true
 
 block options
 name nc_mesh2d_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwt-src.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-src.dfn
@@ -138,7 +138,7 @@ optional true
 mf6internal highest_sat
 longname apply source to highest saturated cell
 description Apply mass source loading rate to specified CELLID or highest underlying cell with a cell saturation greater than zero. The highest\_saturated option has an additional complication for certain types of grids specified using the DISU Package. When the DISU Package is used, a cell may have more than one cell underlying it. If the overlying cell were to become inactive, there is no straightforward method for determining how to apportion the mass source loading rate to the underlying cells. In this case, the approach described by \cite{modflowusg} is used. The mass source loading rate is assigned to the first active cell encountered (determined by searching through the underlying cell numbers from the lowest number to the highest number). In this manner, the total mass source loading rate is conserved; however, the spatial distribution of the applied mass source loading rate may not be maintained as layers become dry or wet during a simulation.
-
+prerelease true
 
 
 # --------------------- gwt src dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/olf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-dis2d.dfn
@@ -98,6 +98,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 # --------------------- olf dis2d dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/olf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-disv1d.dfn
@@ -98,6 +98,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 # --------------------- olf disv1d dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/olf-disv2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-disv2d.dfn
@@ -98,6 +98,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 # --------------------- olf disv2d dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
@@ -107,6 +107,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 block options
 name ncf_filerecord

--- a/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
@@ -107,6 +107,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 block options
 name ncf_filerecord

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -294,6 +294,7 @@ mf6internal ichkmeth
 longname coordinate checking method
 description approach for verifying that release point coordinates are in the cell with the specified ID. By default, release point coordinates are checked at release time.
 default eager
+prerelease true
 
 block options
 name dev_cycle_detection_window

--- a/doc/mf6io/mf6ivar/dfn/swf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-dis2d.dfn
@@ -98,6 +98,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 # --------------------- swf dis2d dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/swf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-disv1d.dfn
@@ -98,6 +98,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 # --------------------- swf disv1d dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/swf-disv2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-disv2d.dfn
@@ -98,6 +98,7 @@ reader urword
 optional true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+prerelease true
 
 # --------------------- swf disv2d dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/readme.md
+++ b/doc/mf6io/mf6ivar/readme.md
@@ -74,7 +74,9 @@ A MODFLOW 6 input variable is described by a set of attributes. Some attributes 
 | preserve_case | Whether the case of the parameter value (if text) should be preserved. | No       | False   | This should be set to true for filename parameters.                                                                                                           |
 | default_value | The parameter's default value.                                         | No       | None    | Should be a valid Python literal.                                                                                                                             |
 | numeric_index | Indicates that this is an index variable.                              | No       | False   | Indicates that FloPy should treat the parameter as zero-based.                                                                                                |
-| deprecated    | Indicates that the parameter has been deprecated.                      | No       | None    | Should a semantic version number, the version in which the parameter was deprecated. If this attribute is provided without a value, it is ignored.            |
+| deprecated    | Indicates that the parameter has been deprecated.                      | No       | None    | Should be a semantic version number, the version in which the parameter was deprecated. If this attribute is provided without a value, it is ignored.            |
+| removed       | Indicates that the parameter has been removed.                         | No       | None    | Should be a semantic version number, the version in which the parameter was removed. If this attribute is provided without a value, it is ignored.               |
+| prerelease    | Indicates that the parameter should not be released yet.               | No       | False   | Should be set to true to indicate that a parameter is not ready for inclusion in releases. The parameter will be omitted from the generated IO guide.   |
 
 ### Reader Attribute
 

--- a/src/Model/Discretization/Dis.f90
+++ b/src/Model/Discretization/Dis.f90
@@ -574,6 +574,10 @@ contains
     !
     ! -- set version
     if (found_crs) then
+      ! TODO remove dev guard for 6.7.0
+      call dev_feature("CRS support is still under development, &
+                       &install the nightly build or compile &
+                       &from source with IDEVELOPMODE = 1.")
       ntxt = ntxt + 1
       version = 2
     end if

--- a/src/Model/Discretization/Dis2d.f90
+++ b/src/Model/Discretization/Dis2d.f90
@@ -508,6 +508,10 @@ contains
     !
     ! -- set version
     if (found_crs) then
+      ! TODO remove dev guard for 6.7.0
+      call dev_feature("CRS support is still under development, &
+                       &install the nightly build or compile &
+                       &from source with IDEVELOPMODE = 1.")
       ntxt = ntxt + 1
       version = 2
     end if

--- a/src/Model/Discretization/Disu.f90
+++ b/src/Model/Discretization/Disu.f90
@@ -934,6 +934,10 @@ contains
     !
     ! -- set version
     if (found_crs) then
+      ! TODO remove dev guard for 6.7.0
+      call dev_feature("CRS support is still under development, &
+                       &install the nightly build or compile &
+                       &from source with IDEVELOPMODE = 1.")
       ntxt = ntxt + 1
       version = 2
     end if

--- a/src/Model/Discretization/Disv.f90
+++ b/src/Model/Discretization/Disv.f90
@@ -736,6 +736,10 @@ contains
     !
     ! -- set version
     if (found_crs) then
+      ! TODO remove dev guard for 6.7.0
+      call dev_feature("CRS support is still under development, &
+                       &install the nightly build or compile &
+                       &from source with IDEVELOPMODE = 1.")
       ntxt = ntxt + 1
       version = 2
     end if

--- a/src/Model/Discretization/Disv1d.f90
+++ b/src/Model/Discretization/Disv1d.f90
@@ -872,6 +872,10 @@ contains
     !
     ! -- set version
     if (found_crs) then
+      ! TODO remove dev guard for 6.7.0
+      call dev_feature("CRS support is still under development, &
+                       &install the nightly build or compile &
+                       &from source with IDEVELOPMODE = 1.")
       ntxt = ntxt + 1
       version = 2
     end if

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -688,6 +688,10 @@ contains
     !
     ! -- set version
     if (found_crs) then
+      ! TODO remove dev guard for 6.7.0
+      call dev_feature("CRS support is still under development, &
+                       &install the nightly build or compile &
+                       &from source with IDEVELOPMODE = 1.")
       ntxt = ntxt + 1
       version = 2
     end if

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -756,6 +756,9 @@ contains
     end if
 
     if (found%ichkmeth) then
+      ! TODO remove dev guard for 6.7.0
+      call dev_feature('PRT coordinate check method is still under development, &
+        &install the nightly build or compile from source with IDEVELOPMODE = 1.')
       if (this%ichkmeth == 0) then
         write (errmsg, '(a)') 'Unsupported coordinate check method. &
           &COORDINATE_CHECK_METHOD must be "NONE" or "EAGER"'

--- a/src/Model/TransportModel/tsp.f90
+++ b/src/Model/TransportModel/tsp.f90
@@ -20,6 +20,7 @@ module TransportModelModule
   use TspObsModule, only: TspObsType
   use BudgetModule, only: BudgetType
   use MatrixBaseModule
+  use DevFeatureModule, only: dev_feature
 
   implicit none
 
@@ -534,6 +535,7 @@ contains
     this%inobs = 0
     this%eqnsclfac = DZERO
     this%idv_scale = 0
+    
   end subroutine allocate_tsp_scalars
 
   !> @brief Define the labels corresponding to the flavor of
@@ -651,6 +653,9 @@ contains
     end if
 
     if (found%idv_scale) then
+      ! TODO remove dev guard for 6.7.0
+      call dev_feature('Dependent variable scaling is still under development, &
+        &install the nightly build or compile from source with IDEVELOPMODE = 1.')
       write (this%iout, '(2(3x,a,/),3x,a,/,9x,a,/)') &
         'X and RHS will be scaled to avoid very large positive or negative', &
         'dependent variable values in the model IMS package.', &


### PR DESCRIPTION
Support a new `prerelease` attribute in DFNs, to mark variables as not ready for release. This can be parsed by our docs tooling to omit options from the IO guide, and by IDM to automatically apply the `dev_feature` guard. @mjreno is exploring the latter &mdash; if it proves feasible for this release, ad hoc applications of `dev_feature` here can be removed