### PR TITLE
refactor(csub): improve interbed error message

### DIFF
--- a/autotest/test_gwf_csub_sub01_fail.py
+++ b/autotest/test_gwf_csub_sub01_fail.py
@@ -163,6 +163,9 @@ def build_model(idx, test):
 
     return sim, None
 
+def check_output(idx, test):
+    buff = test.buffs[0]
+    assert any("Coarse grained material thickness is less than zero" in l for l in buff)
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
@@ -171,6 +174,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         build=lambda t: build_model(idx, t),
         targets=targets,
+        check=lambda t: check_output(idx, t),
         xfail=True,
     )
     test.run()

--- a/autotest/test_gwf_csub_sub01_fail.py
+++ b/autotest/test_gwf_csub_sub01_fail.py
@@ -163,9 +163,11 @@ def build_model(idx, test):
 
     return sim, None
 
+
 def check_output(idx, test):
     buff = test.buffs[0]
     assert any("Coarse grained material thickness is less than zero" in l for l in buff)
+
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):

--- a/autotest/test_gwf_csub_sub01_fail.py
+++ b/autotest/test_gwf_csub_sub01_fail.py
@@ -1,0 +1,176 @@
+#
+# Modified version of sub example 1 where the interbed thickness exceeds the
+# layer thickness and causes the model to terminate with an error
+#
+
+
+import flopy
+import pytest
+from framework import TestFramework
+
+cases = ["csub_sub01"]
+paktest = "csub"
+ndcell = [19] * len(cases)
+
+# static model data
+# spatial discretization
+nlay, nrow, ncol = 1, 1, 3
+shape3d = (nlay, nrow, ncol)
+size3d = nlay * nrow * ncol
+delr, delc = 1.0, 1.0
+top = 0.0
+botm = [-10.0]
+
+# temporal discretization
+nper = 1
+perlen = [1000.0] * nper
+nstp = [100] * nper
+tsmult = [1.05] * nper
+steady = [False] * nper
+
+strt = 0.0
+strt6 = 1.0
+hk = 1e6
+laytyp = [0]
+S = 1e-4
+sy = 0.0
+
+tdis_rc = []
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+ib = 1
+
+c = []
+c6 = []
+for j in range(0, ncol, 2):
+    c.append([0, 0, j, strt, strt])
+    c6.append([(0, 0, j), strt])
+cd = {0: c}
+cd6 = {0: c6}
+
+# sub data
+ninterbeds = 3
+cc = 100.0
+cr = 1.0
+void = 0.82
+theta = void / (1.0 + void)
+kv = 0.025
+sgm = 0.0
+sgs = 0.0
+ini_stress = 1.0
+thick = [1.1, 2.2, 5.5]
+rnb = [3.3, 2.1, 1.0]
+cdelay = ["delay", "delay", "nodelay"]
+boundnames = [f"interbed_{i + 1}" for i in range(ninterbeds)]
+sfe = [cr * b for b in thick]
+sfv = [cc * b for b in thick]
+
+
+def get_model(idx, ws):
+    name = cases[idx]
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name,
+        version="mf6",
+        exe_name="mf6",
+        sim_ws=ws,
+        print_input=True,
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
+
+    # create iterative model solution
+    ims = flopy.mf6.ModflowIms(sim, complexity="simple")
+
+    # create gwf model
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
+
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
+
+    # node property flow
+    npf = flopy.mf6.ModflowGwfnpf(gwf, icelltype=laytyp, k=hk, k33=hk)
+
+    # storage
+    sto = flopy.mf6.ModflowGwfsto(
+        gwf,
+        iconvert=laytyp,
+        ss=0.0,
+        sy=sy,
+        storagecoefficient=True,
+        transient={0: True},
+    )
+
+    # chd files
+    chd = flopy.mf6.modflow.mfgwfchd.ModflowGwfchd(
+        gwf,
+        maxbound=len(c6),
+        stress_period_data=cd6,
+    )
+
+    # csub files
+    sub6 = []
+    for n in range(ninterbeds):
+        sub6.append(
+            (
+                n,
+                (0, 0, 1),
+                cdelay[n],
+                ini_stress,
+                thick[n],
+                rnb[n],
+                sfv[n],
+                sfe[n],
+                theta,
+                kv,
+                ini_stress,
+                boundnames[n],
+            )
+        )
+
+    csub = flopy.mf6.ModflowGwfcsub(
+        gwf,
+        print_input=True,
+        head_based=True,
+        boundnames=True,
+        save_flows=True,
+        effective_stress_lag=True,
+        ndelaycells=ndcell[idx],
+        ninterbeds=ninterbeds,
+        beta=0.0,
+        cg_ske_cr={"iprn": 1, "data": 1e-5},
+        packagedata=sub6,
+    )
+
+    return sim
+
+
+def build_model(idx, test):
+    # build MODFLOW 6 files
+    sim = get_model(idx, test.workspace)
+
+    return sim, None
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_model(idx, t),
+        targets=targets,
+        xfail=True,
+    )
+    test.run()

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -240,6 +240,7 @@ module GwfCsubModule
     procedure, private :: csub_allocate_arrays
     procedure, private :: csub_source_griddata
     procedure, private :: csub_source_packagedata
