### PR TITLE
Put UTVD behind a feature flag

### DIFF
--- a/autotest/test_gwt_adv01.py
+++ b/autotest/test_gwt_adv01.py
@@ -11,11 +11,11 @@ import pytest
 from framework import TestFramework
 
 cases = [
-    pytest.param(0, "adv01a"), 
-    pytest.param(1, "adv01b"), 
-    pytest.param(2, "adv01c"), 
-    pytest.param(3, "adv01d", marks=pytest.mark.developmode)
-    ]
+    pytest.param(0, "adv01a"),
+    pytest.param(1, "adv01b"),
+    pytest.param(2, "adv01c"),
+    pytest.param(3, "adv01d", marks=pytest.mark.developmode),
+]
 scheme = ["upstream", "central", "tvd", "utvd"]
 
 

--- a/autotest/test_gwt_adv01.py
+++ b/autotest/test_gwt_adv01.py
@@ -10,11 +10,16 @@ import numpy as np
 import pytest
 from framework import TestFramework
 
-cases = ["adv01a", "adv01b", "adv01c", "adv01d"]
+cases = [
+    pytest.param(0, "adv01a"), 
+    pytest.param(1, "adv01b"), 
+    pytest.param(2, "adv01c"), 
+    pytest.param(3, "adv01d", marks=pytest.mark.developmode)
+    ]
 scheme = ["upstream", "central", "tvd", "utvd"]
 
 
-def build_models(idx, test):
+def build_models(idx, name, test):
     nlay, nrow, ncol = 1, 1, 100
     nper = 1
     perlen = [5.0]
@@ -38,8 +43,6 @@ def build_models(idx, test):
     tdis_rc = []
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
-
-    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -232,8 +235,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(idx, test):
-    name = cases[idx]
+def check_output(idx, name, test):
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -684,13 +686,13 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.parametrize(("idx", "name"), cases)
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t),
-        check=lambda t: check_output(idx, t),
+        build=lambda t: build_models(idx, name, t),
+        check=lambda t: check_output(idx, name, t),
     )
     test.run()

--- a/autotest/test_gwt_adv01_fmi.py
+++ b/autotest/test_gwt_adv01_fmi.py
@@ -12,11 +12,16 @@ from binary_util import write_budget, write_head
 from flopy.utils.gridutil import uniform_flow_field
 from framework import TestFramework
 
-cases = ["adv01a_fmi", "adv01b_fmi", "adv01c_fmi", "adv01d_fmi"]
+cases = [
+    pytest.param(0, "adv01a_fmi"), 
+    pytest.param(1, "adv01b_fmi"), 
+    pytest.param(2, "adv01c_fmi"), 
+    pytest.param(3, "adv01d_fmi", marks=pytest.mark.developmode)
+    ]
 scheme = ["upstream", "central", "tvd", "utvd"]
 
 
-def build_models(idx, test):
+def build_models(idx, name, test):
     nlay, nrow, ncol = 1, 1, 100
     nper = 1
     perlen = [5.0]
@@ -37,8 +42,6 @@ def build_models(idx, test):
     tdis_rc = []
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
-
-    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -202,8 +205,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(idx, test):
-    name = cases[idx]
+def check_output(idx, name, test):
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -654,13 +656,13 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.parametrize(("idx", "name"), cases)
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t),
-        check=lambda t: check_output(idx, t),
+        build=lambda t: build_models(idx, name, t),
+        check=lambda t: check_output(idx, name, t),
     )
     test.run()

--- a/autotest/test_gwt_adv01_fmi.py
+++ b/autotest/test_gwt_adv01_fmi.py
@@ -13,11 +13,11 @@ from flopy.utils.gridutil import uniform_flow_field
 from framework import TestFramework
 
 cases = [
-    pytest.param(0, "adv01a_fmi"), 
-    pytest.param(1, "adv01b_fmi"), 
-    pytest.param(2, "adv01c_fmi"), 
-    pytest.param(3, "adv01d_fmi", marks=pytest.mark.developmode)
-    ]
+    pytest.param(0, "adv01a_fmi"),
+    pytest.param(1, "adv01b_fmi"),
+    pytest.param(2, "adv01c_fmi"),
+    pytest.param(3, "adv01d_fmi", marks=pytest.mark.developmode),
+]
 scheme = ["upstream", "central", "tvd", "utvd"]
 
 

--- a/autotest/test_gwt_adv01_gwtgwt.py
+++ b/autotest/test_gwt_adv01_gwtgwt.py
@@ -10,7 +10,13 @@ import numpy as np
 import pytest
 from framework import TestFramework
 
-cases = ["adv01a_gwtgwt", "adv01b_gwtgwt", "adv01c_gwtgwt", "adv01d_gwtgwt"]
+cases = [
+    pytest.param(0, "adv01a_gwtgwt"),
+    pytest.param(1, "adv01b_gwtgwt"),
+    pytest.param(2, "adv01c_gwtgwt"),
+    pytest.param(3, "adv01d_gwtgwt", marks=pytest.mark.developmode),
+]
+
 scheme = ["upstream", "central", "tvd", "utvd"]
 gdelr = 1.0
 
