### PR TITLE
refactor(prt): introduce functions for face numbering schemes

### DIFF
--- a/src/Model/ParticleTracking/prt-fmi.f90
+++ b/src/Model/ParticleTracking/prt-fmi.f90
@@ -33,7 +33,7 @@ module PrtFmiModule
     procedure :: mark_boundary_face
     procedure :: is_boundary_face
     procedure :: is_net_out_boundary_face
-    procedure, private :: iflowface_to_iface
+    procedure, private :: iflowface_to_icellface
 
   end type PrtFmiType
 
@@ -155,7 +155,7 @@ contains
     class(PrtFmiType) :: this
     ! local
     integer(I4B) :: j, i, ip, ib
-    integer(I4B) :: ioffset, iflowface, iauxiflowface, iface
+    integer(I4B) :: ioffset, iflowface, iauxiflowface, icellface
     real(DP) :: qbnd
     character(len=LENAUXNAME) :: auxname
     integer(I4B) :: naux
@@ -188,17 +188,17 @@ contains
         if (this%ibound(i) <= 0) cycle
         qbnd = this%gwfpackages(ip)%get_flow(ib)
         ! todo, after initial release: default iflowface values for different packages
-        iflowface = 0 ! iflowface number
-        iface = 0 ! internal face number
+        iflowface = 0
+        icellface = 0
         if (iauxiflowface > 0) then
           iflowface = NINT(this%gwfpackages(ip)%auxvar(iauxiflowface, ib))
-          iface = this%iflowface_to_iface(iflowface)
+          icellface = this%iflowface_to_icellface(iflowface)
         end if
-        if (iface > 0) then
-          call this%mark_boundary_face(i, iface)
+        if (icellface > 0) then
+          call this%mark_boundary_face(i, icellface)
           ioffset = (i - 1) * this%max_faces
-          this%BoundaryFlows(ioffset + iface) = &
-            this%BoundaryFlows(ioffset + iface) + qbnd
+          this%BoundaryFlows(ioffset + icellface) = &
+            this%BoundaryFlows(ioffset + icellface) + qbnd
         else if (qbnd .gt. DZERO) then
           this%SourceFlows(i) = this%SourceFlows(i) + qbnd
         else if (qbnd .lt. DZERO) then
@@ -213,7 +213,7 @@ contains
   subroutine mark_boundary_face(this, ic, iface)
     class(PrtFmiType) :: this
     integer(I4B), intent(in) :: ic !< node number (reduced)
-    integer(I4B), intent(in) :: iface !< face number
+    integer(I4B), intent(in) :: iface !< cell face number
     ! local
     integer(I4B) :: bit_pos
 
@@ -240,7 +240,7 @@ contains
   function is_boundary_face(this, ic, iface) result(is_boundary)
     class(PrtFmiType) :: this
     integer(I4B), intent(in) :: ic !< node number (reduced)
-    integer(I4B), intent(in) :: iface !< face number
+    integer(I4B), intent(in) :: iface !< cell face number
     logical(LGP) :: is_boundary
     ! local
     integer(I4B) :: bit_pos
@@ -269,7 +269,7 @@ contains
   function is_net_out_boundary_face(this, ic, iface) result(is_net_out_boundary)
     class(PrtFmiType) :: this
     integer(I4B), intent(in) :: ic !< node number (reduced)
-    integer(I4B), intent(in) :: iface !< face number
+    integer(I4B), intent(in) :: iface !< cell face number
     logical(LGP) :: is_net_out_boundary
     ! local
     integer(I4B) :: ioffset
@@ -280,15 +280,15 @@ contains
     if (this%BoundaryFlows(ioffset + iface) < DZERO) is_net_out_boundary = .true.
   end function is_net_out_boundary_face
 
-  !> @brief Convert an iflowface number to an iface number
-  function iflowface_to_iface(this, iflowface) result(iface)
+  !> @brief Convert an iflowface number to a cell face number.
+  !! Maps bottom (-2) -> max_faces - 1, top (-1) -> max_faces.
+  function iflowface_to_icellface(this, iflowface) result(iface)
     class(PrtFmiType), intent(inout) :: this
     integer(I4B), intent(in) :: iflowface
     integer(I4B) :: iface
 
     iface = iflowface
