### PR TITLE
doc(dnfs; mf6io): in descriptions, capitalization of "NetCDF"

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwe-cnd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-cnd.dfn
@@ -34,7 +34,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwe cnd griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 block options
@@ -128,7 +128,7 @@ reader urword
 tagged true
 optional false
 longname ncf keyword
-description keyword to specify that record corresponds to a netcdf configuration (NCF) file.
+description keyword to specify that record corresponds to a NetCDF configuration (NCF) file.
 extended true
 
 block options
@@ -150,7 +150,7 @@ reader urword
 optional false
 tagged false
 longname file name of NCF information
-description defines a netcdf configuration (NCF) input file.
+description defines a NetCDF configuration (NCF) input file.
 extended true
 
 # --------------------- gwe dis dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 block options
@@ -128,7 +128,7 @@ reader urword
 tagged true
 optional false
 longname ncf keyword
-description keyword to specify that record corresponds to a netcdf configuration (NCF) file.
+description keyword to specify that record corresponds to a NetCDF configuration (NCF) file.
 extended true
 
 block options
@@ -150,7 +150,7 @@ reader urword
 optional false
 tagged false
 longname file name of NCF information
-description defines a netcdf configuration (NCF) input file.
+description defines a NetCDF configuration (NCF) input file.
 extended true
 
 # --------------------- gwe disv dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwe-ic.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-ic.dfn
@@ -16,7 +16,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwe ic griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwe-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-nam.dfn
@@ -51,7 +51,7 @@ reader urword
 tagged true
 optional true
 longname
-description netcdf layered mesh fileout record.
+description NetCDF layered mesh fileout record.
 mf6internal ncmesh2drec
 
 block options
@@ -63,7 +63,7 @@ reader urword
 tagged true
 optional false
 longname budget keyword
-description keyword to specify that record corresponds to a layered mesh netcdf file.
+description keyword to specify that record corresponds to a layered mesh NetCDF file.
 extended true
 
 block options
@@ -74,7 +74,7 @@ reader urword
 tagged true
 optional true
 longname
-description netcdf structured fileout record.
+description NetCDF structured fileout record.
 mf6internal ncstructrec
 
 block options
@@ -86,7 +86,7 @@ reader urword
 tagged true
 optional false
 longname budget keyword
-description keyword to specify that record corresponds to a structured netcdf file.
+description keyword to specify that record corresponds to a structured NetCDF file.
 mf6internal netcdf_struct
 extended true
 
@@ -111,7 +111,7 @@ reader urword
 tagged false
 optional false
 longname file keyword
-description name of the netcdf ugrid layered mesh output file.
+description name of the NetCDF ugrid layered mesh output file.
 extended true
 
 block options
@@ -124,7 +124,7 @@ reader urword
 tagged false
 optional false
 longname file keyword
-description name of the netcdf structured output file.
+description name of the NetCDF structured output file.
 extended true
 
 block options
@@ -134,7 +134,7 @@ reader urword
 tagged true
 optional true
 longname
-description netcdf filerecord
+description NetCDF filerecord
 
 block options
 name netcdf
@@ -144,7 +144,7 @@ reader urword
 tagged true
 optional false
 longname netcdf keyword
-description keyword to specify that record corresponds to a netcdf input file.
+description keyword to specify that record corresponds to a NetCDF input file.
 extended true
 
 block options
@@ -166,7 +166,7 @@ reader urword
 optional false
 tagged false
 longname netcdf input filename
-description defines a netcdf input file.
+description defines a NetCDF input file.
 mf6internal netcdf_fname
 extended true
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-chdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-chdg.dfn
@@ -107,7 +107,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # dev options

--- a/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 block options
@@ -128,7 +128,7 @@ reader urword
 tagged true
 optional false
 longname ncf keyword
-description keyword to specify that record corresponds to a netcdf configuration (NCF) file.
+description keyword to specify that record corresponds to a NetCDF configuration (NCF) file.
 extended true
 
 block options
@@ -150,7 +150,7 @@ reader urword
 optional false
 tagged false
 longname file name of NCF information
-description defines a netcdf configuration (NCF) input file.
+description defines a NetCDF configuration (NCF) input file.
 extended true
 
 # --------------------- gwf dis dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 block options
@@ -128,7 +128,7 @@ reader urword
 tagged true
 optional false
 longname ncf keyword
-description keyword to specify that record corresponds to a netcdf configuration (NCF) file.
+description keyword to specify that record corresponds to a NetCDF configuration (NCF) file.
 extended true
 
 block options
@@ -150,7 +150,7 @@ reader urword
 optional false
 tagged false
 longname file name of NCF information
-description defines a netcdf configuration (NCF) input file.
+description defines a NetCDF configuration (NCF) input file.
 extended true
 
 # --------------------- gwf disv dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
@@ -125,7 +125,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # dev options

