### PR TITLE
docs: omit prerelease variables/sections in developmode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -501,7 +501,12 @@ jobs:
 
       - name: Build MF6IO files from DFNs
         working-directory: modflow6/doc/mf6io/mf6ivar
-        run: python mf6ivar.py
+        run: |
+          cmd="python mf6ivar.py"
+          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+            cmd="$cmd --releasemode"
+          fi
+          eval "$cmd"
 
       - name: Build documentation
         env:
@@ -518,6 +523,9 @@ jobs:
           fi
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
+          fi
+          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+            cmd="$cmd --releasemode"
           fi
           eval "$cmd"
           mv "doc/ReleaseNotes.pdf" "doc/release.pdf"

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -167,7 +167,7 @@ def test_build_notes_tex():
     build_notes_tex(force=True)
 
 
-def build_mf6io_tex(models: Optional[list[str]] = None, force: bool = False):
+def build_mf6io_tex(models: Optional[list[str]] = None, force: bool = False, developmode: bool = True):
     """Build LaTeX files for the MF6IO guide from DFN files."""
 
     if models is None:
@@ -196,6 +196,8 @@ def build_mf6io_tex(models: Optional[list[str]] = None, force: bool = False):
 
             # run mf6ivar script
             args = [sys.executable, "mf6ivar.py"]
+            if not developmode:
+                args.append("--releasemode")
             for model in models:
                 args += ["--model", model]
             out, err, ret = run_cmd(*args, verbose=True)
@@ -385,6 +387,7 @@ def build_documentation(
     full: bool = False,
     models: Optional[list[str]] = None,
     repo_owner: str = "MODFLOW-ORG",
+    developmode: bool = True,
 ):
     """Build documentation for a MODFLOW 6 distribution."""
 