-    ! maps bot -2 -> max_faces - 1, top -1 -> max_faces
     if (iface < 0) iface = iface + this%max_faces + 1
-  end function iflowface_to_iface
+  end function iflowface_to_icellface
 
 end module PrtFmiModule

--- a/src/Model/ParticleTracking/prt-fmi.f90
+++ b/src/Model/ParticleTracking/prt-fmi.f90
@@ -17,8 +17,8 @@ module PrtFmiModule
   character(len=LENPACKAGENAME) :: text = '    PRTFMI'
 
   type, extends(FlowModelInterfaceType) :: PrtFmiType
-
-    integer(I4B) :: max_faces !< maximum number of faces for grid cell polygons
+    private
+    integer(I4B), public :: max_faces !< maximum number of faces for grid cell polygons
     real(DP), allocatable, public :: SourceFlows(:) ! cell source flows array
     real(DP), allocatable, public :: SinkFlows(:) ! cell sink flows array
     real(DP), allocatable, public :: StorageFlows(:) ! cell storage flows array
@@ -33,6 +33,7 @@ module PrtFmiModule
     procedure :: mark_boundary_face
     procedure :: is_boundary_face
     procedure :: is_net_out_boundary_face
+    procedure, private :: iflowface_to_iface
 
   end type PrtFmiType
 
@@ -191,9 +192,7 @@ contains
         iface = 0 ! internal face number
         if (iauxiflowface > 0) then
           iflowface = NINT(this%gwfpackages(ip)%auxvar(iauxiflowface, ib))
-          iface = iflowface
-          ! maps bot -2 -> max_faces - 1, top -1 -> max_faces
-          if (iface < 0) iface = iface + this%max_faces + 1
+          iface = this%iflowface_to_iface(iflowface)
         end if
         if (iface > 0) then
           call this%mark_boundary_face(i, iface)
@@ -280,5 +279,16 @@ contains
     ioffset = (ic - 1) * this%max_faces
     if (this%BoundaryFlows(ioffset + iface) < DZERO) is_net_out_boundary = .true.
   end function is_net_out_boundary_face
+
+  !> @brief Convert an iflowface number to an iface number
+  function iflowface_to_iface(this, iflowface) result(iface)
+    class(PrtFmiType), intent(inout) :: this
+    integer(I4B), intent(in) :: iflowface
+    integer(I4B) :: iface
+
+    iface = iflowface
+    ! maps bot -2 -> max_faces - 1, top -1 -> max_faces
+    if (iface < 0) iface = iface + this%max_faces + 1
+  end function iflowface_to_iface
 
 end module PrtFmiModule

--- a/src/Solution/ParticleTracker/Method/MethodCell.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCell.f90
@@ -22,7 +22,7 @@ module MethodCellModule
     procedure, public :: store_event
     procedure, public :: get_level
     procedure, public :: try_pass
-    procedure :: iboundary_to_iface
+    procedure :: iboundary_to_icellface
   end type MethodCellType
 
 contains
@@ -40,7 +40,7 @@ contains
     logical(LGP) :: advancing
     integer(I4B) :: nextlevel
     ! local
-    integer(I4B) :: ic, iboundary, iface
+    integer(I4B) :: ic, iboundary, icellface
 
     if (.not. particle%advancing) then
       advancing = .false.
@@ -51,8 +51,8 @@ contains
     call this%pass(particle)
 
     iboundary = particle%iboundary(LEVEL_FEATURE)
-    iface = this%iboundary_to_iface(iboundary)
-    if (iface <= 0) return
+    icellface = this%iboundary_to_icellface(iboundary)
+    if (icellface <= 0) return
 
     ! on a cell face, done advancing. raise an exit event
     advancing = .false.
@@ -60,7 +60,7 @@ contains
 
     ! assigned boundary face with net outflow? terminate
     ic = particle%itrdomain(LEVEL_FEATURE)
-    if (this%fmi%is_net_out_boundary_face(ic, iface)) then
+    if (this%fmi%is_net_out_boundary_face(ic, icellface)) then
       call this%terminate(particle, status=TERM_BOUNDARY)
       return
     end if