--- a/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
@@ -148,7 +148,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwf evta period ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
@@ -116,7 +116,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwf ghbg dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-ic.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-ic.dfn
@@ -16,7 +16,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwf ic griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-nam.dfn
@@ -66,7 +66,7 @@ reader urword
 tagged true
 optional true
 longname
-description netcdf layered mesh fileout record.
+description NetCDF layered mesh fileout record.
 mf6internal ncmesh2drec
 
 block options
@@ -78,7 +78,7 @@ reader urword
 tagged true
 optional false
 longname budget keyword
-description keyword to specify that record corresponds to a layered mesh netcdf file. 
+description keyword to specify that record corresponds to a layered mesh NetCDF file. 
 extended true
 
 block options
@@ -89,7 +89,7 @@ reader urword
 tagged true
 optional true
 longname
-description netcdf structured fileout record.
+description NetCDF structured fileout record.
 mf6internal ncstructrec
 
 block options
@@ -101,7 +101,7 @@ reader urword
 tagged true
 optional false
 longname budget keyword
-description keyword to specify that record corresponds to a structured netcdf file.
+description keyword to specify that record corresponds to a structured NetCDF file.
 mf6internal netcdf_struct
 extended true
 
@@ -126,7 +126,7 @@ reader urword
 tagged false
 optional false
 longname file keyword
-description name of the netcdf ugrid layered mesh output file.
+description name of the NetCDF ugrid layered mesh output file.
 extended true
 
 block options
@@ -139,7 +139,7 @@ reader urword
 tagged false
 optional false
 longname file keyword
-description name of the netcdf structured output file.
+description name of the NetCDF structured output file.
 extended true
 
 block options
@@ -149,7 +149,7 @@ reader urword
 tagged true
 optional true
 longname
-description netcdf filerecord
+description NetCDF filerecord
 
 block options
 name netcdf
@@ -159,7 +159,7 @@ reader urword
 tagged true
 optional false
 longname netcdf keyword
-description keyword to specify that record corresponds to a netcdf input file.
+description keyword to specify that record corresponds to a NetCDF input file.
 extended true
 
 block options
@@ -181,7 +181,7 @@ reader urword
 optional false
 tagged false
 longname netcdf input filename
-description defines a netcdf input file.
+description defines a NetCDF input file.
 mf6internal netcdf_fname
 extended true
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-npf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-npf.dfn
@@ -240,7 +240,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # dev options

--- a/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
@@ -148,7 +148,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwf rcha period ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-rivg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rivg.dfn
@@ -116,7 +116,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwf rivg dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-sto.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sto.dfn
@@ -85,7 +85,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # dev options

--- a/doc/mf6io/mf6ivar/dfn/gwf-vsc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-vsc.dfn
@@ -111,7 +111,7 @@ type integer
 reader urword
 optional false
 longname number of species used in viscosity equation of state
-description number of species used in the viscosity equation of state.  If either concentrations or temperature (or both) are used to update viscosity then then nviscspecies needs to be at least one.
+description number of species used in the viscosity equation of state.  If either concentrations or temperature (or both) are used to update viscosity then nviscspecies needs to be at least one.
 
 
 # --------------------- gwf vsc packagedata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
@@ -171,7 +171,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwf wel dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 block options
@@ -128,7 +128,7 @@ reader urword
 tagged true
 optional false
 longname ncf keyword
-description keyword to specify that record corresponds to a netcdf configuration (NCF) file.
+description keyword to specify that record corresponds to a NetCDF configuration (NCF) file.
 extended true
 
 block options
@@ -150,7 +150,7 @@ reader urword
 optional false
 tagged false
 longname file name of NCF information
-description defines a netcdf configuration (NCF) input file.
+description defines a NetCDF configuration (NCF) input file.
 extended true
 
 # --------------------- gwt dis dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 block options
@@ -128,7 +128,7 @@ reader urword
 tagged true
 optional false
 longname ncf keyword
-description keyword to specify that record corresponds to a netcdf configuration (NCF) file.
+description keyword to specify that record corresponds to a NetCDF configuration (NCF) file.
 extended true
 
 block options
@@ -150,7 +150,7 @@ reader urword
 optional false
 tagged false
 longname file name of NCF information
-description defines a netcdf configuration (NCF) input file.
+description defines a NetCDF configuration (NCF) input file.
 extended true
 
 # --------------------- gwt disv dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-dsp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-dsp.dfn
@@ -34,7 +34,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwt dsp griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-ic.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-ic.dfn
@@ -16,7 +16,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwt ic griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-ist.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-ist.dfn
@@ -275,7 +275,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwt ist griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-mst.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-mst.dfn
@@ -96,7 +96,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 extended true
 
 # --------------------- gwt mst griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-nam.dfn
@@ -51,7 +51,7 @@ reader urword
 tagged true
 optional true
 longname
-description netcdf layered mesh fileout record.
+description NetCDF layered mesh fileout record.
 mf6internal ncmesh2drec
 
 block options
