### PR TITLE
chore: mark developmode tests, update dfn dev doc

### DIFF
--- a/autotest/test_gwt_dvscale.py
+++ b/autotest/test_gwt_dvscale.py
@@ -249,7 +249,7 @@ def check_results(test):
     )
 
 
-@pytest.mark.developmode # TODO remove for 6.7.0
+@pytest.mark.developmode  # TODO remove for 6.7.0
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dvscale.py
+++ b/autotest/test_gwt_dvscale.py
@@ -249,6 +249,7 @@ def check_results(test):
     )
 
 
+@pytest.mark.developmode # TODO remove for 6.7.0
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dvscale_fail.py
+++ b/autotest/test_gwt_dvscale_fail.py
@@ -221,7 +221,7 @@ def build_models(idx, test):
     return sim, None
 
 
-@pytest.mark.developmode # TODO remove for 6.7.0
+@pytest.mark.developmode  # TODO remove for 6.7.0
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dvscale_fail.py
+++ b/autotest/test_gwt_dvscale_fail.py
@@ -1,6 +1,6 @@
 """
 Test the dependent_variable_scale option to make sure modflow fails if the option
-is not specified for all gwt/gwe models in the same IMS solution. Tested for for a
+is not specified for all gwt/gwe models in the same IMS solution. Tested for a
 one-dimensional model grid of square cells.
 """
 
@@ -221,6 +221,7 @@ def build_models(idx, test):
     return sim, None
 
 
+@pytest.mark.developmode # TODO remove for 6.7.0
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_src02_ha.py
+++ b/autotest/test_gwt_src02_ha.py
@@ -246,7 +246,7 @@ def check_output(idx, test):
     assert np.array_equal(nodes, nodes_ans), "src nodes not based on saturation"
 
 
-@pytest.mark.developmode # TODO remove for 6.7.0
+@pytest.mark.developmode  # TODO remove for 6.7.0
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_src02_ha.py
+++ b/autotest/test_gwt_src02_ha.py
@@ -246,6 +246,7 @@ def check_output(idx, test):
     assert np.array_equal(nodes, nodes_ans), "src nodes not based on saturation"
 
 
+@pytest.mark.developmode # TODO remove for 6.7.0
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/doc/mf6io/mf6ivar/readme.md
+++ b/doc/mf6io/mf6ivar/readme.md
@@ -74,7 +74,9 @@ A MODFLOW 6 input variable is described by a set of attributes. Some attributes 
 | preserve_case | Whether the case of the parameter value (if text) should be preserved. | No       | False   | This should be set to true for filename parameters.                                                                                                           |
 | default_value | The parameter's default value.                                         | No       | None    | Should be a valid Python literal.                                                                                                                             |
 | numeric_index | Indicates that this is an index variable.                              | No       | False   | Indicates that FloPy should treat the parameter as zero-based.                                                                                                |
-| deprecated    | Indicates that the parameter has been deprecated.                      | No       | None    | Should a semantic version number, the version in which the parameter was deprecated. If this attribute is provided without a value, it is ignored.            |
+| deprecated    | Indicates that the parameter has been deprecated.                      | No       | None    | Should be a semantic version number, the version in which the parameter was deprecated. If this attribute is provided without a value, it is ignored.            |
+| removed       | Indicates that the parameter has been removed.                         | No       | None    | Should be a semantic version number, the version in which the parameter was removed. If this attribute is provided without a value, it is ignored.               |
+| prerelease    | Indicates that the parameter should not be released yet.               | No       | False   | Should be set to true to indicate that a parameter is not ready for inclusion in releases. The parameter will be omitted from the generated IO guide.   |
 
 ### Reader Attribute
 


### PR DESCRIPTION
Following on #2499, update the DFN spec developer document. Also mark a few tests `developmode` to prep for the upcoming patch release