@@ -310,7 +310,7 @@ contains
   end function get_level
 
   !> @brief Convert an iboundary number to an iface number
-  function iboundary_to_iface(this, iboundary) result(iface)
+  function iboundary_to_icellface(this, iboundary) result(iface)
     class(MethodCellType), intent(inout) :: this
     integer(I4B), intent(in) :: iboundary
     integer(I4B) :: iface
@@ -321,6 +321,6 @@ contains
     if (iface >= nfaces) &
       ! uncompress and drop wraparound index
       iface = iface + (this%fmi%max_faces - nfaces) - 1
-  end function iboundary_to_iface
+  end function iboundary_to_icellface
 
 end module MethodCellModule

--- a/src/Solution/ParticleTracker/Method/MethodCell.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCell.f90
@@ -22,6 +22,7 @@ module MethodCellModule
     procedure, public :: store_event
     procedure, public :: get_level
     procedure, public :: try_pass
+    procedure :: iboundary_to_iface
   end type MethodCellType
 
 contains
@@ -39,7 +40,7 @@ contains
     logical(LGP) :: advancing
     integer(I4B) :: nextlevel
     ! local
-    integer(I4B) :: ic, iface, nfaces
+    integer(I4B) :: ic, iboundary, iface
 
     if (.not. particle%advancing) then
       advancing = .false.
@@ -49,12 +50,8 @@ contains
 
     call this%pass(particle)
 
-    ! TODO: name iface variables to reflect the face numbering scheme
-    iface = particle%iboundary(LEVEL_FEATURE)
-    nfaces = this%cell%defn%npolyverts + 2 ! total 3d faces
-    if (iface >= nfaces) &
-      ! uncompress and drop wraparound index
-      iface = iface + (this%fmi%max_faces - nfaces) - 1
+    iboundary = particle%iboundary(LEVEL_FEATURE)
+    iface = this%iboundary_to_iface(iboundary)
     if (iface <= 0) return
 
     ! on a cell face, done advancing. raise an exit event
@@ -311,5 +308,19 @@ contains
     integer(I4B) :: level
     level = LEVEL_FEATURE
   end function get_level
+
+  !> @brief Convert an iboundary number to an iface number
+  function iboundary_to_iface(this, iboundary) result(iface)
+    class(MethodCellType), intent(inout) :: this
+    integer(I4B), intent(in) :: iboundary
+    integer(I4B) :: iface
+    integer(I4B) :: nfaces
+
+    iface = iboundary
+    nfaces = this%cell%defn%npolyverts + 2
+    if (iface >= nfaces) &
+      ! uncompress and drop wraparound index
+      iface = iface + (this%fmi%max_faces - nfaces) - 1
+  end function iboundary_to_iface
 
 end module MethodCellModule


### PR DESCRIPTION
It's tricky to get these conversions right, so pull them into functions.

There are three face numbering schemes to keep straight. Given `NLATFACES` is each cell's number of lateral faces and `NMAXFACES` is the maximum number of 3d faces (i.e. including top and bottom) of any cell in the grid,

- iflowface: described in mf6io and specified by the user, lateral `1..NLATFACES`, bottom `-2`, top `-1`
- iboundary: internal compressed numbering. lateral `1..NLATFACES`, bottom `NLATFACES + 2`, top `NLATFACES + 3`. the extra offset is because the first lateral face "wraps around". this scheme is used by the tracking method
- icellface: internal grid-aligned numbering. lateral `1..NLATFACES`, bottom `NMAXFACES - 1`, top `NMAXFACES`. this is the numbering used by PRT FMI and expected as input to assigned boundary face check functions

This is as described in https://github.com/MODFLOW-ORG/modflow6/pull/2446#discussion_r2298384910 except for icellface numbering being aligned to the grid's max face count instead of the bit mask size. The iboundary scheme is used in the tracking method since it aligns with the arrays holding cell geometry. The "grid-aligned" icellface scheme is used by FMI so callers can reliably specify top/bottom face to the boundary face check routines without knowing a particular cell's face count, just the grid maximum.

The new conversion functions are private for now but could be made public later if conversion is necessary elsewhere