@@ -813,7 +819,7 @@ def check_output(idx, test):
             # assert np.allclose(res, 0.0, atol=1.0e-6), errmsg
 
 
-@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.parametrize(("idx", "name"), cases)
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_adv02.py
+++ b/autotest/test_gwt_adv02.py
@@ -13,7 +13,13 @@ import numpy as np
 import pytest
 from framework import TestFramework
 
-cases = ["adv02a", "adv02b", "adv02c", "adv02d"]
+cases = [
+    pytest.param(0, "adv02a"),
+    pytest.param(1, "adv02b"),
+    pytest.param(2, "adv02c"),
+    pytest.param(3, "adv02d", marks=pytest.mark.developmode),
+]
+
 scheme = ["upstream", "central", "tvd", "utvd"]
 
 
@@ -62,7 +68,7 @@ def cvfd_to_cell2d(verts, iverts):
     return vertices, cell2d
 
 
-def build_models(idx, test):
+def build_models(idx, name, test):
     nlay, nrow, ncol = 1, 1, 100
     nper = 1
     perlen = [5.0]
@@ -83,8 +89,6 @@ def build_models(idx, test):
     tdis_rc = []
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
-
-    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -291,8 +295,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(idx, test):
-    name = cases[idx]
+def check_output(idx, name, test):
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -1135,13 +1138,13 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.parametrize("idx, name", cases)
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t),
-        check=lambda t: check_output(idx, t),
+        build=lambda t: build_models(idx, name, t),
+        check=lambda t: check_output(idx, name, t),
     )
     test.run()

--- a/autotest/test_gwt_adv02_gwtgwt.py
+++ b/autotest/test_gwt_adv02_gwtgwt.py
@@ -12,7 +12,13 @@ import numpy as np
 import pytest
 from framework import TestFramework
 
-cases = ["adv02a_gwtgwt", "adv02b_gwtgwt", "adv02c_gwtgwt", "adv02d_gwtgwt"]
+cases = [
+    pytest.param(0, "adv02a_gwtgwt"),
+    pytest.param(1, "adv02b_gwtgwt"),
+    pytest.param(2, "adv02c_gwtgwt"),
+    pytest.param(3, "adv02d_gwtgwt", marks=pytest.mark.developmode),
+]
+
 scheme = ["upstream", "central", "tvd", "utvd"]
 gdelr = 1.0
 
@@ -326,7 +332,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.parametrize("idx, name", cases)
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_adv03.py
+++ b/autotest/test_gwt_adv03.py
@@ -13,7 +13,13 @@ import numpy as np
 import pytest
 from framework import TestFramework
 
-cases = ["adv03a", "adv03b", "adv03c", "adv03d"]
+cases = [
+    pytest.param(0, "adv03a"),
+    pytest.param(1, "adv03b"),
+    pytest.param(2, "adv03c"),
+    pytest.param(3, "adv03d", marks=pytest.mark.developmode),
+]
+
 scheme = ["upstream", "central", "tvd", "utvd"]
 
 
@@ -62,7 +68,7 @@ def cvfd_to_cell2d(verts, iverts):
     return vertices, cell2d
 
 
-def build_models(idx, test):
+def build_models(idx, name, test):
     nlay, nrow, ncol = 5, 10, 20
     nper = 1
     delr = 1.0
@@ -89,8 +95,6 @@ def build_models(idx, test):
     tdis_rc = []
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
-
-    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -323,8 +327,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(idx, test):
-    name = cases[idx]
+def check_output(idx, name, test):
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -524,13 +527,13 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.parametrize("idx, name", cases)
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t),
-        check=lambda t: check_output(idx, t),
+        build=lambda t: build_models(idx, name, t),
+        check=lambda t: check_output(idx, name, t),
     )
     test.run()

--- a/autotest/test_gwt_adv04.py
+++ b/autotest/test_gwt_adv04.py
@@ -11,11 +11,17 @@ import numpy as np
 import pytest
 from framework import TestFramework
 
-cases = ["adv04a", "adv04b", "adv04c", "adv04d"]
+cases = [
+    pytest.param(0, "adv04a"),
+    pytest.param(1, "adv04b"),
+    pytest.param(2, "adv04c"),
+    pytest.param(3, "adv04d", marks=pytest.mark.developmode),
+]
+
 scheme = ["upstream", "central", "tvd", "utvd"]
 
 
-def build_models(idx, test):
+def build_models(idx, name, test):
     nlay, nrow, ncol = 1, 21, 21
     nper = 1
     perlen = [5.0]
@@ -51,8 +57,6 @@ def build_models(idx, test):
     tdis_rc = []
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
-
-    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -217,8 +221,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(idx, test):
-    name = cases[idx]
+def check_output(idx, name, test):
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -241,13 +244,13 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.parametrize("idx, name", cases)
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t),
-        check=lambda t: check_output(idx, t),
+        build=lambda t: build_models(idx, name, t),
+        check=lambda t: check_output(idx, name, t),
     )
     test.run()

