### PR TITLE
ci: prepare for external test model changes

### DIFF
--- a/autotest/test_external_models.py
+++ b/autotest/test_external_models.py
@@ -37,6 +37,15 @@ EXCLUDE = [
     "test1002_biscqtg_disv_nr_RCM_dev",
     "test1002_biscqtg_disv_nr_dev",
     "testWetDry/mf2005",
+    # prepare for dry_cell_saturation change
+    "test006_gwf3_gnc_nr",
+    "test006_gwf3_nr",
+    "test014_NWTP3High_mfusg",
+    "test015_KeatingLike_disu_mfusg",
+    "test016_Keating_disu_mfusg",
+    "test041_flowdivert_mfusg",
+    "test053_npf-a_mfusg",
+    "test053_npf-b_mfusg",
 ]
 # models to force original regression comparison
 # (otherwise enabled with --original-regression)


### PR DESCRIPTION
Modified the exclusion list in the external models autotest in preparation for dry_cell_saturation tests.

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