+    procedure, private :: csub_print_packagedata
     !
     ! -- helper methods
     procedure, private :: csub_calc_void_ratio
@@ -370,6 +371,7 @@ contains
     real(DP) :: cg_ske_cr
     real(DP) :: theta
     real(DP) :: v
+    real(DP) :: vtot
     ! -- format
     character(len=*), parameter :: fmtcsub = &
       "(1x,/1x,'CSUB -- COMPACTION PACKAGE, VERSION 1, 12/15/2019', &
@@ -479,8 +481,27 @@ contains
       if (thick < DZERO) then
         call this%dis%noder_to_string(node, cellid)
         write (errmsg, '(a,g0,a,1x,a,a)') &
-          'Aquifer thickness is less than zero (', &
-          thick, ') in cell', trim(adjustl(cellid)), '.'
+          'Coarse grained material thickness is less than zero (', &
+          thick, ') in cell', trim(adjustl(cellid)), '. Interbed thicknesses:'
+
+        vtot = DZERO
+        do ib = 1, this%ninterbeds
+          if (node /= this%nodelist(ib)) then
+            cycle
+          end if
+          idelay = this%idelay(ib)
+          v = this%thickini(ib)
+          if (idelay /= 0) then
+            v = v * this%rnb(ib)
+          end if
+          vtot = vtot + v
+          write (errmsg, '(a,1x,a,i0,a,g0)') &
+            trim(adjustl(errmsg)), &
+            'icbno(', ib, ')=', v
+        end do
+        write (errmsg, '(a,a,g0,a)') &
+          trim(adjustl(errmsg)), &
+          '. Total interbed thickness=', vtot, '.'
         call store_error(errmsg)
       end if
     end do
@@ -1508,7 +1529,110 @@ contains
         call store_error(errmsg)
       end if
     end if
+
+    if (this%iprpak /= 0) then
+      call this%csub_print_packagedata()
+    end if
+
   end subroutine csub_source_packagedata
