### PR TITLE
docs(distribution): rewrite release runbook

### DIFF
--- a/distribution/README.md
+++ b/distribution/README.md
@@ -1,132 +1,296 @@
 # Distributing MODFLOW 6
 
-This document describes release procedures for MODFLOW 6.
+This document describes how to release MODFLOW 6. This folder contains scripts used to create distributions.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Overview](#overview)
-- [Requirements](#requirements)
+- [Flavors](#flavors)
+  - [Development](#development)
+  - [Standard](#standard)
+- [Versioning](#versioning)
+  - [Patch](#patch)
+  - [Minor](#minor)
 - [Steps](#steps)
-  - [Update release notes](#update-release-notes)
-  - [Update version info](#update-version-info)
-  - [Build makefiles](#build-makefiles)
-  - [Build example models](#build-example-models)
-  - [Benchmark example models](#benchmark-example-models)
-  - [Build documentation](#build-documentation)
-  - [Build the distribution archive](#build-the-distribution-archive)
-  - [Verify the distribution archive](#verify-the-distribution-archive)
-- [Procedure](#procedure)
+  - [Review features](#review-features)
+  - [Review deprecations](#review-deprecations)
+  - [Review release notes](#review-release-notes)
+  - [Create a release branch](#create-a-release-branch)
+  - [Build assets/distributions](#build-assetsdistributions)
+  - [Merge release branch to master](#merge-release-branch-to-master)
+  - [Publish the release](#publish-the-release)
+  - [Reset the develop branch](#reset-the-develop-branch)
+    - [Update version strings](#update-version-strings)
+    - [Update release notes](#update-release-notes)
+- [Actions](#actions)
+  - [Dispatch workflow](#dispatch-workflow)
+  - [Release workflow](#release-workflow)
+- [Scripts](#scripts)
+  - [Updating version numbers](#updating-version-numbers)
+  - [Regenerating build files](#regenerating-build-files)
+  - [Collecting deprecations](#collecting-deprecations)
+  - [Benchmarking examples](#benchmarking-examples)
+  - [Building PDF documents](#building-pdf-documents)
+  - [Building distributions](#building-distributions)
+  - [Checking distributions](#checking-distributions)
 - [Testing](#testing)
   - [Testing release scripts](#testing-release-scripts)
   - [Testing the release workflow](#testing-the-release-workflow)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## Overview
+## Flavors
 
-MODFLOW 6 releases come in two flavors:
+There are two kinds of distribution: provisional development builds and standard approved releases.
 
-- nightly development builds
-- full/approved distributions
+### Provisional
 
-Development builds are created nightly from the tip of the `develop` branch and released from the [`MODFLOW-ORG/modflow6-nightly-build` repository](https://github.com/MODFLOW-ORG/modflow6-nightly-build). Development distributions contain only MODFLOW 6 input/output documentation, release notes, `code.json` metadata, and core executables and libraries:
+Provisional develop builds are created nightly from the `develop` branch and released from the [`MODFLOW-ORG/modflow6-nightly-build` repository](https://github.com/MODFLOW-ORG/modflow6-nightly-build). Development distributions contain only input/output documentation, release notes, `code.json` metadata, and binaries:
 
 - `mf6`: MODFLOW 6 executable
 - `zbud6`: Zonebudget executable
 - `mf5to6`: MODFLOW 5 to 6 converter executable
 - `libmf6`: MODFLOW 6 dynamic library
 
-Full distributions contain the items listed above, as well as:
+Binaries are built in develop mode, with feature flags disabled, making prerelease features accessible.
 
-- Meson build files
+Running `mf6 -d` shows language describing the preliminary state of the software.
+
+### Standard
+
+Standard releases contain everything in development builds, plus:
+
 - Fortran source code
-- MODFLOW 6 example models
-- MODFLOW 6 makefiles
-- MODFLOW 6 Visual Studio files
-- more extensive documentation, including:
-  - MODFLOW 6 input/output docs
-  - MODFLOW 6 example model docs
-  - MODFLOW 6 release notes
-  - MODFLOW 6 supplementary technical information
-  - docs for various MODFLOW 6 features and packages
+- Meson files, makefiles, MSVS project files
+- MF6 example models
+- extensive docs:
+  - MF6 input/output guide
+  - example model docs
+  - release notes
+  - supplementary technical information
   - docs for `mf5to6` and `zbud6`
 
-Official releases can be classified further into two types: patch and minor releases. Patch releases should typically branch from `master` and cherry-pick relevant commits, since `develop` may contain broader changes not yet ready for release. Minor releases typically branch from `develop`. MODFLOW 6 does not currently increment the major version number.
+Binaries are built in release mode, with feature flags enabled, making prerelease features inaccessible. Prerelease features are filtered out of the generated documentation.
 
-Both nightly builds and official distributions are created automatically with GitHub Actions.
+Running `mf6 -d` shows language affirming that the software has been reviewed and approved for distribution.
 
-## Requirements
+## Versioning
 
-This document assumes a MODFLOW 6 development environment has been configured as per the [developer documentation](../DEVELOPER.md), including a Fortran compiler (either `ifort` or `gfortran`) as well as a Pixi environment as specified in `pixi.toml`. Official distributions are currently prepared with Intel Fortran (`ifort`).
+MF6 loosely follows a modified form of [semantic versioning](semver.org).
+
+### Patch
+
+Patch releases contain bugfixes and behavior changes related to correctness.
+
+Patch releases may be made in one of two ways.
+
+- Branch from `master` and cherry-pick commits. "Hotfix" release.
+- Branch from `develop` and use feature flags: "Flagged" release.
+
+Hotfixes are quick and suitable for urgent, narrowly-scoped patches. Flagged releases need more careful preparation, but [trunk-based development](https://www.atlassian.com/continuous-delivery/continuous-integration/trunk-based-development) allows incremental development of features on the mainline.
+
+### Minor
+
+Minor releases may contain bugfixes, changes and new features. Minor releases branch from `develop`.
+
+There are no major releases as the MF6 major version number is constant. Breaking changes are made in minor releases.
 
 ## Steps
 
-Broadly, steps to prepare an official release for distribution include:
+If building distributions locally, a development environment [must be configured](../DEVELOPER.md) including a Fortran compiler and a Python environment. If using GitHub Actions, nothing is needed besides `git`.  This section assumes releases are made with GitHub Actions.
 
-- update release notes for the release (and reset them after)
-- update version information with `update_version.py`
-- (re)build makefiles with `build_makefiles.py`
-- benchmark example models with `benchmark.py`
-- build the MF6IO documentation with `build_docs.py`
-- build the distribution archive with `build_dist.py`
-- verify the distribution archive with `check_dist.py`
+To make a release,
 
-These should occur roughly in the order presented above. The procedure is automated in the `.github/workflows/release.yml` and `release_dispatch.yml` workflows.
+1. review features
+2. review deprecations
+3. review release notes
+4. release examples repo
+5. create a release branch
+6. build assets/distributions
+7. merge release branch to master
+8. publish the release
+9. reset the develop branch
 
-**Note**: `git`- and/or GitHub-related steps are omitted from this section. See the [Procedure](#procedure) section below for a step-by-step recipe for creating and distributing release with the help of GitHub Actions.
+The release manager undertakes steps 1-3 in consultation with the development team. Step 4 [is described in the examples repository's developer docs](https://github.com/MODFLOW-ORG/modflow6-examples/blob/develop/DEVELOPER.md#releasing-the-examples). Step 5 triggers automation for steps 6-9.
 
-### Update release notes
+### Review features
 
-The release notes PDF document is constructed from the `doc/ReleaseNotes/ReleaseNotes.tex` LaTeX file. During development, release notes should be maintained in `doc/ReleaseNotes/develop.toml` &mdash; this file is turned into a LaTeX file by `doc/ReleaseNotes/mk_releasenotes.py`. A pixi task is available for this, e.g. `pixi run make-release-notes`. The resulting LaTex file is referenced from `doc/ReleaseNotes/ReleaseNotes.tex`.
+Determine whether any new developments need feature flags. To help keep the trunk prepared for a prompt release, it may be convenient to guard code and docs with feature flags by convention until the new features are ready for release.
 
-Before making a release, add a line to the Release History section of `ReleaseNotes.tex` providing the version number, date and DOI of the current release, e.g. `6.4.4 & February 13, 2024 & \url{https://doi.org/10.5066/P9FL1JCC}`.
+Code can be guarded with the `dev_feature` routine in `DevFeatureModule`. DFN variables may be guarded with an attribute `prerelease true`. LaTeX sections may be wrapped in `\ifdevelopmode ... \fi`
 
-**Note**: Deprecated and removed MF6IO options are included in the release notes. See the [developer docs](../DEVELOPER.md#deprecation-policy) for more info on deprecation policy, searching for deprecations among DFNs, and generating a deprecations/removals table for insertion into the release notes.
+### Review deprecations
 
-### Update version info
+Before proceeding with a release, check for deprecated DFN variables due for removal. See the [developer docs](../DEVELOPER.md#deprecation-policy) for more info on deprecation policy and how to search DFNs for deprecated variables. Deprecated/removed variables are automatically detected and inserted into a table in the release notes.
 
-MODFLOW 6 version numbers follow the [semantic versioning](https://semver.org/) convention `major.minor.patch`. Release tags do *not* include an initial `v`, as is common in many other projects.
+### Review release notes
 
-Version information is stored primarily in `version.txt` in the project root, as well as in several other files in the repository.
+Double-check release notes in `doc/ReleaseNotes/develop.toml` with the authors of any changes to be included in the release.
 
-The `update_version.py` script updates files containing version information. First a file lock is acquired, then repository files are updated, then the lock is released.
+For hotfix releases, `develop.toml` must be trimmed manually on the release branch. For patch releases made from `develop`, release notes are automatically filtered to include only fixes.
 
-The version can be specified with the `--version` (short `-v`) option. For instance, to set version to `6.4.1`, run from the `scripts/` folder:
+**Note**: For all releases, add a line to the Release History section of `ReleaseNotes.tex` providing the version number, date and DOI of the release, e.g. `6.4.4 & February 13, 2024 & \url{https://doi.org/10.5066/P9FL1JCC}`. DOIs are updated with minor releases and remain the same for patch releases.
+
+### Create a release branch
+
+Create a release candidate branch from the `develop` or `master`. The branch's name must begin with `v` followed by the version number. For a dry run in which a candidate distribution is built but the release does not proceed, append `rc` to the version string, e.g. `v6.4.0rc`. For an approved release, include *only* the version number.
 
 ```shell
-python update_version.py -v 6.4.1
+git checkout develop
+git switch -c v6.4.0
 ```
 
-If no `--version` is provided, the version is not changed, only the build timestamp.
+Push the branch to the repository. This triggers the release workflow. 
 
-An optional label may be appended to the release number, e.g.
+### Build assets/distributions
+
+GitHub actions runs the release workflow and builds binaries, documentation and distribution archives for supported platforms.
+
+If this is a dry run (branch name ends with `rc`) binaries are built with `IDEVELOPMODE` set to 1, and the workflow ends after uploading artifacts. If this is not a dry run, the workflow will continue, drafting a pull request against the `master` branch after the build completes.
+
+### Merge release branch to master
+
+Review the distributions. If they pass inspection, merge (don't squash) the pull request from the release branch into `master`. (Squashing will cause `master` and `develop` to diverge.) This triggers another job to tag the new tip of `master` with the release number, draft a release, and upload binaries and documentation as release assets.
+
+### Publish the release
+
+Inspect the draft release. The generated description should be in the form:
+
+```
+This is the approved USGS MODFLOW <semver> release.
+
+<authors>, <release year>, MODFLOW 6 Modular Hydrologic Model version <semver>: U.S. Geological Survey Software Release, <release date>, <doi link>
+
+Visit the USGS "MODFLOW and Related Programs" site for information on MODFLOW 6 and related software: https://doi.org/10.5066/F76Q1VQV
+```
+
+Update the DOI link in the citation if necessary. The DOI on the last line is the original and stays the same.
+
+Publish the release.
+
+### Reset the develop branch
+
+Make a new branch from `master`:
+
+```shell
+git checkout master
+git switch -c post-6.x.y-release-reset
+```
+
+#### Update version strings
+
+Update the version number for the next development cycle:
+
+```shell
+pixi run update-version -v 6.x.ydev0
+```
+
+This will substitute the new version number into the necessary files and set `IDEVELOPMODE` back to 1.
+
+#### Update release notes
+
+Generate a `develop.tex` file from `develop.toml`:
+
+```shell
+pixi run make-release-notes
+```
+
+Move/rename it to `doc/ReleaseNotes/previous/vx.y.z.tex` (where `x.y.z` is the version just released), then insert a new line `\input{./previous/vx.y.z.tex}` at the top of `doc/ReleaseNotes/appendixA.tex`.
+
+If this was not a hotfix, trim `doc/ReleaseNotes/develop.toml` as necessary to remove items just released.
+
+Create and merge (don't squash) a pull request from this branch into `develop`.
+
+That's it, all done.
+
+## Actions
+
+There are two workflows:
+
+- `.github/workflows/release.yml`: "callable" workflow for development or standard releases
+- `.github/workflows/release_dispatch.yml`: dispatches a release on various triggers
+
+### Dispatch workflow
+
+The `release.yml` workflow has no triggers of its own, and must be dispatched by `.github/workflows/release_dispatch.yml`, in one of two ways:
+
+- Pushing a branch with a suitable name (e.g. `vx.y.z[rc]`) to the `MODFLOW-ORG/modflow6` repository. This is how releases are typically triggered.
+- Triggering the workflow via GitHub CLI or web UI. Useful for testing release candidates or verifying the release automation before a final release is made.
+
+### Release workflow
+
+The `release.yml` workflow is a callable function for producing distributions. It uses the scripts in this directory to build a distribution for each supported platform. Custom actions in `.github/actions/` are also used for extended builds.
+
+This workflow is also used by the [nightly build repository](https://github.com/MODFLOW-ORG/modflow6-nightly-build).
+
+## Scripts
+
+This directory contains scripts for
+
+- updating version numbers
+- regenerating build files
+- collecting deprecations
+- benchmarking examples
+- building PDF documents
+- building distributions
+- verifying distributions
+
+### Updating version numbers
+
+MODFLOW 6 version numbers follow the [semantic versioning](https://semver.org/) convention `major.minor.patch`. Release tags do not include an initial `v`.
+
+The current version is stored in `version.txt` in the project root. The version number appears in several other files in the repository, as well as date and timestamp information.
+
+The `update_version.py` script updates `version.txt` and other files containing version information. For instance, to set the version string to `6.4.1`:
+
+```shell
+pixi run update-version -v 6.4.1
+python update_version.py -v 6.4.1 # or from the scripts/ folder
+```
+
+If a `--version` value is not provided, the version string will not be changed, just dates and timestamps.
+
+The `--version` value may contain trailing letters, e.g.
 
 ```shell
 python update_version.py -v 6.4.2rc
 ```
 
-The label must start immediately following the patch version number, with no space in between. The label may contain numeric characters or symbols, but *must not* start with a number (otherwise there is no way to distinguish it from the patch version number).
+These must begin immediately after the patch version number, and may contain numerics after an initial alphabetic character.
 
 The `update_version.py` script has a few other flags:
+
+- `--get` (short `-g`): print the current version number to `stdout` without making any updates.
 
 - `--approved` (short `-a`): approve an official release. If the `--approved` flag is provided, disclaimer language is altered to reflect approval. If the flag is not provided, the language reflects preliminary/provisional status and `(preliminary)` is appended to version numbers.
 
 - `--releasemode` (short `-r`): toggle whether binaries are built in development or release mode by editing the contents of `src/Utilities/version.f90`. If the `--releasemode` flag is provided, `IDEVELOPMODE` is set to 0. If `--releasemode` is not provided, `IDEVELOPMODE` is set to 1.
 
-- `--get` (short `-g`): print the current version number to `stdout` without making any updates.
-
 - `--citation` (short `-c`): generate a citation from the contents of `CITATION.cff` and print it to `stdout`, again without making any updates.
 
-### Build makefiles
+### Regenerating build files
 
-The `build_makefiles.py` script is used to rewrite makefiles after Fortran source files have been added, removed, or renamed. Up-to-date makefiles must be generated for inclusion in a distribution. A pixi task `build-makefiles` is also available.
+Up-to-date makefiles must be generated for inclusion in a distribution. The `build_makefiles.py` script rewrites makefiles after Fortran source files have been added, removed, or renamed. 
 
-### Build example models
+```shell
+pixi run build-makefiles
+python build_makefiles.py # or from the distribution/ folder
+```
 
-MODFLOW 6 [example models](https://github.com/MODFLOW-ORG/modflow6-examples) are bundled with official releases. Example models must be built and run to generate plots and tables before documentation can be generated. The `release.yml` workflow attempts to download the latest release from the examples repository, only re-building and re-running example models if no such release is available. See the examples repository for more information on preparing example models.
+MSVS project files are also included in the distribution. These currently cannot be auto-generated and must be updated/verified by hand.
 
-### Benchmark example models
+### Collecting deprecations
+
+Deprecated/removed variables are scraped from DFNs to create a table for insertion into the release notes:
+
+```shell
+pixi run collect-deprecations
+python deprecations.py # or from the doc/mf6io/mf6ivar/ folder
+```
+
+### Benchmarking examples
+
+MODFLOW 6 [example models](https://github.com/MODFLOW-ORG/modflow6-examples) are bundled with official releases. Example models must be built and run to generate plots and tables before documentation can be generated. The `release.yml` workflow attempts to download the latest release from the examples repository if it can find one, otherwise it will rebuild and run example models. See the examples repository for more information on releasing the examples.
 
 MODFLOW 6 documentation includes a performance evaluation comparing the current version against the last official release. Benchmarks must run before a release can be prepared. Benchmarks run as a component of the `docs.yml` CI workflow &mdash; `release.yml` attempts to download benchmark results if available, only re-running them if necessary.
 
@@ -145,13 +309,13 @@ python benchmark.py -e ../modflow6-examples -o .benchmarks
 
 The above will write results to a markdown file `.benchmarks/run-time-comparison.md` relative to the project root.
 
-### Build documentation
+### Building PDF documents
 
 Extensive documentation is bundled with official MODFLOW 6 releases. MODFLOW 6 documentation is written in LaTeX. Some LaTeX files (in particular for MODFLOW 6 input/output documentation) are automatically generated from DFN files. The `release.yml` workflow first runs `update_version.py` to update version strings to be substituted into the docs, then runs `build_docs.py` to regenerate LaTeX files where necessary, download benchmark results (and convert the Markdown results file to LaTeX), download publications hosted on the USGS website, and finally convert LaTeX to PDFs.
 
 Manually building MODFLOW 6 documentation requires additional Python dependencies specified in `build_rtd_docs/requirements.rtd.txt`. Styles defined in the [`MODFLOW-ORG/usgslatex`](https://github.com/MODFLOW-ORG/usgslatex) are also required. (See that repository's `README` for installation instructions or this repo's [`../.github/workflows/docs.yml](../.github/workflows/docs.yml) CI workflow for an example.)
 
-### Build the distribution archive
+### Building distributions
 
 After each step above is complete, the `build_dist.py` script can be used to construct the MODFLOW 6 distribution. The `build_dist.py` script can be used to create both minimal and full distributions. By default, a minimal distribution is created. To create a full distribution, run the script with the `--full` flag.
 
@@ -168,43 +332,9 @@ Default paths are resolved relative to the script's location on the filesystem, 
 
 See [the `release.yml` workflow](../.github/workflows/release.yml) for a complete example of how to build a distribution archive.
 
-### Verify the distribution archive
+### Checking distributions
 
 The `check_dist.py` script can be used to check the release distribution folder. The `--path` argument is the path to the dist folder. The `--approved` flag can be used to signal that the release is approved/official. By default the release is assumed preliminary. The script checks the version string emitted by `mf6 -v` for the presence or absence of "preliminary" depending on this flag.
-
-## Procedure
-
-The steps above are automated in the `.github/workflows/release.yml` and `release_dispatch.yml` workflows. The `.github/workflows/release.yml` workflow is used for both nightly builds and official releases. It should not be necessary to prepare a release manually.
-
-The `release.yml` workflow has no triggers of its own, and must be dispatched by `.github/workflows/release_dispatch.yml`, in one of two ways:
-
-- Push a release branch to the `MODFLOW-ORG/modflow6` repository. This method should be used for proper releases. 
-- Manually trigger the workflow via GitHub CLI or web UI. Useful for testing release candidates or verifying the release automation before a final release is made &mdash; see the [Testing](#testing) section below for more detail.
-
-To release an official version of MODFLOW 6 via the release branch method:
-
-1. Create a release candidate branch from the tip of `develop` or `master`. The branch's name must begin with `v` followed by the version number. For an officially approved release, include *only* the version number. For a preliminary release candidate, append `rc` after the version number, e.g. `v6.4.0rc`. If the branch name does not end in `rc`, the release is assumed to be approved.
-2. Push the branch to the `MODFLOW-ORG/modflow6` repository. This triggers the release workflow. If the release is still an unapproved candidate (i.e. the branch name ends with `rc`) binaries are built with `IDEVELOPMODE` set to 1, and the workflow ends after uploading binaries and documentation artifacts for inspection. If the release is approved/official, the workflow drafts a pull request against the `master` branch.
-3. To continue with the release, merge (**do not squash**) the PR into `master`. This triggers another job to tag the new tip of `master` with the release number, draft a release, and upload binaries and documentation as release assets.
-4. If the release assets pass inspection, publish the release. The following format convention is used for the GitHub release post:
-
-    ```
-    This is the approved USGS MODFLOW <semver> release.
-  
-    <authors>, <release year>, MODFLOW 6 Modular Hydrologic Model version <semver>: U.S. Geological Survey Software Release, <release date>, <doi link>
-  
-    Visit the USGS "MODFLOW and Related Programs" site for information on MODFLOW 6 and related software: https://doi.org/10.5066/F76Q1VQV
-    ```
-
-5. Create a branch from `master`, naming it something like `post-release-x.y.z-reset`. Run `distribution/update_version.py -v x.y.z.devN`, substituting `x`, `y`, `z` and `N` as appropriate for the next development cycle's version number. This will substitute the version number into all necessary files and will also set `IDEVELOPMODE` back to 1. Reset the release notes by
-
-    - copying the `develop.tex` file generated from `develop.toml` to `doc/ReleaseNotes/previous/vx.y.z.tex` (where `x.y.z` is the semantic version just released), then
-    - inserting a new line `\input{./previous/vx.y.z.tex}` at the top of `doc/ReleaseNotes/appendixA.tex`, then
-    - clearing `develop.toml`.
-
-Open a pull request into `master` from the reset branch. Merge (**do not squash**) the PR.
-
-**Note**: Squashing the release PR into `master` or the post-release reset PR into `develop` causes `develop` and `master` to diverge, leading to conflicts at the next release time. Both pull requests should be **merged with a merge commit**, *not* squashed.
 
 ## Testing
 
@@ -212,19 +342,19 @@ Each script used in the release procedure can be tested separately. The procedur
 
 ### Testing release scripts
 
-Each script in `distribution/` contains its own tests. To run them, run `pytest` from the `distribution/` folder. The tests will not be discovered if `pytest` is run from a different location, as the scripts in this folder are not named `test_*.py` and are only discoverable by virtue of the patterns provided in `distribution/pytest.ini`.  The tests use temporary directories where possible and revert modifications to tracked files on teardown.
+Each script in `distribution/` contains its own tests. To run them, run `pytest` from the `distribution/` folder. (This happens in standard CI.) The tests will not be discovered if `pytest` is run from a different location, as the scripts in this folder are not named `test_*.py` and are only discoverable by virtue of the patterns provided in `distribution/pytest.ini`.  The tests use temporary directories where possible and revert modifications to tracked files on teardown.
 
-**Note:** the tests clean up by reverting changes to files in the following locations:
+There is a small additional suite of tests that can be used to validate a release distribution folder after it is built: `check_dist.py`. These tests are run as part of the release workflow &mdash; see below for more detail.
+
+**Note:** the tests clean up after themselves by reverting changes to files in the following locations:
 
 - `doc/`
 - `make`
 - `utils/**/make/`
 
-Make sure you don't have any uncommitted changes in these locations before running the tests.
+Make sure you don't have any uncommitted changes in these locations before running the tests in your environment.
 
 **Note:** to avoid contested file access, the tests will refuse to run in parallel with `pytest-xdist`.
-
-There is a small additional suite of tests that can be used to validate a release distribution folder after it is built: `check_dist.py`. These tests are run as part of the release workflow &mdash; see below for more detail.
 
 ### Testing the release workflow
 
@@ -237,3 +367,4 @@ To dispatch the release workflow, navigate to the Actions tab of this repository
 - `development`: whether to build a minimal development distribution or a full distribution
 - `run_tests`: whether to run autotests after building binaries
 - `version`: the version number of the release
+- `patch`: whether this is a patch release

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -371,11 +371,4 @@ Make sure you don't have any uncommitted changes in these locations before runni
 
 The `workflow_dispatch` event is GitHub's mechanism for manually triggering workflows. This can be accomplished from the Actions tab in the GitHub UI. This is a convenient way to test the release procedure and evaluate release candidate distributions.
 
-To dispatch the release workflow, navigate to the Actions tab of this repository. Select the release dispatch workflow. A `Run workflow` button should be visible in an alert at the top of the list of workflow runs. Click the `Run workflow` button, selecting values for the various inputs:
-
-- `approve`: whether the release is officially approved, or just a release candidate
-- `branch`: the branch to release from
-- `development`: whether to build a minimal development distribution or a full distribution
-- `run_tests`: whether to run autotests after building binaries
-- `version`: the version number of the release
-- `patch`: whether this is a patch release
+To dispatch the release workflow, navigate to the Actions tab of this repository. Select the release dispatch workflow. A `Run workflow` button should be visible in an alert at the top of the list of workflow runs. Click the `Run workflow` button, providing suitable values for the inputs.

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -97,7 +97,9 @@ There are no major releases as the MF6 major version number is constant. Breakin
 
 ## Steps
 
-If building distributions locally, a development environment [must be configured](../DEVELOPER.md) including a Fortran compiler and a Python environment. If using GitHub Actions, nothing is needed besides `git`.  This section assumes releases are made with GitHub Actions.
+If building distributions locally, a development environment [must be configured](../DEVELOPER.md) including a Fortran compiler, a Python environment, a LaTeX environment, and the [`MODFLOW-ORG/usgslatex`](https://github.com/MODFLOW-ORG/usgslatex) styles.
+
+If using GitHub Actions, nothing is needed besides `git`.  This section assumes releases are made with GitHub Actions.
 
 To make a release,
 
@@ -130,6 +132,10 @@ Double-check release notes in `doc/ReleaseNotes/develop.toml` with the authors o
 For hotfix releases, `develop.toml` must be trimmed manually on the release branch. For patch releases made from `develop`, release notes are automatically filtered to include only fixes.
 
 **Note**: For all releases, add a line to the Release History section of `ReleaseNotes.tex` providing the version number, date and DOI of the release, e.g. `6.4.4 & February 13, 2024 & \url{https://doi.org/10.5066/P9FL1JCC}`. DOIs are updated with minor releases and remain the same for patch releases.
+
+### Release examples repo
+
+MODFLOW 6 [example models](https://github.com/MODFLOW-ORG/modflow6-examples) are bundled with official releases. Example models must be built and run to generate plots and tables before documentation can be generated. The `release.yml` workflow attempts to download the latest release from the examples repository if it can find one, otherwise it will rebuild example models.
 
 ### Create a release branch
 
@@ -239,34 +245,22 @@ This directory contains scripts for
 
 MODFLOW 6 version numbers follow the [semantic versioning](https://semver.org/) convention `major.minor.patch`. Release tags do not include an initial `v`.
 
-The current version is stored in `version.txt` in the project root. The version number appears in several other files in the repository, as well as date and timestamp information.
+The version string is stored in `version.txt` in the project root. The version string appears in several other files in the repository, as well as date and timestamp information.
 
-The `update_version.py` script updates `version.txt` and other files containing version information. For instance, to set the version string to `6.4.1`:
+The `update_version.py` script synchronizes updates to `version.txt` and other files containing version information.
 
 ```shell
 pixi run update-version -v 6.4.1
-python update_version.py -v 6.4.1 # or from the scripts/ folder
+python update_version.py -v 6.4.1 # or from the distribution/ folder
 ```
 
-If a `--version` value is not provided, the version string will not be changed, just dates and timestamps.
-
-The `--version` value may contain trailing letters, e.g.
+If a `--version` value is not provided, the version string will not be changed, just dates and timestamps. The `--version` value may contain trailing letters, e.g.
 
 ```shell
 python update_version.py -v 6.4.2rc
 ```
 
 These must begin immediately after the patch version number, and may contain numerics after an initial alphabetic character.
-
-The `update_version.py` script has a few other flags:
-
-- `--get` (short `-g`): print the current version number to `stdout` without making any updates.
-
-- `--approved` (short `-a`): approve an official release. If the `--approved` flag is provided, disclaimer language is altered to reflect approval. If the flag is not provided, the language reflects preliminary/provisional status and `(preliminary)` is appended to version numbers.
-
-- `--releasemode` (short `-r`): toggle whether binaries are built in development or release mode by editing the contents of `src/Utilities/version.f90`. If the `--releasemode` flag is provided, `IDEVELOPMODE` is set to 0. If `--releasemode` is not provided, `IDEVELOPMODE` is set to 1.
-
-- `--citation` (short `-c`): generate a citation from the contents of `CITATION.cff` and print it to `stdout`, again without making any updates.
 
 ### Regenerating build files
 
@@ -290,51 +284,68 @@ python deprecations.py # or from the doc/mf6io/mf6ivar/ folder
 
 ### Benchmarking examples
 
-MODFLOW 6 [example models](https://github.com/MODFLOW-ORG/modflow6-examples) are bundled with official releases. Example models must be built and run to generate plots and tables before documentation can be generated. The `release.yml` workflow attempts to download the latest release from the examples repository if it can find one, otherwise it will rebuild and run example models. See the examples repository for more information on releasing the examples.
+The `benchmark.py` script benchmarks the current development version of MODFLOW 6 against the latest release rebuilt in development mode, using the models from the `MODFLOW-ORG/modflow6-examples` repository.
 
-MODFLOW 6 documentation includes a performance evaluation comparing the current version against the last official release. Benchmarks must run before a release can be prepared. Benchmarks run as a component of the `docs.yml` CI workflow &mdash; `release.yml` attempts to download benchmark results if available, only re-running them if necessary.
+Paths to pre-built binaries for both versions can be provided via the `--current-bin-path` (short `-c`) and `--previous-bin-path` (short `-p`) command line options. If bin paths are not provided, executables are rebuilt in the default locations:
 
-The `benchmark.py` script benchmarks the current development version of MODFLOW 6 against the latest release rebuilt in development mode, using the models from the `MODFLOW-ORG/modflow6-examples` repository. Paths to pre-built binaries for both versions can be provided via the `--current-bin-path` (short `-c`) and `--previous-bin-path` (short `-p`) command line options. If bin paths are not provided, executables are rebuilt in the default locations:
-
-`<project root>/bin`: current development version
-`<project root>/bin/rebuilt`: previous version
+- `<project root>/bin`: current development version
+- `<project root>/bin/rebuilt`: previous version
 
 The examples repository must first be installed and prepared as described above. Its path may be explicitly provided with the `--examples-repo-path` (short `-e`) option. If no path is provided, the repository is assumed to be named `modflow6-examples` and live side-by-side with the `modflow6` repository on the filesystem.
 
-The directory to write benchmark results can be specified with `--output-path` (short `-o`). If no such option is provided, results are written to the current working directory.
-
 ```shell
-python benchmark.py -e ../modflow6-examples -o .benchmarks
+pixi run benchmark
+python benchmark.py # or from the distribution/ folder
 ```
-
-The above will write results to a markdown file `.benchmarks/run-time-comparison.md` relative to the project root.
 
 ### Building PDF documents
 
-Extensive documentation is bundled with official MODFLOW 6 releases. MODFLOW 6 documentation is written in LaTeX. Some LaTeX files (in particular for MODFLOW 6 input/output documentation) are automatically generated from DFN files. The `release.yml` workflow first runs `update_version.py` to update version strings to be substituted into the docs, then runs `build_docs.py` to regenerate LaTeX files where necessary, download benchmark results (and convert the Markdown results file to LaTeX), download publications hosted on the USGS website, and finally convert LaTeX to PDFs.
+The `build_docs.py` script constructs documentation.
 
-Manually building MODFLOW 6 documentation requires additional Python dependencies specified in `build_rtd_docs/requirements.rtd.txt`. Styles defined in the [`MODFLOW-ORG/usgslatex`](https://github.com/MODFLOW-ORG/usgslatex) are also required. (See that repository's `README` for installation instructions or this repo's [`../.github/workflows/docs.yml](../.github/workflows/docs.yml) CI workflow for an example.)
+- regenerates LaTeX files from DFN files (via `mf6ivar.py`)
+- downloads or reruns benchmarks (via `benchmark.py`)
+- downloads publications hosted on the USGS website
+- builds the MF6IO PDF document
+
+```shell
+pixi run build-docs
+python build_docs.py # or from the distribution/ folder
+```
+
+The script is lazy &mdash; files are regenerated only if they do not already exist or the `--force` flag is provided. Likewise for installing example models and running benchmarks.
 
 ### Building distributions
 
-After each step above is complete, the `build_dist.py` script can be used to construct the MODFLOW 6 distribution. The `build_dist.py` script can be used to create both minimal and full distributions. By default, a minimal distribution is created. To create a full distribution, run the script with the `--full` flag.
+The `build_dist.py` script constructs a complete distribution.
 
-The `build_dist.py` script is lazy &mdash; benchmarks, example models and documentation artifacts are downloaded via the GitHub API if available, and only re-created if none exist or the `--force` (`-f`) flag is provided. This allows the release workflow to consume artifacts previously created by other workflow runs, reducing the time needed to create and publish a release.
+- builds binaries
+- builds examples
+- builds documentation
+- collects release assets
+- creates a distribution archive
 
-The script has several other arguments:
+```shell
+pixi run build-dist -o $DISTDIR
+python build_dist.py -o $DISTDIR # or from the distribution/ folder
+```
 
-- `--build-path`: path to the build workspace, defaults to `<project root>/builddir`
-- `--output-path (-o)`: path to create a distribution zipfile, defaults to `<project root>/distribution/`
-- `--examples-repo-path (-e)`: path to the [`MODFLOW-ORG/modflow6-examples`](https://github.com/MODFLOW-ORG/modflow6-examples) repository, defaults to `modflow6-examples` side-by-side with project root
-- `--force (-f)`: whether to recreate and overwrite preexisting components of the distribution, if they already exist
-
-Default paths are resolved relative to the script's location on the filesystem, *not* the current working directory, so the script can be run from `distribution/`, from the project root, or from anywhere else. This is true of all scripts in the `distribution/` directory.
-
-See [the `release.yml` workflow](../.github/workflows/release.yml) for a complete example of how to build a distribution archive.
+The script is lazy &mdash; components of the distribution are recreated only if they do not exist or the `--force` flag is provided.
 
 ### Checking distributions
 
-The `check_dist.py` script can be used to check the release distribution folder. The `--path` argument is the path to the dist folder. The `--approved` flag can be used to signal that the release is approved/official. By default the release is assumed preliminary. The script checks the version string emitted by `mf6 -v` for the presence or absence of "preliminary" depending on this flag.
+The `check_dist.py` script runs some checks on the distribution, e.g.:
+
+- binaries are present
+- source code is present
+- PDF documents are present
+- binaries successfully run example models 
+- binaries emit expected version strings and other output
+- build files are present and can successfully build the source code
+
+```shell
+pixi run check-dist --path $DISTDIR
+pytest -v -s check_dist.py --path $DISTDIR # or from the distributions/ folder
+```
 
 ## Testing
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -117,6 +117,7 @@ prepare-pull-request = {depends-on = ["fix-style", "fix-python-style", "build-ma
 benchmark = { cmd = "python benchmark.py", cwd = "distribution" }
 build-docs = { cmd = "python build_docs.py", cwd = "distribution" }
 build-dist = { cmd = "python build_dist.py", cwd = "distribution" }
+check-dist = { cmd = "pytest -v -s check_dist.py", cwd = "distribution" }
 test-dist-scripts = { cmd = "pytest -v --durations 0", cwd = "distribution" }
 update-version = { cmd = "python update_version.py", cwd = "distribution" }
 collect-deprecations = { cmd = "python deprecations.py", cwd = "doc/mf6io/mf6ivar" }


### PR DESCRIPTION
The developer-facing release guide was in need of an update. Reorganize and edit so it reads more clearly too. Some discussion has been had about the process' complexity, things may change in future. But for now, this aims to describe the current system accurately