@@ -63,7 +63,7 @@ reader urword
 tagged true
 optional false
 longname budget keyword
-description keyword to specify that record corresponds to a layered mesh netcdf file.
+description keyword to specify that record corresponds to a layered mesh NetCDF file.
 extended true
 
 block options
@@ -74,7 +74,7 @@ reader urword
 tagged true
 optional true
 longname
-description netcdf structured fileout record.
+description NetCDF structured fileout record.
 mf6internal ncstructrec
 
 block options
@@ -86,7 +86,7 @@ reader urword
 tagged true
 optional false
 longname budget keyword
-description keyword to specify that record corresponds to a structured netcdf file.
+description keyword to specify that record corresponds to a structured NetCDF file.
 mf6internal netcdf_struct
 extended true
 
@@ -111,7 +111,7 @@ reader urword
 tagged false
 optional false
 longname file keyword
-description name of the netcdf ugrid layered mesh output file.
+description name of the NetCDF ugrid layered mesh output file.
 extended true
 
 block options
@@ -124,7 +124,7 @@ reader urword
 tagged false
 optional false
 longname file keyword
-description name of the netcdf structured output file.
+description name of the NetCDF structured output file.
 extended true
 
 block options
@@ -134,7 +134,7 @@ reader urword
 tagged true
 optional true
 longname
-description netcdf filerecord
+description NetCDF filerecord
 
 block options
 name netcdf
@@ -144,7 +144,7 @@ reader urword
 tagged true
 optional false
 longname netcdf keyword
-description keyword to specify that record corresponds to a netcdf input file.
+description keyword to specify that record corresponds to a NetCDF input file.
 extended true
 
 block options
@@ -166,7 +166,7 @@ reader urword
 optional false
 tagged false
 longname netcdf input filename
-description defines a netcdf input file.
+description defines a NetCDF input file.
 mf6internal netcdf_fname
 extended true
 

--- a/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
@@ -96,7 +96,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 
 block options
 name crs
@@ -126,7 +126,7 @@ reader urword
 tagged true
 optional false
 longname ncf keyword
-description keyword to specify that record corresponds to a netcdf configuration (NCF) file.
+description keyword to specify that record corresponds to a NetCDF configuration (NCF) file.
 
 block options
 name filein
@@ -147,7 +147,7 @@ reader urword
 optional false
 tagged false
 longname file name of NCF information
-description defines a netcdf configuration (NCF) input file.
+description defines a NetCDF configuration (NCF) input file.
 
 # --------------------- prt dis dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
@@ -96,7 +96,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output netcdf file.
+description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
 
 block options
 name crs
@@ -126,7 +126,7 @@ reader urword
 tagged true
 optional false
 longname ncf keyword
-description keyword to specify that record corresponds to a netcdf configuration (NCF) file.
+description keyword to specify that record corresponds to a NetCDF configuration (NCF) file.
 
 block options
 name filein
@@ -147,7 +147,7 @@ reader urword
 optional false
 tagged false
 longname file name of NCF information
-description defines a netcdf configuration (NCF) input file.
+description defines a NetCDF configuration (NCF) input file.
 
 # --------------------- prt disv dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/utl-ncf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-ncf.dfn
@@ -18,7 +18,7 @@ type integer
 reader urword
 optional true
 longname variable compression deflate level
-description is the variable deflate level (0=min, 9=max) in the netcdf file. Defining this parameter activates per-variable compression at the level specified.
+description is the variable deflate level (0=min, 9=max) in the NetCDF file. Defining this parameter activates per-variable compression at the level specified.
 
 block options
 name shuffle
@@ -26,7 +26,7 @@ type keyword
 reader urword
 optional true
 longname
-description is the keyword used to turn on the netcdf variable shuffle filter when the deflate option is also set. The shuffle filter has the effect of storing the first byte of all of a variable's values in a chunk contiguously, followed by all the second bytes, etc. This can be an optimization for compression with certain types of data.
+description is the keyword used to turn on the NetCDF variable shuffle filter when the deflate option is also set. The shuffle filter has the effect of storing the first byte of all of a variable's values in a chunk contiguously, followed by all the second bytes, etc. This can be an optimization for compression with certain types of data.
 
 block options
 name chunk_time
@@ -74,7 +74,7 @@ type keyword
 reader urword
 optional true
 longname
-description is the keyword used to turn off internal input tagging in the model netcdf file. Tagging adds internal modflow 6 attribute(s) to variables which facilitate identification. Currently this applies to gridded arrays.
+description is the keyword used to turn off internal input tagging in the model NetCDF file. Tagging adds internal modflow 6 attribute(s) to variables which facilitate identification. Currently this applies to gridded arrays.
 mf6internal attr_off
 
 # --------------------- utl ncf dimensions ---------------------


### PR DESCRIPTION
For consistency with other instances of "NetCDF" in mf6io, changed capitalization from "netcdf" to "NetCDF" in appropriate places in dfn descriptions