### PR TITLE
refactor(prt): improve naming for model level tracking method routines

### DIFF
--- a/src/Solution/ParticleTracker/Method/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/Method/MethodDisv.f90
@@ -31,13 +31,13 @@ module MethodDisvModule
     procedure :: map_neighbor !< map a location on the cell face to the shared face of a neighbor
     procedure :: update_flowja !< update intercell mass flows
     procedure :: load_particle !< load particle properties
-    procedure :: load_properties !< load cell properties
-    procedure :: load_polygon !< load cell polygon
-    procedure :: load_neighbors !< load cell face neighbors
-    procedure :: load_indicators !< load cell 180-degree vertex indicator
-    procedure :: load_flows !< load the cell's flows
-    procedure :: load_boundary_flows_to_defn_poly !< load boundary flows to a polygonal cell definition
-    procedure :: load_face_flows_to_defn_poly !< load face flows to a polygonal cell definition
+    procedure :: load_cell_properties !< load cell properties
+    procedure :: load_cell_polygon !< load cell polygon
+    procedure :: load_cell_neighbors !< load cell face neighbors
+    procedure :: load_cell_flags !< load cell 180-degree vertex indicator
+    procedure :: load_cell_flows !< load the cell's flows
+    procedure :: load_cell_boundary_flows !< load boundary flows to a polygonal cell definition
+    procedure :: load_cell_face_flows !< load face flows to a polygonal cell definition
   end type MethodDisvType
 
 contains
@@ -315,16 +315,16 @@ contains
     integer(I4B), intent(in) :: ic
     type(CellDefnType), pointer, intent(inout) :: defn
 
-    call this%load_properties(ic, defn)
-    call this%load_polygon(defn)
-    call this%load_neighbors(defn)
-    call this%load_saturation_status(defn)
-    call this%load_indicators(defn)
-    call this%load_flows(defn)
+    call this%load_cell_properties(ic, defn)
+    call this%load_cell_polygon(defn)
+    call this%load_cell_neighbors(defn)
+    call this%load_cell_saturation_status(defn)
+    call this%load_cell_flags(defn)
+    call this%load_cell_flows(defn)
   end subroutine load_cell_defn
 
   !> @brief Loads cell properties to cell definition from the grid.
-  subroutine load_properties(this, ic, defn)
+  subroutine load_cell_properties(this, ic, defn)
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     integer(I4B), intent(in) :: ic
@@ -355,9 +355,9 @@ contains
       defn%ilay = ilay
     end select
 
-  end subroutine load_properties
+  end subroutine load_cell_properties
 
-  subroutine load_polygon(this, defn)
+  subroutine load_cell_polygon(this, defn)
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     type(CellDefnType), pointer, intent(inout) :: defn
@@ -367,11 +367,11 @@ contains
       defn%polyvert, &
       closed=.true.)
     defn%npolyverts = size(defn%polyvert, dim=2) - 1
-  end subroutine load_polygon
+  end subroutine load_cell_polygon
 
   !> @brief Loads face neighbors to cell definition from the grid
   !! Assumes cell index and number of vertices are already loaded.
-  subroutine load_neighbors(this, defn)
+  subroutine load_cell_neighbors(this, defn)
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     type(CellDefnType), pointer, intent(inout) :: defn
@@ -440,12 +440,12 @@ contains
     end select
     ! List of edge (polygon) faces wraps around
     defn%facenbr(defn%npolyverts + 1) = defn%facenbr(1)
-  end subroutine load_neighbors
+  end subroutine load_cell_neighbors
 
   !> @brief Load flows into the cell definition.
   !! These include face, boundary and net distributed flows.
   !! Assumes cell index and number of vertices are already loaded.
-  subroutine load_flows(this, defn)
+  subroutine load_cell_flows(this, defn)
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     type(CellDefnType), pointer, intent(inout) :: defn
@@ -462,10 +462,10 @@ contains
     ! the last two elements, respectively, for size npolyverts + 3.
     ! If there is no flow through any face, set a no-exit-face flag.
     defn%faceflow = DZERO
-    call this%load_boundary_flows_to_defn_poly(defn)
-    call this%load_face_flows_to_defn_poly(defn)
-    call this%cap_wt_flow(defn)
-    call this%load_no_exit_face(defn)
+    call this%load_cell_boundary_flows(defn)
+    call this%load_cell_face_flows(defn)
+    call this%cap_cell_wt_flow(defn)
+    call this%load_cell_no_exit_face(defn)
 
     ! Add up net distributed flow
     defn%distflow = this%fmi%SourceFlows(defn%icell) + &