@@ -401,7 +404,7 @@ def build_documentation(
     out_path.mkdir(parents=True, exist_ok=True)
 
     with TemporaryDirectory() as temp:
-        build_mf6io_tex(force=force, models=models)
+        build_mf6io_tex(force=force, models=models, developmode=developmode)
         build_usage_tex(
             bin_path=bin_path,
             workspace_path=Path(temp),
@@ -498,11 +501,20 @@ Additional LaTeX files may be included in the distribution by specifying --tex-p
         action="append",
         help="Filter model types to include",
     )
+    parser.add_argument(
+        "-r",
+        "--releasemode",
+        required=False,
+        action="store_true",
+        help="Omit prerelease variables from documentation "
+        "(defaults to false for development distributions)",
+    )
     args = parser.parse_args()
     output_path = Path(args.output_path).expanduser().absolute()
     output_path.mkdir(parents=True, exist_ok=True)
     bin_path = Path(args.bin_path).expanduser().absolute()
     models = args.model if args.model else DEFAULT_MODELS
+    developmode = not args.releasemode
     build_documentation(
         bin_path=bin_path,
         out_path=output_path,
@@ -510,4 +522,5 @@ Additional LaTeX files may be included in the distribution by specifying --tex-p
         full=args.full,
         models=models,
         repo_owner=args.repo_owner,
+        developmode=developmode,
     )

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -167,7 +167,9 @@ def test_build_notes_tex():
     build_notes_tex(force=True)
 
 
-def build_mf6io_tex(models: Optional[list[str]] = None, force: bool = False, developmode: bool = True):
+def build_mf6io_tex(
+    models: Optional[list[str]] = None, force: bool = False, developmode: bool = True
+):
     """Build LaTeX files for the MF6IO guide from DFN files."""
 
     if models is None:

--- a/doc/mf6io/framework/binaryoutput.tex
+++ b/doc/mf6io/framework/binaryoutput.tex
@@ -190,6 +190,7 @@ The binary grid file for DISU grids may contain information on the vertices and 
 \noindent Record 15: \texttt{(IAVERT(J),J=1,NODES+1)} {\color{red} \footnotesize{INTEGER ARRAY SIZE(NODES+1)}} \\
 \noindent Record 16: \texttt{(JAVERT(J),J=1,NJAVERT)} {\color{red} \footnotesize{INTEGER ARRAY SIZE(NJAVERT)}} \\
 
+\ifdevelopmode
 \newpage
 \subsubsection{Version 2 Binary Grid File}
 \mf~will write a version 2 binary grid file when the discretization supports the CRS input option and that option is defined.  If the discretization supports the CRS option but it is not defined in the discretization OPTIONS block, the version 1 file will be generated.  Version 2 binary grid files contain an additional definition string and data record associated with the CRS input.  The length of the data CHARACTER array record will be the trimmed length (TRIMLEN) of the provided input string.  An example for the DIS grid follows.
@@ -240,6 +241,7 @@ The binary grid file for DISU grids may contain information on the vertices and 
 \noindent Record 15: \texttt{(IDOMAIN(J),J=1,NCELLS)} {\color{red} \footnotesize{INTEGER ARRAY SIZE(NCELLS)}} \\
 \noindent Record 16: \texttt{(ICELLTYPE(J),J=1,NCELLS)} {\color{red} \footnotesize{INTEGER ARRAY SIZE(NCELLS)}} \\
 \noindent Record 17: \texttt{(CRS(J),J=1,TRIMLEN)} {\color{red} \footnotesize{CHARACTER ARRAY SIZE(TRIMLEN)}} \\
+\fi
 
 \newpage
 \subsection{Dependent Variable File}

--- a/doc/mf6io/mf6ivar/mf6ivar.py
+++ b/doc/mf6io/mf6ivar/mf6ivar.py
@@ -116,21 +116,6 @@
 #   output control rewritten entirely, and implemented in the code
 #
 
-# DEFINITION FILE KEYWORDS
-# block :: name of block
-# name :: variable name
-# in_record :: optional True or False, False if not specified
-# type :: recarray, record, keyword, integer, double precision, keystring
-# tagged :: optional True or False, True if not specified.
-#           If tagged, then keyword comes before value
-# shape :: (size), optional, only required for arrays
-# valid :: description of valid values
-# reader :: urword, readarray, u1dint, ...
-# optional :: optional True or False, False if not specified
-# longname :: long name for variable
-# description :: description for variable, REPLACE tag indicates that
-#                description will come from common.dfn
-
 
 import os
 import re
@@ -299,7 +284,9 @@ def block_entry(varname, block, vardict, prefix="  "):
     return s
 
 
-def write_block(vardict, block, blk_var_list, varexcludeprefix=None, indent=None):
+def write_block(
+    vardict, block, blk_var_list, varexcludeprefix=None, indent=None, developmode=True
+):
     prepend = "" if indent is None else indent * " "
     s = prepend + f"BEGIN {block.upper()}"
     for variable in blk_var_list:
@@ -325,10 +312,12 @@ def write_block(vardict, block, blk_var_list, varexcludeprefix=None, indent=None
                 # because it is part of a record
                 addv = False
             if v.get("block_variable", "") == "true":
-                # do not separately include this variable
-                # because it is part of a record
                 addv = False
-            if v.get("deprecated", "") != "" or v.get("removed", "") != "":
+            if (
+                v.get("deprecated", "") != ""
+                or v.get("removed", "") != ""
+                or (not developmode and v.get("prerelease", "") != "")
+            ):
                 addv = False
             if addv:
                 ts = block_entry(name, block, vardict, prefix="  " + prepend)
@@ -356,7 +345,7 @@ def get_description(desc):
     return desc
 
 
-def write_desc(vardict, block, blk_var_list, varexcludeprefix=None):
+def write_desc(vardict, block, blk_var_list, varexcludeprefix=None, developmode=True):
     s = ""
     for name, b in vardict.keys():
         v = vardict[(name, b)]
@@ -376,6 +365,8 @@ def write_desc(vardict, block, blk_var_list, varexcludeprefix=None):
             if v.get("deprecated", "") != "":
                 addv = False
             if v.get("removed", "") != "":
+                addv = False
+            if not developmode and v.get("prerelease", "") != "":
                 addv = False
             if addv:
                 if v["type"] == "keyword":
@@ -421,6 +412,9 @@ def write_desc(vardict, block, blk_var_list, varexcludeprefix=None):
                         if (
                             "removed" in vardict[(vn, block)]
                             or "deprecated" in vardict[(vn, block)]
+                            or (
+                                not developmode and "prerelease" in vardict[(vn, block)]
+                            )
                         ):
                             continue
                         blockentry = block_entry(vn, block, vardict, "")
@@ -431,7 +425,9 @@ def write_desc(vardict, block, blk_var_list, varexcludeprefix=None):
     return s
 
 
-def write_desc_md(vardict, block, blk_var_list, varexcludeprefix=None):
+def write_desc_md(
+    vardict, block, blk_var_list, varexcludeprefix=None, developmode=True
+):
     s = ""
     for name, b in vardict.keys():
         v = vardict[(name, b)]
@@ -451,6 +447,8 @@ def write_desc_md(vardict, block, blk_var_list, varexcludeprefix=None):
             if v.get("deprecated", "") != "":
                 addv = False
             if v.get("removed", "") != "":
+                addv = False
+            if not developmode and v.get("prerelease", "") != "":
                 addv = False
             if addv:
                 if v["type"] == "keyword":
@@ -727,7 +725,7 @@ def get_dfn_files(models):
     return files
 
 
-def write_variables():
+def write_variables(developmode=True):
     allblocks = []  # cumulative list of all block names
 
     # write markdown input variables file
@@ -761,12 +759,24 @@ def write_variables():
                 # Write the name of the block to the latex file
                 desc += f"\\item \\textbf{'{Block: ' + b.upper() + '}'}\n\n"
                 desc += "\\begin{description}\n"
-                desc += write_desc(vardict, b, blk_var_list, varexcludeprefix="dev_")
+                desc += write_desc(
+                    vardict,
+                    b,
+                    blk_var_list,
+                    varexcludeprefix="dev_",
+                    developmode=developmode,
+                )
                 desc += "\\end{description}\n"
 
                 with open(TEX_DIR_PATH / f"{fpath.stem}-{b}.dat", "w") as f:
                     s = (
-                        write_block(vardict, b, blk_var_list, varexcludeprefix="dev_")
+                        write_block(
+                            vardict,
+                            b,
+                            blk_var_list,
+                            varexcludeprefix="dev_",
+                            developmode=developmode,
+                        )
                         + "\n"
                     )
                     f.write(s)
@@ -793,7 +803,11 @@ def write_variables():
                     desc += f"##### Block: {b.upper()}\n\n"
 
                     desc += write_desc_md(
-                        vardict, b, blk_var_list, varexcludeprefix="dev_"
+                        vardict,
+                        b,
+                        blk_var_list,
+                        varexcludeprefix="dev_",
+                        developmode=developmode,
                     )
 
                     if "period" in b.lower():
@@ -807,6 +821,7 @@ def write_variables():
                                 blk_var_list,
                                 varexcludeprefix="dev_",
                                 indent=4,
+                                developmode=developmode,
                             )
                         )
                         + "\n"