+
+  subroutine csub_print_packagedata(this)
+    class(GwfCsubType) :: this
+    ! local
+    character(len=LINELENGTH) :: title
+    character(len=LINELENGTH) :: tag
+    character(len=10) :: ctype
+    character(len=20) :: cellid
+    integer(I4B) :: ntabrows
+    integer(I4B) :: ntabcols
+    integer(I4B) :: ib
+    integer(I4b) :: idelay
+    integer(I4B) :: node
+
+    ! set title
+    title = 'CSUB'//' PACKAGE ('// &
+            trim(adjustl(this%packName))//') INTERBED DATA'
+    !
+    ! determine the number of columns and rows
+    ntabrows = this%ninterbeds
+    ntabcols = 13
+    if (this%inamedbound /= 0) then
+      ntabcols = ntabcols + 1
+    end if
+
+    ! setup table
+    call table_cr(this%inputtab, this%packName, title)
+    call this%inputtab%table_df(ntabrows, ntabcols, this%iout)
+    !
+    ! add columns
+    !<icsubno> <cellid> <cdelay> <pcs0> <thick_frac> <rnb> <ssv_cc> <sse_cr> <theta> <kv> <h0> [<boundname>]
+
+    tag = 'INTERBED NUMBER'
+    call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
+    tag = 'CELLID'
+    call this%inputtab%initialize_column(tag, 20, alignment=TABLEFT)
+    tag = 'INTERBED TYPE'
+    call this%inputtab%initialize_column(tag, 10, alignment=TABCENTER)
+    tag = 'PCS0'
+    call this%inputtab%initialize_column(tag, 12, alignment=TABCENTER)
+    tag = 'THICK_FRAC'
+    call this%inputtab%initialize_column(tag, 12, alignment=TABCENTER)
+    tag = 'RNB'
+    call this%inputtab%initialize_column(tag, 12, alignment=TABCENTER)
+    tag = 'INTERBED THICKNESS'
+    call this%inputtab%initialize_column(tag, 12, alignment=TABCENTER)
+    tag = 'CELL THICKNESS'
+    call this%inputtab%initialize_column(tag, 12, alignment=TABCENTER)
+    tag = 'SSV_CV'
+    call this%inputtab%initialize_column(tag, 12, alignment=TABCENTER)
+    tag = 'SSE_CR'
+    call this%inputtab%initialize_column(tag, 12, alignment=TABCENTER)
+    tag = 'THETA'
+    call this%inputtab%initialize_column(tag, 12, alignment=TABCENTER)
+    tag = 'KV'
+    call this%inputtab%initialize_column(tag, 12, alignment=TABCENTER)
+    tag = 'H0'
+    call this%inputtab%initialize_column(tag, 12, alignment=TABCENTER)
+    if (this%inamedbound /= 0) then
+      tag = 'BOUNDNAME'
+      call this%inputtab%initialize_column(tag, 40, alignment=TABLEFT)
+    end if
+
+    do ib = 1, this%ninterbeds
+      idelay = this%idelay(ib)
+      node = this%nodelist(ib)
+      call this%dis%noder_to_string(node, cellid)
+      if (idelay == 0) then
+        ctype = 'nodelay'
+      else
+        ctype = 'delay'
+      end if
+
+      ! fill table line
+      call this%inputtab%add_term(ib)
+      call this%inputtab%add_term(cellid)
+      call this%inputtab%add_term(ctype)
+      call this%inputtab%add_term(this%pcs(ib))
+      call this%inputtab%add_term(this%thickini(ib))
+      call this%inputtab%add_term(this%rnb(ib))
+      call this%inputtab%add_term(this%thickini(ib) * this%rnb(ib))
+      call this%inputtab%add_term(this%dis%top(node) - this%dis%bot(node))
+      call this%inputtab%add_term(this%ci(ib))
+      call this%inputtab%add_term(this%rci(ib))
+      call this%inputtab%add_term(this%theta(ib))
+      if (idelay == 0) then
+        call this%inputtab%add_term("--")
+        call this%inputtab%add_term("--")
+      else
+        call this%inputtab%add_term(this%kv(ib))
+        call this%inputtab%add_term(this%h0(ib))
+      end if
+      if (this%inamedbound /= 0) then
+        call this%inputtab%add_term(this%boundname(ib))
+      end if
+    end do
+
+  end subroutine csub_print_packagedata
 
   !> @ brief Final processing for package
   !!

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -1536,6 +1536,8 @@ contains
 
   end subroutine csub_source_packagedata
 
+  !> @ brief Print packagedata
+  !<
   subroutine csub_print_packagedata(this)
     class(GwfCsubType) :: this
     ! local


### PR DESCRIPTION
Improve error message when the interbed thickness exceeds the layer thickness. Add a test that exercises this csub failure. Added functionality to print packagedata input when the print_input option specified to facilitate debugging interbed input.

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