--- a/autotest/test_gwt_henry_gwtgwt.py
+++ b/autotest/test_gwt_henry_gwtgwt.py
@@ -6,12 +6,14 @@ import pytest
 from framework import TestFramework
 
 cases = [
-    "henry01-gwtgwt-ups",
-    "henry01-gwtgwt-cen",
-    "henry01-gwtgwt-tvd",
-    "henry01-gwtgwt-utvd",
+    pytest.param(0, "henry01-gwtgwt-ups"),
+    pytest.param(1, "henry01-gwtgwt-cen"),
+    pytest.param(2, "henry01-gwtgwt-tvd"),
+    pytest.param(3, "henry01-gwtgwt-utvd", marks=pytest.mark.developmode),
 ]
-advection_scheme = ["UPSTREAM", "CENTRAL", "TVD", "UTVD"]
+
+
+advection_scheme = ["upstream", "central", "tvd", "utvd"]
 
 lx = 2.0
 lz = 1.0
@@ -216,8 +218,7 @@ def get_gwt_model(sim, model_shape, model_desc, adv_scheme):
     return gwt
 
 
-def build_models(idx, test):
-    name = cases[idx]
+def build_models(idx, name, test):
     print("RUINNING: ", name, advection_scheme[idx])
 
     # build MODFLOW 6 files
@@ -398,14 +399,14 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.parametrize("idx, name", cases)
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t),
+        build=lambda t: build_models(idx, name, t),
         check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_par_gwt_henry.py
+++ b/autotest/test_par_gwt_henry.py
@@ -6,13 +6,18 @@ test_gwt_henry_gwtgwt.py and runs it in parallel mode.
 import pytest
 from framework import TestFramework
 
-cases = ["par-henry-ups", "par-henry-cen", "par-henry-tvd", "par-henry-utvd"]
+cases = [
+    pytest.param(0, "par-henry-ups"),
+    pytest.param(1, "par-henry-cen"),
+    pytest.param(2, "par-henry-tvd"),
+    pytest.param(3, "par-henry-utvd", marks=pytest.mark.developmode),
+]
 
 
-def build_models(idx, test):
+def build_models(idx, name, test):
     from test_gwt_henry_gwtgwt import build_models as build
 
-    sim, dummy = build(idx, test)
+    sim, dummy = build(idx, name, test)
     return sim, dummy
 
 
@@ -23,13 +28,13 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.parametrize("idx, name", cases)
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t),
+        build=lambda t: build_models(idx, name, t),
         check=lambda t: check_output(idx, t),
         compare=None,
         parallel=True,

--- a/doc/mf6io/mf6ivar/dfn/gwt-adv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-adv.dfn
@@ -3,11 +3,11 @@
 block options
 name scheme
 type string
-valid central upstream tvd utvd
+valid central upstream tvd
 reader urword
 optional true
 longname advective scheme
-description scheme used to solve the advection term.  Can be upstream, central, TVD or UTVD.  If not specified, upstream weighting is the default weighting scheme.
+description scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.
 
 block options
 name ats_percel

--- a/src/Model/TransportModel/tsp-adv.f90
+++ b/src/Model/TransportModel/tsp-adv.f90
@@ -376,8 +376,8 @@ contains
     end if
 
     if (this%iadvwt == ADV_SCHEME_UTVD) then
-        call dev_feature('UTVD is still under development, install the &
-            &nightly build or compile from source with IDEVELOPMODE = 1.')
+      call dev_feature('UTVD is still under development, install the &
+          &nightly build or compile from source with IDEVELOPMODE = 1.')
     end if
 
     if (found_atspercel) then

--- a/src/Model/TransportModel/tsp-adv.f90
+++ b/src/Model/TransportModel/tsp-adv.f90
@@ -2,6 +2,7 @@ module TspAdvModule
 
   use KindModule, only: DP, I4B
   use ConstantsModule, only: DONE, DZERO, DNODATA, DPREC, LINELENGTH
+  use DevFeatureModule, only: dev_feature
   use NumericalPackageModule, only: NumericalPackageType
   use BaseDisModule, only: DisBaseType
   use TspFmiModule, only: TspFmiType
@@ -373,6 +374,12 @@ contains
         this%iadvwt = this%iadvwt - 1
       end if
     end if
+
+    if (this%iadvwt == ADV_SCHEME_UTVD) then
+        call dev_feature('UTVD is still under development, install the &
+            &nightly build or compile from source with IDEVELOPMODE = 1.')
+    end if
+
     if (found_atspercel) then
       if (this%ats_percel == DZERO) this%ats_percel = DNODATA
     end if


### PR DESCRIPTION
This PR puts the UTVD feature behind a feature flag.
The pytests need some rework the be compatible with the flag

Checklist of items for pull request

- [ ] Replaced section above with description of pull request
- [ ] Closed issue #xxxx
- [ ] Referenced issue or pull request #xxxx
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