@@ -903,9 +918,18 @@ if __name__ == "__main__":
         action="store_true",
         help="Whether to show verbose output",
     )
+    parser.add_argument(
+        "-r",
+        "--releasemode",
+        required=False,
+        action="store_true",
+        help="Omit prerelease variables from documentation "
+        "(defaults to false for development distributions)",
+    )
     args = parser.parse_args()
     models = args.model if args.model else DEFAULT_MODELS
     verbose = args.verbose
+    developmode = not args.releasemode
 
     # clean/recreate docdir
     if os.path.isdir(RTD_DOC_DIR_PATH):
@@ -915,7 +939,7 @@ if __name__ == "__main__":
     # filter dfn files corresponding to the selected set of models
     # and write variables and appendix to markdown and latex files
     dfns = get_dfn_files(models)
-    blocks = write_variables()
+    blocks = write_variables(developmode=developmode)
     write_appendix(blocks)
     if verbose:
         for block in blocks:

--- a/doc/mf6io/mf6ivar/mf6ivar.py
+++ b/doc/mf6io/mf6ivar/mf6ivar.py
@@ -413,7 +413,8 @@ def write_desc(vardict, block, blk_var_list, varexcludeprefix=None, developmode=
                             "removed" in vardict[(vn, block)]
                             or "deprecated" in vardict[(vn, block)]
                             or (
-                                not developmode and vardict[(vn, block)].get("prerelease", "") == "true"
+                                not developmode
+                                and vardict[(vn, block)].get("prerelease", "") == "true"
                             )
                         ):
                             continue

--- a/doc/mf6io/mf6ivar/mf6ivar.py
+++ b/doc/mf6io/mf6ivar/mf6ivar.py
@@ -316,7 +316,7 @@ def write_block(
             if (
                 v.get("deprecated", "") != ""
                 or v.get("removed", "") != ""
-                or (not developmode and v.get("prerelease", "") != "")
+                or (not developmode and v.get("prerelease", "") == "true")
             ):
                 addv = False
             if addv:
@@ -413,7 +413,7 @@ def write_desc(vardict, block, blk_var_list, varexcludeprefix=None, developmode=
                             "removed" in vardict[(vn, block)]
                             or "deprecated" in vardict[(vn, block)]
                             or (
-                                not developmode and "prerelease" in vardict[(vn, block)]
+                                not developmode and vardict[(vn, block)].get("prerelease", "") == "true"
                             )
                         ):
                             continue
@@ -448,7 +448,7 @@ def write_desc_md(
                 addv = False
             if v.get("removed", "") != "":
                 addv = False
-            if not developmode and v.get("prerelease", "") != "":
+            if not developmode and v.get("prerelease", "") == "true":
                 addv = False
             if addv:
                 if v["type"] == "keyword":


### PR DESCRIPTION
Supersedes #2504. Modify `update_version.py`, `mf6ivar.py` and `build_docs.py` to filter prerelease variables out of the intermediate markdown/latex artifacts in develop mode, and likewise in the io guide with a new `ifdevelopmode` conditional