@@ -478,9 +478,9 @@ contains
     else
       defn%iweaksink = 0
     end if
-  end subroutine load_flows
+  end subroutine load_cell_flows
 
-  subroutine load_face_flows_to_defn_poly(this, defn)
+  subroutine load_cell_face_flows(this, defn)
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     type(CellDefnType), pointer, intent(inout) :: defn
@@ -496,11 +496,11 @@ contains
         defn%faceflow(m) = defn%faceflow(m) + q
       end if
     end do
-  end subroutine load_face_flows_to_defn_poly
+  end subroutine load_cell_face_flows
 
   !> @brief Load boundary flows from the grid into a polygonal cell.
   !! Assumes cell index and number of vertices are already loaded.
-  subroutine load_boundary_flows_to_defn_poly(this, defn)
+  subroutine load_cell_boundary_flows(this, defn)
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     type(CellDefnType), pointer, intent(inout) :: defn
@@ -525,13 +525,13 @@ contains
       defn%faceflow(npolyverts + 3) + &
       this%fmi%BoundaryFlows(ioffset + max_faces)
 
-  end subroutine load_boundary_flows_to_defn_poly
+  end subroutine load_cell_boundary_flows
 
   !> @brief Load 180-degree vertex indicator array and set flags
   !! indicating how cell can be represented. Assumes cell index
   !! and number of vertices are already loaded.
   !<
-  subroutine load_indicators(this, defn)
+  subroutine load_cell_flags(this, defn)
     ! dummy
     class(MethodDisvType), intent(inout) :: this
     type(CellDefnType), pointer, intent(inout) :: defn
@@ -622,6 +622,6 @@ contains
         defn%can_be_quad = .true.
       end if
     end if
-  end subroutine load_indicators
+  end subroutine load_cell_flags
 
 end module MethodDisvModule

--- a/src/Solution/ParticleTracker/Method/MethodModel.f90
+++ b/src/Solution/ParticleTracker/Method/MethodModel.f90
@@ -18,9 +18,9 @@ module MethodModelModule
     procedure, public :: assess
     procedure, public :: get_level
     ! cell load utilities
-    procedure :: cap_wt_flow
-    procedure :: load_no_exit_face
-    procedure :: load_saturation_status
+    procedure :: cap_cell_wt_flow
+    procedure :: load_cell_no_exit_face
+    procedure :: load_cell_saturation_status
   end type MethodModelType
 
 contains
@@ -51,7 +51,7 @@ contains
   !!
   !! Assumes cell properties and flows are already loaded.
   !<
-  subroutine cap_wt_flow(this, defn)
+  subroutine cap_cell_wt_flow(this, defn)
     class(MethodModelType), intent(inout) :: this
     type(CellDefnType), pointer, intent(inout) :: defn
     ! local
@@ -66,11 +66,11 @@ contains
       defn%faceflow(itopface) = max(DZERO, defn%faceflow(itopface))
     end if
 
-  end subroutine cap_wt_flow
+  end subroutine cap_cell_wt_flow
 
   !> @brief Set flag indicating if the cell has any faces with outflow.
   !! Assumes cell properties and flows are already loaded.
-  subroutine load_no_exit_face(this, defn)
+  subroutine load_cell_no_exit_face(this, defn)
     ! dummy
     class(MethodModelType), intent(inout) :: this
     type(CellDefnType), pointer, intent(inout) :: defn
@@ -83,11 +83,11 @@ contains
       if (defn%faceflow(m) < DZERO) defn%inoexitface = 0
     end do
 
-  end subroutine load_no_exit_face
+  end subroutine load_cell_no_exit_face
 
   !> @brief Set the saturation status of a cell.
   !! See the status enumeration in CellDefnModule.
-  subroutine load_saturation_status(this, defn)
+  subroutine load_cell_saturation_status(this, defn)
     ! dummy
     class(MethodModelType), intent(inout) :: this
     type(CellDefnType), pointer, intent(inout) :: defn
@@ -125,6 +125,6 @@ contains
       return
     end if
 
-  end subroutine load_saturation_status
+  end subroutine load_cell_saturation_status
 
 end module MethodModelModule


### PR DESCRIPTION
make naming consistent and reflect the fact that these routines load data onto the cell