### PR TITLE
ci: simplify distribution scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,7 +496,7 @@ jobs:
       - name: Collect deprecations
         working-directory: modflow6/doc/mf6io/mf6ivar
         run: |
-          pixi run deprecations
+          pixi run collect-deprecations
           cat md/deprecations.md
 
       - name: Upload deprecations

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -633,7 +633,7 @@ jobs:
         run: |
           # build distribution
           distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
-          cmd="pixi run --manifest-path modflow6/pixi.toml build-dist -o $distname"
+          cmd="pixi run --manifest-path modflow6/pixi.toml build-dist -o ../../$distname"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,18 @@ jobs:
       version: ${{ steps.set_version.outputs.version }}
       distname: ${{ steps.set_version.outputs.distname }}
     steps:
+      - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout modflow6
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,10 @@ jobs:
           fi
           eval "$cmd"
 
+      - name: Setup tmate
+        if: runner.os == 'macOS'
+        uses: mxschmitt/action-tmate@v3
+
       - name: Set OS tag
         id: ostag
         working-directory: modflow6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,10 +179,6 @@ jobs:
           fi
           eval "$cmd"
 
-      - name: Setup tmate
-        if: runner.os == 'macOS'
-        uses: mxschmitt/action-tmate@v3
-
       - name: Set OS tag
         id: ostag
         working-directory: modflow6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,6 @@ on:
   # from this repo or the nightly build repo for dev builds
   workflow_call:
     inputs:
-      approve:
-        description: 'Approve the release, modifying disclaimer language to indicate the distribution has been reviewed. If false, disclaimers & version strings indicate preliminary/provisional status.'
-        required: false
-        type: boolean
-        default: false
       branch:
         description: 'Branch to release from.'
         required: true
@@ -23,13 +18,8 @@ on:
         required: false
         type: string
         default: '2021.7'
-      developmode:
-        description: 'Build binaries in develop mode. If false, IDEVELOPMODE is set to 0.'
-        required: false
-        type: boolean
-        default: true
       full:
-        description: 'Build a full distribution containing sources, examples, and all documentation. If false, the distribution contains only binaries, mf6io, release notes, and code.json.'
+        description: 'Build a full distribution containing sources, examples, and all documentation. If false, the distribution contains only binaries, mf6io, release notes, and code.json, with binaries built in develop mode, and disclaimers & version strings indicating preliminary/provisional status. If true, a full distribution is created, with binaries built in release mode, and disclaimer language indicating review and approval.'
         required: false
         type: boolean
         default: false
@@ -46,10 +36,6 @@ on:
       version:
         description: 'Version number to use for release.'
         required: true
-        type: string
-      models:
-        description: 'Models to include in the release documentation'
-        required: false
         type: string
       patch:
         description: 'Create a patch release. If true, only bug fixes will be included in generated documentation.'
@@ -166,11 +152,8 @@ jobs:
         run: |
           ver="${{ steps.set_version.outputs.version }}"
           cmd="pixi run update-version -v $ver"
-          if [[ "${{ inputs.approve }}" == "true" ]]; then
-            cmd="$cmd --approve"
-          fi
-          if [[ "${{ inputs.developmode }}" == "false" ]]; then
-            cmd="$cmd --releasemode"
+          if [[ "${{ inputs.full }}" == "true" ]]; then
+            cmd="$cmd --full
           fi
           eval "$cmd"
 
@@ -179,7 +162,7 @@ jobs:
         working-directory: modflow6
         run: |
           cmd="pixi run update-flopy"
-          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+          if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
           eval "$cmd"
@@ -199,7 +182,7 @@ jobs:
         id: set_markers
         run: |
           markers="not large"
-          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+          if [[ "${{ inputs.full }}" == "true" ]]; then
             markers="$markers and not developmode"
           fi
           echo "markers=$markers" >> $GITHUB_OUTPUT
@@ -442,11 +425,8 @@ jobs:
         run: |
           ver="${{ needs.build.outputs.version }}"
           cmd="python update_version.py -v $ver"
-          if [[ "${{ inputs.approve }}" == "true" ]]; then
-            cmd="$cmd --approve"
-          fi
-          if [[ "${{ inputs.developmode }}" == "false" ]]; then
-            cmd="$cmd --releasemode"
+          if [[ "${{ inputs.full }}" == "true" ]]; then
+            cmd="$cmd --full
           fi
           eval "$cmd"
 
@@ -454,7 +434,7 @@ jobs:
         working-directory: modflow6
         run: |
           cmd="python -m flopy.mf6.utils.generate_classes --dfnpath doc/mf6io/mf6ivar/dfn"
-          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+          if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
           eval "$cmd"
@@ -493,7 +473,7 @@ jobs:
         if: inputs.full == true
         working-directory: modflow6-examples/autotest
         run: |
-          models="${{ inputs.models }}"
+          models="gwf,gwt,gwe,prt"
           pytest -v -n auto test_scripts.py --init -k "${models//,/ or }"
       
       - name: Collect deprecations
@@ -512,29 +492,19 @@ jobs:
         working-directory: modflow6/doc/mf6io/mf6ivar
         run: |
           cmd="python mf6ivar.py"
-          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+          if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
           eval "$cmd"
 
       - name: Build documentation
         env:
-          # this step is lazy about building the mf6 examples PDF document, first
-          # trying to download a prebuilt PDF from MODFLOW-ORG/modflow6-examples,
-          # so it needs a GITHUB_TOKEN.
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "${{ needs.build.outputs.distname }}/doc"
           cmd="python modflow6/distribution/build_docs.py -b bin -o doc --force"
-          models="${{ inputs.models }}"
-          if [ -n "$models" ]; then
-            cmd="$cmd -m ${models//,/ -m }"
-          fi
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
-          fi
-          if [[ "${{ inputs.developmode }}" == "false" ]]; then
-            cmd="$cmd --releasemode"
           fi
           if [[ "${{ inputs.patch }}" == "true" ]]; then
             cmd="$cmd --patch"
@@ -604,11 +574,8 @@ jobs:
         run: |
           ver="${{ needs.build.outputs.version }}"
           cmd="python update_version.py -v $ver"
-          if [[ "${{ inputs.approve }}" == "true" ]]; then
-            cmd="$cmd --approve"
-          fi
-          if [[ "${{ inputs.developmode }}" == "false" ]]; then
-            cmd="$cmd --releasemode"
+          if [[ "${{ inputs.full }}" == "true" ]]; then
+            cmd="$cmd --full"
           fi
           eval "$cmd"
  
@@ -649,10 +616,6 @@ jobs:
           # build distribution
           distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
           cmd="python modflow6/distribution/build_dist.py -o $distname"
-          models="${{ inputs.models }}"
-          if [ -n "$models" ]; then
-            cmd="$cmd -m ${models//,/ -m }"
-          fi
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
           fi
@@ -758,12 +721,6 @@ jobs:
           fi
 
           cmd="pytest -v -s modflow6/distribution/check_dist.py --path $checkdir/$distname"
-          if [[ "${{ inputs.approve }}" == "true" ]]; then
-            cmd="$cmd --approved"
-          fi
-          if [[ "${{ inputs.developmode }}" == "false" ]]; then
-             cmd="$cmd --releasemode"
-          fi
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
         default: '2021.7'
-      full:
+      releasemode:
         description: 'Build a full distribution containing sources, examples, and all documentation. If false, the distribution contains only binaries, mf6io, release notes, and code.json, with binaries built in develop mode, and disclaimers & version strings indicating preliminary/provisional status. If true, a full distribution is created, with binaries built in release mode, and disclaimer language indicating review and approval.'
         required: false
         type: boolean
@@ -152,8 +152,8 @@ jobs:
         run: |
           ver="${{ steps.set_version.outputs.version }}"
           cmd="pixi run update-version -v $ver"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
-            cmd="$cmd --full
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
+            cmd="$cmd --releasemode
           fi
           eval "$cmd"
 
@@ -162,7 +162,7 @@ jobs:
         working-directory: modflow6
         run: |
           cmd="pixi run update-flopy"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
           eval "$cmd"
@@ -182,7 +182,7 @@ jobs:
         id: set_markers
         run: |
           markers="not large"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             markers="$markers and not developmode"
           fi
           echo "markers=$markers" >> $GITHUB_OUTPUT
@@ -425,8 +425,8 @@ jobs:
         run: |
           ver="${{ needs.build.outputs.version }}"
           cmd="python update_version.py -v $ver"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
-            cmd="$cmd --full
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
+            cmd="$cmd --releasemode
           fi
           eval "$cmd"
 
@@ -434,7 +434,7 @@ jobs:
         working-directory: modflow6
         run: |
           cmd="python -m flopy.mf6.utils.generate_classes --dfnpath doc/mf6io/mf6ivar/dfn"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
           eval "$cmd"
@@ -460,7 +460,7 @@ jobs:
           chmod +x "${{ github.workspace }}/bin/zbud6"
     
       - name: Install dependencies for building models
-        if: inputs.full == true
+        if: inputs.releasemode == true
         working-directory: modflow6-examples/etc
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -470,7 +470,7 @@ jobs:
           get-modflow "${{ github.workspace }}/bin" --subset mf2005,triangle,gridgen
 
       - name: Build example models
-        if: inputs.full == true
+        if: inputs.releasemode == true
         working-directory: modflow6-examples/autotest
         run: |
           models="gwf,gwt,gwe,prt"
@@ -492,7 +492,7 @@ jobs:
         working-directory: modflow6/doc/mf6io/mf6ivar
         run: |
           cmd="python mf6ivar.py"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
           eval "$cmd"
@@ -503,8 +503,8 @@ jobs:
         run: |
           mkdir -p "${{ needs.build.outputs.distname }}/doc"
           cmd="python modflow6/distribution/build_docs.py -b bin -o doc --force"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
-            cmd="$cmd --full"
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
+            cmd="$cmd --releasemode"
           fi
           if [[ "${{ inputs.patch }}" == "true" ]]; then
             cmd="$cmd --patch"
@@ -574,8 +574,8 @@ jobs:
         run: |
           ver="${{ needs.build.outputs.version }}"
           cmd="python update_version.py -v $ver"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
-            cmd="$cmd --full"
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
+            cmd="$cmd --releasemode"
           fi
           eval "$cmd"
  
@@ -616,13 +616,13 @@ jobs:
           # build distribution
           distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
           cmd="python modflow6/distribution/build_dist.py -o $distname"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
-            cmd="$cmd --full"
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
+            cmd="$cmd --releasemode"
           fi
           eval "$cmd"
 
           # rename PDF documents
-          if [[ "${{ inputs.full }}" == "true" ]]; then
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             mv "$distname/doc/converter_mf5to6.pdf" "$distname/doc/mf5to6.pdf"
           fi
 
@@ -630,7 +630,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             zip -r $distname.zip \
               $distname/bin \
               $distname/src \
@@ -665,7 +665,7 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             7z a -tzip $distname.zip \
               $distname/bin \
               $distname/src \
@@ -721,7 +721,7 @@ jobs:
           fi
 
           cmd="pytest -v -s modflow6/distribution/check_dist.py --path $checkdir/$distname"
-          if [[ "${{ inputs.full }}" == "true" ]]; then
-            cmd="$cmd --full"
+          if [[ "${{ inputs.releasemode }}" == "true" ]]; then
+            cmd="$cmd --releasemode"
           fi
           eval "$cmd"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -519,7 +519,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "${{ needs.build.outputs.distname }}/doc"
-          cmd="pixi run --manifest-path modflow6/pixi.toml build-docs -b bin -o doc --force"
+          cmd="pixi run --manifest-path modflow6/pixi.toml build-docs -b ../../bin -o ../../doc --force"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,12 +418,15 @@ jobs:
         working-directory: usgslatex/usgsLaTeX
         run: sudo ./install.sh --all-users
 
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v1
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
-          environment-file: modflow6/environment.yml
-          cache-downloads: true
-          cache-environment: true
+          pixi-version: v0.41.4
+          manifest-path: "modflow6/pixi.toml"
+
+      - name: Custom pixi install
+        working-directory: modflow6
+        run: pixi run install
 
       - name: Setup ${{ inputs.compiler_toolchain }} ${{ inputs.compiler_version }}
         uses: fortran-lang/setup-fortran@v1
@@ -436,7 +439,7 @@ jobs:
         working-directory: modflow6/distribution
         run: |
           ver="${{ needs.build.outputs.version }}"
-          cmd="python update_version.py -v $ver"
+          cmd="pixi run update-version -v $ver"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
@@ -445,16 +448,18 @@ jobs:
       - name: Update flopy
         working-directory: modflow6
         run: |
-          cmd="python -m flopy.mf6.utils.generate_classes --dfnpath doc/mf6io/mf6ivar/dfn"
+          cmd="pixi run update-flopy --dfnpath doc/mf6io/mf6ivar/dfn"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
           eval "$cmd"
 
       - name: Get OS tag
+
         id: ostag
+        working-directory: modflow6
         run: |
-          ostag=$(python -c "from modflow_devtools.ostags import get_ostag; print(get_ostag())")
+          ostag=$(pixi run python -c "from modflow_devtools.ostags import get_ostag; print(get_ostag())")
           echo "ostag=$ostag" >> $GITHUB_OUTPUT
 
       - name: Download pre-built binaries
@@ -477,21 +482,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          pip install -r requirements.pip.txt
+          pixi run --manifest-path ../../modflow6/pixi.toml pip install -r requirements.pip.txt
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-          get-modflow "${{ github.workspace }}/bin" --subset mf2005,triangle,gridgen
+          pixi run --manifest-path ../../modflow6/pixi.toml get-modflow "${{ github.workspace }}/bin" --subset mf2005,triangle,gridgen
 
       - name: Build example models
         if: inputs.releasemode == true
         working-directory: modflow6-examples/autotest
         run: |
           models="gwf,gwt,gwe,prt"
-          pytest -v -n auto test_scripts.py --init -k "${models//,/ or }"
+          pixi run --manifest-path ../../modflow6/pixi.toml pytest -v -n auto test_scripts.py --init -k "${models//,/ or }"
       
       - name: Collect deprecations
         working-directory: modflow6/doc/mf6io/mf6ivar
         run: |
-          python deprecations.py
+          pixi run deprecations
           cat md/deprecations.md
 
       - name: Upload deprecations
@@ -503,7 +508,7 @@ jobs:
       - name: Build MF6IO files from DFNs
         working-directory: modflow6/doc/mf6io/mf6ivar
         run: |
-          cmd="python mf6ivar.py"
+          cmd="pixi run run-mf6ivar"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
@@ -514,7 +519,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "${{ needs.build.outputs.distname }}/doc"
-          cmd="python modflow6/distribution/build_docs.py -b bin -o doc --force"
+          cmd="pixi run --manifest-path modflow6/pixi.toml build-docs -b bin -o doc --force"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
@@ -564,37 +569,38 @@ jobs:
           repository: MODFLOW-ORG/modflow6-examples
           path: modflow6-examples
 
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: modflow6/environment.yml
-          cache-downloads: true
-          cache-environment: true
-          init-shell: >-
-            bash
-            powershell
-
       - name: Setup ${{ inputs.compiler_toolchain }} ${{ inputs.compiler_version }}
         uses: fortran-lang/setup-fortran@v1
         with:
           compiler: ${{ inputs.compiler_toolchain }}
           version: ${{ inputs.compiler_version }}
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.1
+        with:
+          pixi-version: v0.41.4
+          manifest-path: "modflow6/pixi.toml"
+
+      - name: Custom pixi install
+        working-directory: modflow6
+        run: pixi run install
       
       - name: Update version
         id: update_version
         working-directory: modflow6/distribution
         run: |
           ver="${{ needs.build.outputs.version }}"
-          cmd="python update_version.py -v $ver"
+          cmd="pixi run update-version -v $ver"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
           eval "$cmd"
  
       - name: Get OS tag
+        working-directory: modflow6
         id: ostag
         run: |
-          ostag=$(python -c "from modflow_devtools.ostags import get_ostag; print(get_ostag())")
+          ostag=$(pixi run python -c "from modflow_devtools.ostags import get_ostag; print(get_ostag())")
           if [[ "${{ matrix.extended }}" == "true" ]]; then
             ostag="${ostag}ext"
           fi
@@ -627,7 +633,7 @@ jobs:
         run: |
           # build distribution
           distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
-          cmd="python modflow6/distribution/build_dist.py -o $distname"
+          cmd="pixi run --manifest-path modflow6/pixi.toml build-dist -o $distname"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi
@@ -732,7 +738,7 @@ jobs:
             unzip $distfile -d $checkdir
           fi
 
-          cmd="pytest -v -s modflow6/distribution/check_dist.py --path $checkdir/$distname"
+          cmd="pixi run --manifest-path modflow6/pixi.toml check-dist --path $checkdir/$distname"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             cmd="$cmd --releasemode"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,7 +426,7 @@ jobs:
           ver="${{ needs.build.outputs.version }}"
           cmd="python update_version.py -v $ver"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
-            cmd="$cmd --releasemode
+            cmd="$cmd --releasemode"
           fi
           eval "$cmd"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
           ver="${{ steps.set_version.outputs.version }}"
           cmd="pixi run update-version -v $ver"
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
-            cmd="$cmd --releasemode
+            cmd="$cmd --releasemode"
           fi
           eval "$cmd"
 

--- a/autotest/TestFeatureFlags.f90
+++ b/autotest/TestFeatureFlags.f90
@@ -1,28 +1,28 @@
-module TestDevFeature
+module TestFeatureFlags
   use testdrive, only: error_type, unittest_type, new_unittest, check
-  use DevFeatureModule, only: dev_feature
+  use FeatureFlagsModule, only: developmode
   use ConstantsModule, only: LINELENGTH
   use VersionModule, only: IDEVELOPMODE
 
   implicit none
   private
-  public :: collect_dev_feature
+  public :: collect_feature_flags
 
 contains
 
-  subroutine collect_dev_feature(testsuite)
+  subroutine collect_feature_flags(testsuite)
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
     testsuite = [ &
                 ! expect failure if in release mode, otherwise pass
-                new_unittest("dev_feature", test_dev_feature, &
+                new_unittest("developmode", test_developmode, &
                              should_fail=(IDEVELOPMODE == 0)) &
                 ]
-  end subroutine collect_dev_feature
+  end subroutine collect_feature_flags
 
-  subroutine test_dev_feature(error)
+  subroutine test_developmode(error)
     type(error_type), allocatable, intent(out) :: error
     character(len=LINELENGTH) :: errmsg
-    call dev_feature(errmsg)
-  end subroutine test_dev_feature
+    call developmode(errmsg)
+  end subroutine test_developmode
 
-end module TestDevFeature
+end module TestFeatureFlags

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -2,7 +2,7 @@ test_drive = dependency('test-drive', required : false)
 if test_drive.found() and not fc_id.contains('intel')
   tests = [
     'ArrayHandlers',
-    'DevFeature',
+    'FeatureFlags',
     'GeomUtil',
     'HashTable',
     'InputOutput',

--- a/autotest/tester.f90
+++ b/autotest/tester.f90
@@ -3,7 +3,7 @@ program tester
   use testdrive, only: run_testsuite, new_testsuite, testsuite_type, &
     & select_suite, run_selected, get_argument
   use TestArrayHandlers, only: collect_arrayhandlers
-  use TestDevFeature, only: collect_dev_feature
+  use TestFeatureFlags, only: collect_feature_flags
   use TestGeomUtil, only: collect_geomutil
   use TestHashTable, only: collect_hashtable
   use TestInputOutput, only: collect_inputoutput
@@ -32,7 +32,7 @@ program tester
   stat = 0
   testsuites = [ &
                new_testsuite("ArrayHandlers", collect_arrayhandlers), &
-               new_testsuite("DevFeature", collect_dev_feature), &
+               new_testsuite("FeatureFlags", collect_feature_flags), &
                new_testsuite("GeomUtil", collect_geomutil), &
                new_testsuite("HashTable", collect_hashtable), &
                new_testsuite("InputOutput", collect_inputoutput), &

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -116,7 +116,9 @@ To make a release,
 9. reset the develop branch
 10. release downstream repos
 
-The release manager undertakes steps 1-3 in consultation with the development team. Step 4 [is described in the examples repository's developer docs](https://github.com/MODFLOW-ORG/modflow6-examples/blob/develop/DEVELOPER.md#releasing-the-examples). Step 5 triggers automation for steps 6-9. The release manager performs step 10.
+Complete steps 1-3 in consultation with the development team, then steps 4 and 5 once the release is greenlit. Step 5 triggers automation for steps 6-8. Step 6 happens automatically; steps 7 and 8 require review and manual sign-off. Steps 9 and 10 are performed manually.
+
+It is typical to undergo several iterations of 5-6 as candidate distributions are reviewed and issues are identified and resolved.
 
 ### Review features
 
@@ -138,11 +140,11 @@ For hotfix releases, `develop.toml` must be trimmed manually on the release bran
 
 ### Release examples repo
 
-MODFLOW 6 [example models](https://github.com/MODFLOW-ORG/modflow6-examples) are bundled with official releases. Example models must be built and run to generate plots and tables before documentation can be generated. The `release.yml` workflow attempts to download the latest release from the examples repository if it can find one, otherwise it will rebuild example models.
+MODFLOW 6 [example models](https://github.com/MODFLOW-ORG/modflow6-examples) are bundled with official releases. The `release.yml` workflow attempts to download the latest release from the examples repository. An examples release is typically made before proceeding with an MF6 release (this may not be necessary if example models have not changed since the last release). See the [examples release instructions](https://github.com/MODFLOW-ORG/modflow6-examples/blob/develop/DEVELOPER.md#releasing-the-examples) for more information.
 
 ### Create a release branch
 
-Create a release candidate branch from the `develop` or `master`. The branch's name must begin with `v` followed by the version number. For a dry run in which a candidate distribution is built but the release does not proceed, append `rc` to the version string, e.g. `v6.4.0rc`. For an approved release, include *only* the version number.
+Create a release candidate branch from `develop` or `master`. The branch's name must begin with `v` followed by the version number. For a dry run in which a candidate distribution is built but the release does not proceed, append `rc` to the version string, e.g. `v6.4.0rc`. For an approved release, include *only* the version number.
 
 ```shell
 git checkout develop
@@ -155,7 +157,7 @@ Push the branch to the repository. This triggers the release workflow.
 
 GitHub actions runs the release workflow and builds binaries, documentation and distribution archives for supported platforms.
 
-If this is a dry run (branch name ends with `rc`) binaries are built with `IDEVELOPMODE` set to 1, and the workflow ends after uploading artifacts. If this is not a dry run, the workflow will continue, drafting a pull request against the `master` branch after the build completes.
+If this is a dry run (branch name ends with `rc`) binaries are built with `IDEVELOPMODE` set to 1, and the workflow ends after uploading artifacts for review. If this is not a dry run, the workflow will continue, drafting a pull request against the `master` branch after the build completes.
 
 ### Merge release branch to master
 

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -124,7 +124,7 @@ It is typical to undergo several iterations of 5-6 as candidate distributions ar
 
 Determine whether any new developments need feature flags. To help keep the trunk prepared for a prompt release, it may be convenient to guard code and docs with feature flags by convention until the new features are ready for release.
 
-Code can be guarded with the `dev_feature` routine in `DevFeatureModule`. DFN variables may be guarded with an attribute `prerelease true`. LaTeX sections may be wrapped in `\ifdevelopmode ... \fi`
+Code can be guarded with the `developmode` routine in `FeatureFlagModule`. DFN variables may be guarded with an attribute `developmode true`. LaTeX sections may be wrapped in `\ifdevelopmode ... \fi`
 
 ### Review deprecations
 

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -41,9 +41,9 @@ This document describes how to release MODFLOW 6. This folder contains scripts u
 
 ## Modes
 
-There are two kinds of distribution: provisional development builds and standard distributions approved for "official" release.
+There are two kinds of distribution: provisional development builds and standard distributions approved for release.
 
-The release-related tooling has two corresponding modes: develop mode and release mode, respectively. This document uses the same terminology.
+The release-related tooling has two corresponding modes: develop mode and release mode. This document uses the same terminology.
 
 ### Develop
 
@@ -78,7 +78,7 @@ Running `mf6 -d` shows language affirming that the software has been reviewed an
 
 ## Versions
 
-MF6 loosely follows a modified form of [semantic versioning](semver.org).
+MF6 loosely follows a modified form of [semantic versioning](https://www.semver.org).
 
 ### Patch
 

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -124,7 +124,7 @@ It is typical to undergo several iterations of 5-6 as candidate distributions ar
 
 Determine whether any new developments need feature flags. To help keep the trunk prepared for a prompt release, it may be convenient to guard code and docs with feature flags by convention until the new features are ready for release.
 
-Code can be guarded with the `developmode` routine in `FeatureFlagModule`. DFN variables may be guarded with an attribute `developmode true`. LaTeX sections may be wrapped in `\ifdevelopmode ... \fi`
+Code can be guarded with the `developmode` routine in `FeatureFlagsModule`. DFN variables may be guarded with an attribute `developmode true`. LaTeX sections may be wrapped in `\ifdevelopmode ... \fi`
 
 ### Review deprecations
 

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -404,7 +404,7 @@ if __name__ == "__main__":
         required=False,
         default=False,
         action="store_true",
-        help="Build a full (standard/approved) distribution.",
+        help="Build a distribution in release mode.",
     )
     parser.add_argument(
         "-f",

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -25,6 +25,7 @@ from utils import get_project_root_path
 PROJ_ROOT_PATH = get_project_root_path()
 BUILDDIR_PATH = PROJ_ROOT_PATH / "builddir"
 DEFAULT_MODELS = ["gwf", "gwt", "gwe", "prt"]
+DEVELOP_MODELS = ["chf", "olf", "swf"]
 
 # OS-specific extensions
 SYSTEM = platform.system()
@@ -109,6 +110,7 @@ def setup_examples(
     bin_path: PathLike,
     examples_path: PathLike,
     force: bool = False,
+    developmode: bool = False,
 ):
     examples_path = Path(examples_path).expanduser().absolute()
 
@@ -123,8 +125,11 @@ def setup_examples(
     # filter examples for models selected for release
     # and omit any excluded models
     excluded = ["ex-prt-mp7-p02", "ex-prt-mp7-p04"]
+    models = DEFAULT_MODELS
+    if developmode:
+        models.extend(DEVELOP_MODELS)
     for p in examples_path.glob("*"):
-        if not any(m in p.stem for m in DEFAULT_MODELS):
+        if not any(m in p.stem for m in models):
             print(f"Omitting example due to model selection: {p.stem}")
             rmtree(p)
         if any(e in p.stem for e in excluded):
@@ -286,10 +291,10 @@ def test_build_makefiles(tmp_path):
 def build_distribution(
     build_path: PathLike,
     output_path: PathLike,
-    full: bool = False,
+    developmode: bool = False,
     force: bool = False,
 ):
-    print(f"Building {'full' if full else 'minimal'} distribution")
+    print(f"Building {'develop' if developmode else 'release'} mode distribution")
 
     build_path = Path(build_path).expanduser().absolute()
     output_path = Path(output_path).expanduser().absolute()
@@ -305,7 +310,7 @@ def build_distribution(
     copy(PROJ_ROOT_PATH / "code.json", output_path)
 
     # full releases include examples, source code, makefiles and docs
-    if not full:
+    if developmode:
         return
 
     # download and setup example models
@@ -324,8 +329,8 @@ def build_distribution(
     # build docs
     build_documentation(
         bin_path=output_path / "bin",
-        full=full,
         out_path=output_path / "doc",
+        developmode=developmode,
         force=force,
     )
 
@@ -333,39 +338,35 @@ def build_distribution(
 @no_parallel
 @requires_exe("pdflatex")
 @pytest.mark.skip(reason="manual testing")
-@pytest.mark.parametrize("full", [True, False])
-def test_build_distribution(tmp_path, full):
+@pytest.mark.parametrize("developmode", [True, False])
+def test_build_distribution(tmp_path, developmode):
     output_path = tmp_path / "dist"
     build_distribution(
         build_path=tmp_path / "builddir",
         output_path=output_path,
-        full=full,
+        developmode=developmode,
         force=True,
     )
 
-    if full:
-        # todo
-        pass
-    else:
-        # check binaries and libs
-        system = platform.system()
-        ext = ".exe" if system == "Windows" else ""
-        for exe in ["mf6", "mf5to6", "zbud6"]:
-            assert (output_path / f"{exe}{ext}").is_file()
-        assert (
-            output_path
-            / (
-                "libmf6"
-                + (
-                    ".so"
-                    if system == "Linux"
-                    else (".dylib" if system == "Darwin" else ".dll")
-                )
+    # check binaries and libs
+    system = platform.system()
+    ext = ".exe" if system == "Windows" else ""
+    for exe in ["mf6", "mf5to6", "zbud6"]:
+        assert (output_path / f"{exe}{ext}").is_file()
+    assert (
+        output_path
+        / (
+            "libmf6"
+            + (
+                ".so"
+                if system == "Linux"
+                else (".dylib" if system == "Darwin" else ".dll")
             )
-        ).is_file()
+        )
+    ).is_file()
 
-        # check mf6io docs
-        assert (output_path / "mf6io.pdf").is_file()
+    # check mf6io docs
+    assert (output_path / "mf6io.pdf").is_file()
 
 
 if __name__ == "__main__":
@@ -379,8 +380,8 @@ if __name__ == "__main__":
             By default, a minimal, preliminary distribution (including
             binaries, mf6io documentation, release notes and code.json)
             is created. To create a standard distribution with complete
-            documentation, examples, build files, etc, use --full. Use
-            --force (-f) to overwrite preexisting artifacts; by default
+            docs, examples, build files, etc use --releasemode. Use the
+            --force flag to overwrite preexisting artifacts; by default
             the script is lazy and will only create what it can't find.
             """
         ),
@@ -399,7 +400,7 @@ if __name__ == "__main__":
         help="The distribution directory path",
     )
     parser.add_argument(
-        "--full",
+        "--releasemode",
         required=False,
         default=False,
         action="store_true",
@@ -414,14 +415,17 @@ if __name__ == "__main__":
         help="Overwrite existing artifacts. Defaults to false, "
         "so that pre-existing artifacts are used if available.",
     )
+
     args = parser.parse_args()
     build_path = Path(args.build_path)
     out_path = Path(args.output_path)
     out_path.mkdir(parents=True, exist_ok=True)
+    developmode = not args.releasemode
+    force = args.force
 
     build_distribution(
         build_path=build_path,
         output_path=out_path,
-        full=args.full,
+        developmode=developmode,
         force=args.force,
     )

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -6,7 +6,6 @@ from os import PathLike, environ
 from pathlib import Path
 from pprint import pprint
 from shutil import copy, copyfile, copytree, ignore_patterns, rmtree
-from typing import Optional
 
 import pytest
 from build_docs import build_documentation
@@ -25,7 +24,7 @@ from utils import get_project_root_path
 # default paths
 PROJ_ROOT_PATH = get_project_root_path()
 BUILDDIR_PATH = PROJ_ROOT_PATH / "builddir"
-DEFAULT_MODELS = ["gwf", "gwt", "gwe", "prt", "swf"]
+DEFAULT_MODELS = ["gwf", "gwt", "gwe", "prt"]
 
 # OS-specific extensions
 SYSTEM = platform.system()
@@ -110,7 +109,6 @@ def setup_examples(
     bin_path: PathLike,
     examples_path: PathLike,
     force: bool = False,
-    models: Optional[list[str]] = None,
 ):
     examples_path = Path(examples_path).expanduser().absolute()
 
@@ -126,7 +124,7 @@ def setup_examples(
     # and omit any excluded models
     excluded = ["ex-prt-mp7-p02", "ex-prt-mp7-p04"]
     for p in examples_path.glob("*"):
-        if not any(m in p.stem for m in models):
+        if not any(m in p.stem for m in DEFAULT_MODELS):
             print(f"Omitting example due to model selection: {p.stem}")
             rmtree(p)
         if any(e in p.stem for e in excluded):
@@ -290,7 +288,6 @@ def build_distribution(
     output_path: PathLike,
     full: bool = False,
     force: bool = False,
-    models: Optional[list[str]] = None,
 ):
     print(f"Building {'full' if full else 'minimal'} distribution")
 
@@ -316,7 +313,6 @@ def build_distribution(
         bin_path=output_path / "bin",
         examples_path=output_path / "examples",
         force=force,
-        models=models,
     )
 
     # copy source code files
@@ -379,14 +375,12 @@ if __name__ == "__main__":
             """\
             Create a MODFLOW 6 distribution. If output path is provided
             distribution files are written to the selected path, if not
-            they are written to the distribution/ project subdirectory.
-            By default a minimal distribution containing only binaries,
-            mf6io documentation, release notes and metadata (code.json)
-            is created. To create a full distribution including sources
-            and examples, use the --full flag. Models to be included in
-            the examples and documentation can be selected with --model
-            (or -m), which may be used multiple times. Use --force (-f)
-            to overwrite preexisting distribution artifacts; by default
+            they are written directly to the distribution/ subdirectory.
+            By default, a minimal, preliminary distribution (including
+            binaries, mf6io documentation, release notes and code.json)
+            is created. To create a standard distribution with complete
+            documentation, examples, build files, etc, use --full. Use
+            --force (-f) to overwrite preexisting artifacts; by default
             the script is lazy and will only create what it can't find.
             """
         ),
@@ -395,28 +389,21 @@ if __name__ == "__main__":
         "--build-path",
         required=False,
         default=str(BUILDDIR_PATH),
-        help="Path to the build workspace",
+        help="The build directory path",
     )
     parser.add_argument(
         "-o",
         "--output-path",
         required=False,
         default=str(PROJ_ROOT_PATH / "distribution"),
-        help="Path to create distribution artifacts",
-    )
-    parser.add_argument(
-        "-m",
-        "--model",
-        required=False,
-        action="append",
-        help="Filter models to include",
+        help="The distribution directory path",
     )
     parser.add_argument(
         "--full",
         required=False,
         default=False,
         action="store_true",
-        help="Build a full rather than minimal distribution",
+        help="Build a full (standard/approved) distribution.",
     )
     parser.add_argument(
         "-f",
@@ -424,18 +411,17 @@ if __name__ == "__main__":
         required=False,
         default=False,
         action="store_true",
-        help="Recreate and overwrite existing artifacts",
+        help="Overwrite existing artifacts. Defaults to false, "
+        "so that pre-existing artifacts are used if available.",
     )
     args = parser.parse_args()
     build_path = Path(args.build_path)
     out_path = Path(args.output_path)
     out_path.mkdir(parents=True, exist_ok=True)
-    models = args.model if args.model else DEFAULT_MODELS
 
     build_distribution(
         build_path=build_path,
         output_path=out_path,
         full=args.full,
         force=args.force,
-        models=models,
     )

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -459,8 +459,8 @@ Create documentation for a distribution. By default, this only includes the mf6i
 document. If the --full flag is provided this includes benchmarks, release notes, the
 MODFLOW 6 input/output specification, example model documentation, supplemental info,
 documentation for the MODFLOW 5 to 6 converter and Zonebudget 6, and several articles
-downloaded from the USGS website. These are all written to a specified --output-path.
-Additional LaTeX files may be included in the distribution by specifying --tex-paths.
+downloaded from the USGS website too. By default, the script is lazy and will create
+only what it can't find. Use the --force (-f) flag to regenerate existing artifacts.
             """
         ),
     )
@@ -469,7 +469,7 @@ Additional LaTeX files may be included in the distribution by specifying --tex-p
         "--bin-path",
         required=False,
         default=str(BIN_PATH),
-        help="Location of modflow6 executables",
+        help="The path to the directory containing binaries",
     )
     parser.add_argument(
         "-f",
@@ -477,68 +477,52 @@ Additional LaTeX files may be included in the distribution by specifying --tex-p
         required=False,
         default=False,
         action="store_true",
-        help="Recreate and overwrite existing artifacts",
+        help="Overwrite existing artifacts. Defaults to false, "
+        "so that pre-existing artifacts are used if available.",
     )
     parser.add_argument(
         "--full",
         required=False,
         default=False,
         action="store_true",
-        help="Build docs for a full rather than minimal distribution",
+        help="Build docs for a full (standard/approved) distribution. "
+        "This omits prerelease variables/sections from documentation: "
+        "filtering out MF6IO variables marked 'prerelease' as well as "
+        "any LaTeX sections wrapped with '\\ifdevelopmode ... \\fi'. "
+        "Defaults false, suitable for preliminary development builds.",
     )
     parser.add_argument(
         "-o",
         "--output-path",
         required=False,
         default=os.getcwd(),
-        help="Location to create documentation artifacts",
+        help="The location to create documentation artifacts",
     )
     parser.add_argument(
         "--repo-owner",
         required=False,
         default="MODFLOW-ORG",
-        help="Repository owner (substitute your own for a fork)",
-    )
-    parser.add_argument(
-        "-m",
-        "--model",
-        required=False,
-        action="append",
-        help="Filter model types to include",
-    )
-    parser.add_argument(
-        "-r",
-        "--releasemode",
-        required=False,
-        action="store_true",
-        help="Omit prerelease variables/sections from documentation. "
-        "MF6IO variables marked 'prerelease' are omitted, as well as "
-        "LaTeX sections surrounded with '\\ifdevelopmode ... \\fi'. "
-        "Defaults to false.",
+        help="Repository owner. Use this option to fetch examples "
+        "from a fork of the repository. Defaults to MODFLOW-ORG.",
     )
     parser.add_argument(
         "--patch",
         default=False,
         action="store_true",
-        help="Filter content from documentation for a patch release. "
-        "Include only items in the 'fixes' section in release notes; "
-        "that's all this does now, but in the future it may do more. "
+        help="Filter content from release notes for a patch release: "
+        "include only items in the 'fixes' section in release notes. "
         "Defaults to false.",
     )
     args = parser.parse_args()
     output_path = Path(args.output_path).expanduser().absolute()
     output_path.mkdir(parents=True, exist_ok=True)
     bin_path = Path(args.bin_path).expanduser().absolute()
-    models = args.model if args.model else DEFAULT_MODELS
-    developmode = not args.releasemode
     patch = args.patch
     build_documentation(
         bin_path=bin_path,
         out_path=output_path,
         force=args.force,
         full=args.full,
-        models=models,
         repo_owner=args.repo_owner,
-        developmode=developmode,
         patch=patch,
     )

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -521,8 +521,8 @@ only what it can't find. Use the --force (-f) flag to regenerate existing artifa
         default=False,
         action="store_true",
         help="Build documents in release mode for standard releases. "
-        "Will omit prerelease variables/sections from documentation, "
-        "filtering out MF6IO variables marked 'prerelease', and also "
+        "Will omit developmode variables/sections from documentation, "
+        "filtering out MF6IO variables marked 'developmode', and also "
         "any LaTeX sections wrapped with '\\ifdevelopmode ... \\fi'. "
         "Defaults false, suitable for preliminary development builds.",
     )

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -47,9 +47,9 @@ TEX_PATHS = {
     ],
 }
 
-# models to include in the docs by default,
-# filterable with the --models (-m) option
-DEFAULT_MODELS = ["gwf", "gwt", "gwe", "prt", "chf", "olf"]
+# models to include in the docs
+DEFAULT_MODELS = ["gwf", "gwt", "gwe", "prt"]
+DEVELOP_MODELS = ["chf", "olf", "swf"]
 
 # OS-specific extensions
 SYSTEM = platform.system()
@@ -169,13 +169,12 @@ def test_build_notes_tex():
     build_notes_tex(force=True)
 
 
-def build_mf6io_tex(
-    models: Optional[list[str]] = None, force: bool = False, developmode: bool = True
-):
+def build_mf6io_tex(force: bool = False, developmode: bool = True):
     """Build LaTeX files for the MF6IO guide from DFN files."""
 
-    if models is None:
-        models = DEFAULT_MODELS
+    models = DEFAULT_MODELS
+    if developmode:
+        models.extend(DEVELOP_MODELS)
 
     included = models + ["sim", "utl", "exg", "sln"]
     excluded = ["appendix", "common"] + list(set(DEFAULT_MODELS) - set(models))
@@ -202,8 +201,6 @@ def build_mf6io_tex(
             args = [sys.executable, "mf6ivar.py"]
             if not developmode:
                 args.append("--releasemode")
-            for model in models:
-                args += ["--model", model]
             out, err, ret = run_cmd(*args, verbose=True)
             assert not ret, out + err
 
@@ -389,7 +386,6 @@ def build_documentation(
     out_path: PathLike,
     force: bool = False,
     full: bool = False,
-    models: Optional[list[str]] = None,
     repo_owner: str = "MODFLOW-ORG",
     developmode: bool = True,
     patch: bool = False,
@@ -409,7 +405,7 @@ def build_documentation(
     out_path.mkdir(parents=True, exist_ok=True)
 
     with TemporaryDirectory() as temp:
-        build_mf6io_tex(force=force, models=models, developmode=developmode)
+        build_mf6io_tex(force=force, developmode=developmode)
         build_usage_tex(
             bin_path=bin_path,
             workspace_path=Path(temp),
@@ -456,7 +452,7 @@ if __name__ == "__main__":
         epilog=textwrap.dedent(
             """\
 Create documentation for a distribution. By default, this only includes the mf6io PDF
-document. If the --full flag is provided this includes benchmarks, release notes, the
+document. If --releasemode is provided, this includes benchmarks, release notes, the
 MODFLOW 6 input/output specification, example model documentation, supplemental info,
 documentation for the MODFLOW 5 to 6 converter and Zonebudget 6, and several articles
 downloaded from the USGS website too. By default, the script is lazy and will create
@@ -472,6 +468,13 @@ only what it can't find. Use the --force (-f) flag to regenerate existing artifa
         help="The path to the directory containing binaries",
     )
     parser.add_argument(
+        "-o",
+        "--output-path",
+        required=False,
+        default=os.getcwd(),
+        help="The location to create documentation artifacts",
+    )
+    parser.add_argument(
         "-f",
         "--force",
         required=False,
@@ -481,22 +484,23 @@ only what it can't find. Use the --force (-f) flag to regenerate existing artifa
         "so that pre-existing artifacts are used if available.",
     )
     parser.add_argument(
-        "--full",
+        "--patch",
+        default=False,
+        action="store_true",
+        help="Filter content from release notes for a patch release: "
+        "include only items in the 'fixes' section in release notes. "
+        "Defaults to false.",
+    )
+    parser.add_argument(
+        "--releasemode",
         required=False,
         default=False,
         action="store_true",
-        help="Build docs for a full (standard/approved) distribution. "
-        "This omits prerelease variables/sections from documentation: "
-        "filtering out MF6IO variables marked 'prerelease' as well as "
+        help="Build docs for a full distribution (approved release). "
+        "Will omit prerelease variables/sections from documentation, "
+        "filtering out MF6IO variables marked 'prerelease', and also "
         "any LaTeX sections wrapped with '\\ifdevelopmode ... \\fi'. "
         "Defaults false, suitable for preliminary development builds.",
-    )
-    parser.add_argument(
-        "-o",
-        "--output-path",
-        required=False,
-        default=os.getcwd(),
-        help="The location to create documentation artifacts",
     )
     parser.add_argument(
         "--repo-owner",
@@ -505,24 +509,21 @@ only what it can't find. Use the --force (-f) flag to regenerate existing artifa
         help="Repository owner. Use this option to fetch examples "
         "from a fork of the repository. Defaults to MODFLOW-ORG.",
     )
-    parser.add_argument(
-        "--patch",
-        default=False,
-        action="store_true",
-        help="Filter content from release notes for a patch release: "
-        "include only items in the 'fixes' section in release notes. "
-        "Defaults to false.",
-    )
+
     args = parser.parse_args()
+    bin_path = Path(args.bin_path).expanduser().absolute()
     output_path = Path(args.output_path).expanduser().absolute()
     output_path.mkdir(parents=True, exist_ok=True)
-    bin_path = Path(args.bin_path).expanduser().absolute()
+    developmode = not args.releasemode
+    repo_owner = args.repo_owner
+    force = args.force
     patch = args.patch
+
     build_documentation(
         bin_path=bin_path,
         out_path=output_path,
-        force=args.force,
-        full=args.full,
-        repo_owner=args.repo_owner,
+        repo_owner=repo_owner,
+        developmode=developmode,
+        force=force,
         patch=patch,
     )

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -34,11 +34,11 @@ MF6IO_PATH = DOCS_PATH / "mf6io"
 MF6IVAR_PATH = MF6IO_PATH / "mf6ivar"
 RELEASE_NOTES_PATH = DOCS_PATH / "ReleaseNotes"
 TEX_PATHS = {
-    "minimal": [
+    "develop": [
         MF6IO_PATH / "mf6io.tex",
         DOCS_PATH / "ReleaseNotes" / "ReleaseNotes.tex",
     ],
-    "full": [
+    "release": [
         MF6IO_PATH / "mf6io.tex",
         DOCS_PATH / "ReleaseNotes" / "ReleaseNotes.tex",
         DOCS_PATH / "zonebudget" / "zonebudget.tex",
@@ -56,7 +56,7 @@ SYSTEM = platform.system()
 EXE_EXT = ".exe" if SYSTEM == "Windows" else ""
 LIB_EXT = ".dll" if SYSTEM == "Windows" else ".so" if SYSTEM == "Linux" else ".dylib"
 
-# publications included in full dist docs
+# publications
 PUB_URLS = [
     "https://pubs.usgs.gov/tm/06/a55/tm6a55.pdf",
     "https://pubs.usgs.gov/tm/06/a56/tm6a56.pdf",
@@ -385,14 +385,13 @@ def build_documentation(
     bin_path: PathLike,
     out_path: PathLike,
     force: bool = False,
-    full: bool = False,
     repo_owner: str = "MODFLOW-ORG",
     developmode: bool = True,
     patch: bool = False,
 ):
     """Build documentation for a MODFLOW 6 distribution."""
 
-    print(f"Building {'full' if full else 'minimal'} documentation")
+    print(f"Building documentation in {'release' if developmode else 'develop'} mode")
 
     bin_path = Path(bin_path).expanduser().absolute()
     out_path = Path(out_path).expanduser().absolute()
@@ -413,13 +412,13 @@ def build_documentation(
         )
         build_notes_tex(force=force, patch=patch)
 
-        if full:
+        if developmode:
             build_benchmark_tex(out_path=out_path, force=force)
             fetch_example_docs(out_path=out_path, force=force, repo_owner=repo_owner)
             fetch_usgs_pubs(out_path=out_path, force=force)
-            tex_paths = TEX_PATHS["full"]
+            tex_paths = TEX_PATHS["release"]
         else:
-            tex_paths = TEX_PATHS["minimal"]
+            tex_paths = TEX_PATHS["develop"]
 
         build_pdfs(tex_paths=tex_paths, out_path=out_path, force=force)
 
@@ -429,7 +428,7 @@ def build_documentation(
 
     # make sure we have expected PDFs
     assert pdf_path.is_file()
-    if full:
+    if developmode:
         assert (out_path / "ReleaseNotes.pdf").is_file()
         assert (out_path / "zonebudget.pdf").is_file()
         assert (out_path / "converter_mf5to6.pdf").is_file()
@@ -496,7 +495,7 @@ only what it can't find. Use the --force (-f) flag to regenerate existing artifa
         required=False,
         default=False,
         action="store_true",
-        help="Build docs for a full distribution (approved release). "
+        help="Build documents in release mode for standard releases. "
         "Will omit prerelease variables/sections from documentation, "
         "filtering out MF6IO variables marked 'prerelease', and also "
         "any LaTeX sections wrapped with '\\ifdevelopmode ... \\fi'. "

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -74,17 +74,20 @@ def github_user() -> Optional[str]:
 def build_benchmark_tex(
     out_path: PathLike,
     force: bool = False,
+    repo_owner: str = "MODFLOW-ORG",
 ):
     """Build LaTeX files for MF6 performance benchmarks to go into the release notes."""
 
     # run benchmarks again if no benchmarks found on GitHub or overwrite requested
     benchmarks_path = out_path / "run-time-comparison.md"
+    examples_path = EXAMPLES_REPO_PATH / "examples"
     if force or not benchmarks_path.is_file():
+        fetch_examples_zip(examples_path, force=force, repo_owner=repo_owner)
         run_benchmarks(
             build_path=PROJ_ROOT_PATH / "builddir",
             current_bin_path=PROJ_ROOT_PATH / "bin",
             previous_bin_path=PROJ_ROOT_PATH / "bin" / "rebuilt",
-            examples_path=EXAMPLES_REPO_PATH / "examples",
+            examples_path=examples_path,
             out_path=out_path,
         )
     assert benchmarks_path.is_file()
@@ -364,7 +367,20 @@ def fetch_example_docs(
     if force or not (out_path / pdf_name).is_file():
         latest = get_release(f"{repo_owner}/modflow6-examples", "latest")
         assets = latest["assets"]
-        asset = next(iter([a for a in assets if a["name"] == pdf_name]), None)
+        pdf_asset = next(iter([a for a in assets if a["name"] == pdf_name]), None)
+        download_and_unzip(pdf_asset["browser_download_url"], out_path, verbose=True)
+
+
+def fetch_examples_zip(
+    out_path: PathLike, force: bool = False, repo_owner: str = "MODFLOW-ORG"
+):
+    zip_name = "examples.zip"
+    if force or not any(os.listdir(out_path)):
+        latest = get_release(
+            f"{repo_owner}/modflow6-examples", tag="latest", verbose=True
+        )
+        assets = latest["assets"]
+        asset = next(iter([a for a in assets if a["name"] == zip_name]), None)
         download_and_unzip(asset["browser_download_url"], out_path, verbose=True)
 
 
@@ -413,7 +429,7 @@ def build_documentation(
         build_notes_tex(force=force, patch=patch)
 
         if developmode:
-            build_benchmark_tex(out_path=out_path, force=force)
+            build_benchmark_tex(out_path=out_path, force=force, repo_owner=repo_owner)
             fetch_example_docs(out_path=out_path, force=force, repo_owner=repo_owner)
             fetch_usgs_pubs(out_path=out_path, force=force)
             tex_paths = TEX_PATHS["release"]

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -375,7 +375,8 @@ def fetch_examples_zip(
     out_path: PathLike, force: bool = False, repo_owner: str = "MODFLOW-ORG"
 ):
     zip_name = "examples.zip"
-    if force or not any(os.listdir(out_path)):
+    out_path = Path(out_path).expanduser().absolute()
+    if force or not out_path.is_dir() or not any(os.listdir(out_path)):
         latest = get_release(
             f"{repo_owner}/modflow6-examples", tag="latest", verbose=True
         )

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -367,8 +367,12 @@ def fetch_example_docs(
     if force or not (out_path / pdf_name).is_file():
         latest = get_release(f"{repo_owner}/modflow6-examples", "latest")
         assets = latest["assets"]
-        pdf_asset = next(iter([a for a in assets if a["name"] == pdf_name]), None)
-        download_and_unzip(pdf_asset["browser_download_url"], out_path, verbose=True)
+        asset = next(iter([a for a in assets if a["name"] == pdf_name]), None)
+        if asset is None:
+            raise ValueError(
+                f"Release {latest['tag_name']} does not have asset {pdf_name}"
+            )
+        download_and_unzip(asset["browser_download_url"], out_path, verbose=True)
 
 
 def fetch_examples_zip(
@@ -381,7 +385,11 @@ def fetch_examples_zip(
             f"{repo_owner}/modflow6-examples", tag="latest", verbose=True
         )
         assets = latest["assets"]
-        asset = next(iter([a for a in assets if a["name"] == zip_name]), None)
+        asset = next(iter([a for a in assets if a["name"].endswith(zip_name)]), None)
+        if asset is None:
+            raise ValueError(
+                f"Release {latest['tag_name']} does not have asset {zip_name}"
+            )
         download_and_unzip(asset["browser_download_url"], out_path, verbose=True)
 
 

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -416,7 +416,7 @@ def build_documentation(
 ):
     """Build documentation for a MODFLOW 6 distribution."""
 
-    print(f"Building documentation in {'release' if developmode else 'develop'} mode")
+    print(f"Building documentation in {'develop' if developmode else 'release'} mode")
 
     bin_path = Path(bin_path).expanduser().absolute()
     out_path = Path(out_path).expanduser().absolute()
@@ -438,12 +438,12 @@ def build_documentation(
         build_notes_tex(force=force, patch=patch)
 
         if developmode:
+            tex_paths = TEX_PATHS["develop"]
+        else:
             build_benchmark_tex(out_path=out_path, force=force, repo_owner=repo_owner)
             fetch_example_docs(out_path=out_path, force=force, repo_owner=repo_owner)
             fetch_usgs_pubs(out_path=out_path, force=force)
             tex_paths = TEX_PATHS["release"]
-        else:
-            tex_paths = TEX_PATHS["develop"]
 
         build_pdfs(tex_paths=tex_paths, out_path=out_path, force=force)
 
@@ -453,7 +453,7 @@ def build_documentation(
 
     # make sure we have expected PDFs
     assert pdf_path.is_file()
-    if developmode:
+    if not developmode:
         assert (out_path / "ReleaseNotes.pdf").is_file()
         assert (out_path / "zonebudget.pdf").is_file()
         assert (out_path / "converter_mf5to6.pdf").is_file()

--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -19,7 +19,7 @@ FC = environ.get("FC", None)
 
 # top-leveldirectories included in distributions
 DIST_DIRS = {
-    "full": [
+    "releasemode": [
         "bin",
         "doc",
         "examples",
@@ -29,7 +29,7 @@ DIST_DIRS = {
         "make",
         "utils",
     ],
-    "minimal": [
+    "provisional": [
         "bin",
         "doc",
     ],
@@ -58,15 +58,15 @@ def dist_dir_path(request):
 
 
 @no_parallel
-def test_directories(dist_dir_path, full):
-    for dir_path in DIST_DIRS["full" if full else "minimal"]:
+def test_directories(dist_dir_path, releasemode):
+    for dir_path in DIST_DIRS["releasemode" if releasemode else "provisional"]:
         assert (dist_dir_path / dir_path).is_dir()
 
 
 @no_parallel
-def test_sources(dist_dir_path, releasemode, full):
-    if not full:
-        pytest.skip(reason="sources not included in minimal distribution")
+def test_sources(dist_dir_path, releasemode):
+    if not releasemode:
+        pytest.skip(reason="sources not included in provisional distribution")
 
     # check top-level meson files
     assert (dist_dir_path / "meson.build").is_file()
@@ -97,9 +97,9 @@ def test_sources(dist_dir_path, releasemode, full):
 
 @no_parallel
 @pytest.mark.skipif(not FC, reason="needs Fortran compiler")
-def test_makefiles(dist_dir_path, full):
-    if not full:
-        pytest.skip(reason="makefiles not included in minimal distribution")
+def test_makefiles(dist_dir_path, releasemode):
+    if not releasemode:
+        pytest.skip(reason="makefiles not included in provisional distribution")
 
     assert (dist_dir_path / "make" / "makefile").is_file()
     assert (dist_dir_path / "make" / "makedefaults").is_file()
@@ -128,9 +128,9 @@ def test_makefiles(dist_dir_path, full):
 
 
 @no_parallel
-def test_msvs(dist_dir_path, full):
-    if not full:
-        pytest.skip(reason="MSVS files not included in minimal distribution")
+def test_msvs(dist_dir_path, releasemode):
+    if not releasemode:
+        pytest.skip(reason="MSVS files not included in provisional distribution")
 
     assert (dist_dir_path / "msvs" / "mf6.sln").is_file()
     assert (dist_dir_path / "msvs" / "mf6.vfproj").is_file()
@@ -140,11 +140,11 @@ def test_msvs(dist_dir_path, full):
 
 
 @no_parallel
-def test_docs(dist_dir_path, full):
+def test_docs(dist_dir_path, releasemode):
     # mf6io should always be included
     assert (dist_dir_path / "doc" / "mf6io.pdf").is_file()
 
-    if full:
+    if releasemode:
         # check other custom-built documentation
         assert (dist_dir_path / "doc" / "release.pdf").is_file()
         assert (dist_dir_path / "doc" / "mf5to6.pdf").is_file()
@@ -164,9 +164,9 @@ def test_docs(dist_dir_path, full):
 
 
 @no_parallel
-def test_examples(dist_dir_path, full):
-    if not full:
-        pytest.skip(reason="examples not included in minimal distribution")
+def test_examples(dist_dir_path, releasemode):
+    if not releasemode:
+        pytest.skip(reason="examples not included in provisional distribution")
 
     # check examples directory
     examples_path = dist_dir_path / "examples"
@@ -198,7 +198,7 @@ def test_examples(dist_dir_path, full):
 
 
 @no_parallel
-def test_binaries(dist_dir_path, approved):
+def test_binaries(dist_dir_path, releasemode):
     bin_path = dist_dir_path / "bin"
     assert (bin_path / f"mf6{EXE_EXT}").is_file()
     assert (bin_path / f"zbud6{EXE_EXT}").is_file()
@@ -214,7 +214,7 @@ def test_binaries(dist_dir_path, approved):
     assert output.startswith("mf6")
 
     # make sure version string reflects approval
-    assert ("preliminary" in output) != approved
+    assert ("preliminary" in output) != releasemode
 
     # check version numbers
     version = output.lower().split(" ")[1]
@@ -224,6 +224,6 @@ def test_binaries(dist_dir_path, approved):
 
     # approved release should use semantic version number with
     # exactly 3 components and no alphabetic characters in it
-    if approved:
+    if releasemode:
         assert len(v_split) == 3
         assert all(s.isdigit() for s in v_split[:3])

--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -17,9 +17,13 @@ SCR_EXT = ".bat" if SYSTEM == "Windows" else ".sh"
 # fortran compiler
 FC = environ.get("FC", None)
 
-# top-leveldirectories included in distributions
+# expected dirs
 DIST_DIRS = {
-    "releasemode": [
+    "develop": [
+        "bin",
+        "doc",
+    ],
+    "release": [
         "bin",
         "doc",
         "examples",
@@ -28,10 +32,6 @@ DIST_DIRS = {
         "msvs",
         "make",
         "utils",
-    ],
-    "provisional": [
-        "bin",
-        "doc",
     ],
 }
 
@@ -59,7 +59,7 @@ def dist_dir_path(request):
 
 @no_parallel
 def test_directories(dist_dir_path, releasemode):
-    for dir_path in DIST_DIRS["releasemode" if releasemode else "provisional"]:
+    for dir_path in DIST_DIRS["release" if releasemode else "develop"]:
         assert (dist_dir_path / dir_path).is_dir()
 
 

--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -37,18 +37,8 @@ DIST_DIRS = {
 
 
 @pytest.fixture
-def approved(request):
-    return request.config.getoption("--approved")
-
-
-@pytest.fixture
 def releasemode(request):
     return request.config.getoption("--releasemode")
-
-
-@pytest.fixture
-def full(request):
-    return request.config.getoption("--full")
 
 
 @pytest.fixture

--- a/distribution/conftest.py
+++ b/distribution/conftest.py
@@ -12,6 +12,4 @@ DIST_PATH = (
 def pytest_addoption(parser):
     # all options below are for check_dist.py
     parser.addoption("-P", "--path", action="store", default=str(DIST_PATH))
-    parser.addoption("-A", "--approved", action="store_true", default=False)
     parser.addoption("-R", "--releasemode", action="store_true", default=False)
-    parser.addoption("-F", "--full", action="store_true", default=False)

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -23,10 +23,10 @@ version numbers, and an optional label. Version numbers are substituted into sou
 code, latex files, markdown files, etc. The version number can be provided explicitly
 using --version, short -v.
 
-If the --releasemode flag is provided, IDEVELOPMODE is set to 0 in
+If the --full flag is provided, IDEVELOPMODE is set to 0 in
 src/Utilities/version.f90.  Otherwise, IDEVELOPMODE is set to 1.
 
-if the --approved flag (short -a) is provided, the disclaimer in
+if the --full flag is provided, the disclaimer in
 src/Utilities/version.f90 and the README/DISCLAIMER markdown files is modified to
 reflect review and approval. Otherwise the language reflects preliminary/provisional
 status, and version strings contain "(preliminary)".
@@ -129,13 +129,13 @@ def get_disclaimer(approved: bool = False, formatted: bool = False) -> str:
 
 
 def get_software_citation(
-    timestamp: datetime, version: Version, approved: bool = False
+    timestamp: datetime, version: Version, full: bool = False
 ) -> str:
     # get data Software/Code citation for FloPy
     citation = yaml.safe_load((project_root_path / "CITATION.cff").read_text())
 
     sb = ""
-    if not approved:
+    if not full:
         sb = " (preliminary)"
     # format author names
     authors = []
@@ -203,7 +203,7 @@ def update_meson_build(version: Version):
     log_update(path, version)
 
 
-def update_version_tex(version: Version, timestamp: datetime, developmode: bool = True):
+def update_version_tex(version: Version, timestamp: datetime, full: bool = True):
     path = project_root_path / "doc" / "version.tex"
     with open(path, "w") as f:
         lines = [
@@ -214,7 +214,7 @@ def update_version_tex(version: Version, timestamp: datetime, developmode: bool 
                 "{Version \\modflowversion---\\modflowdate}"
             ),
             "\\newif\\ifdevelopmode",
-            f"\\developmode{'true' if developmode else 'false'}",
+            f"\\developmode{'false' if full else 'true'}",
         ]
         for line in lines:
             f.write(f"{line}\n")
@@ -225,8 +225,7 @@ def update_version_tex(version: Version, timestamp: datetime, developmode: bool 
 def update_version_f90(
     version: Optional[Version],
     timestamp: datetime,
-    approved: bool = False,
-    developmode: bool = True,
+    full: bool = False,
 ):
     path = project_root_path / "src" / "Utilities" / "version.f90"
     lines = open(path, "r").read().splitlines()
@@ -249,34 +248,34 @@ def update_version_f90(
             elif ":: IDEVELOPMODE =" in line:
                 line = (
                     "  integer(I4B), parameter :: "
-                    + f"IDEVELOPMODE = {1 if developmode else 0}"
+                    + f"IDEVELOPMODE = {0 if full else 1}"
                 )
             elif ":: VERSIONNUMBER =" in line:
                 line = line.rpartition("::")[0] + f":: VERSIONNUMBER = '{version_num}'"
             elif ":: VERSIONTAG =" in line:
                 fmat_tstmp = timestamp.strftime("%m/%d/%Y")
                 label_clause = version_label if version_label else ""
-                label_clause += " (preliminary)" if not approved else ""
+                label_clause += " (preliminary)" if not full else ""
                 line = (
                     line.rpartition("::")[0]
                     + f":: VERSIONTAG = '{label_clause} {fmat_tstmp}'"
                 )
             elif ":: FMTDISCLAIMER =" in line:
-                line = get_disclaimer(approved, formatted=True)
+                line = get_disclaimer(full, formatted=True)
                 skip = True
             f.write(f"{line}\n")
     log_update(path, version)
 
 
-def update_readme_and_disclaimer(version: Version, approved: bool = False):
-    disclaimer = get_disclaimer(approved, formatted=False)
+def update_readme_and_disclaimer(version: Version, full: bool = False):
+    disclaimer = get_disclaimer(full, formatted=False)
     readme_path = str(project_root_path / "README.md")
     readme_lines = open(readme_path, "r").read().splitlines()
     with open(readme_path, "w") as f:
         for line in readme_lines:
             if "## Version " in line:
                 version_line = f"### Version {version}"
-                if not approved:
+                if not full:
                     version_line += " (preliminary)"
                 f.write(f"{version_line}\n")
             elif "Disclaimer" in line:
@@ -305,14 +304,14 @@ def update_citation_cff(version: Version, timestamp: datetime):
     log_update(path, version)
 
 
-def update_codejson(version: Version, timestamp: datetime, approved: bool = False):
+def update_codejson(version: Version, timestamp: datetime, full: bool = False):
     path = project_root_path / "code.json"
     with open(path, "r") as f:
         data = json.load(f, object_pairs_hook=OrderedDict)
 
     data[0]["date"]["metadataLastUpdated"] = timestamp.strftime("%Y-%m-%d")
     data[0]["version"] = str(version)
-    data[0]["status"] = "Release" if approved else "Preliminary"
+    data[0]["status"] = "Release" if full else "Preliminary"
     with open(path, "w") as f:
         json.dump(data, f, indent=4)
         f.write("\n")
@@ -345,8 +344,7 @@ def update_pixi(version: Version):
 def update_version(
     version: Version = None,
     timestamp: datetime = datetime.now(),
-    approved: bool = False,
-    developmode: bool = True,
+    full: bool = False,
 ):
     """
     Update version information stored in version.txt in the project root,
@@ -366,11 +364,11 @@ def update_version(
         with lock:
             update_version_txt_and_py(version, timestamp)
             update_meson_build(version)
-            update_version_tex(version, timestamp, developmode)
-            update_version_f90(version, timestamp, approved, developmode)
-            update_readme_and_disclaimer(version, approved)
+            update_version_tex(version, timestamp, full)
+            update_version_f90(version, timestamp, full)
+            update_readme_and_disclaimer(version, full)
             update_citation_cff(version, timestamp)
-            update_codejson(version, timestamp, approved)
+            update_codejson(version, timestamp, full)
             update_doxyfile(version)
             update_pixi(version)
 
@@ -394,19 +392,13 @@ _current_version = Version(version_file_path.read_text().strip())
         ),
     ],
 )
-@pytest.mark.parametrize("approved", [True, False])
-@pytest.mark.parametrize("developmode", [True, False])
-def test_update_version(version, approved, developmode):
+@pytest.mark.parametrize("full", [True, False])
+def test_update_version(version, full):
     m_times = [get_modified_time(file) for file in touched_file_paths]
     timestamp = datetime.now()
 
     try:
-        update_version(
-            timestamp=timestamp,
-            version=version,
-            approved=approved,
-            developmode=developmode,
-        )
+        update_version(timestamp=timestamp, version=version, full=full)
         updated = Version(version_file_path.read_text().strip())
 
         # check files containing version info were modified
@@ -424,20 +416,18 @@ def test_update_version(version, approved, developmode):
         # check IDEVELOPMODE was set correctly
         version_f90_path = project_root_path / "src" / "Utilities" / "version.f90"
         lines = version_f90_path.read_text().splitlines()
-        assert any(
-            f"IDEVELOPMODE = {1 if developmode else 0}" in line for line in lines
-        )
+        assert any(f"IDEVELOPMODE = {0 if full else 1}" in line for line in lines)
 
         # check disclaimer has appropriate language
         disclaimer_path = project_root_path / "DISCLAIMER.md"
         lines = disclaimer_path.read_text().splitlines()
-        assert any(("approved for release") in line for line in lines) == approved
-        assert any(("preliminary or provisional") in line for line in lines) != approved
+        assert any(("approved for release") in line for line in lines) == full
+        assert any(("preliminary or provisional") in line for line in lines) != full
 
         # check readme has appropriate language
         readme_path = project_root_path / "README.md"
         lines = readme_path.read_text().splitlines()
-        assert any(("(preliminary)") in line for line in lines) != approved
+        assert any(("(preliminary)") in line for line in lines) != full
     finally:
         for p in touched_file_paths:
             os.system(f"git restore {p}")
@@ -468,19 +458,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-a",
-        "--approved",
+        "--full",
         required=False,
         action="store_true",
-        help="Approve the release version "
-        "(defaults to false for preliminary/development distributions)",
-    )
-    parser.add_argument(
-        "-r",
-        "--releasemode",
-        required=False,
-        action="store_true",
-        help="Set IDEVELOPMODE to 0 for release mode "
-        "(defaults to false for development distributions)",
+        help="Approve the release version, modifying disclaimer language "
+        "and setting IDEVELOPMODE to 0. Defaults to false for preliminary "
+        "development distributions.",
     )
     parser.add_argument(
         "-g",
@@ -498,24 +481,15 @@ if __name__ == "__main__":
         help="Show the citation, don't update anything (defaults to False)",
     )
     args = parser.parse_args()
-    approved = args.approved
-    releasemode = args.releasemode
+    full = args.full
     version = Version(args.version) if args.version else _current_version
     if args.get:
         print(Version((project_root_path / "version.txt").read_text().strip()))
     elif args.citation:
         print(
-            get_software_citation(
-                timestamp=datetime.now(), version=version, approved=approved
-            )
+            get_software_citation(timestamp=datetime.now(), version=version, full=full)
         )
     else:
         print(f"Updating to version {version} with options")
-        print(f"    approved: {approved}")
-        print(f"    releasemode: {releasemode}")
-        update_version(
-            version=version,
-            timestamp=datetime.now(),
-            approved=approved,
-            developmode=not releasemode,
-        )
+        print(f"    full: {full}")
+        update_version(version=version, timestamp=datetime.now(), full=full)

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -23,10 +23,10 @@ version numbers, and an optional label. Version numbers are substituted into sou
 code, latex files, markdown files, etc. The version number can be provided explicitly
 using --version, short -v.
 
-If the --full flag is provided, IDEVELOPMODE is set to 0 in
+If --releasemode is provided, IDEVELOPMODE is set to 0 in
 src/Utilities/version.f90.  Otherwise, IDEVELOPMODE is set to 1.
 
-if the --full flag is provided, the disclaimer in
+if --releasemode is provided, the disclaimer in
 src/Utilities/version.f90 and the README/DISCLAIMER markdown files is modified to
 reflect review and approval. Otherwise the language reflects preliminary/provisional
 status, and version strings contain "(preliminary)".
@@ -121,21 +121,20 @@ resulting from the authorized or unauthorized use of the software.
 """
 
 
-def get_disclaimer(approved: bool = False, formatted: bool = False) -> str:
-    if approved:
-        return _approved_fmtdisclaimer if formatted else _approved_disclaimer
-    else:
+def get_disclaimer(developmode: bool = False, formatted: bool = False) -> str:
+    if developmode:
         return _preliminary_fmtdisclaimer if formatted else _preliminary_disclaimer
+    return _approved_fmtdisclaimer if formatted else _approved_disclaimer
 
 
 def get_software_citation(
-    timestamp: datetime, version: Version, full: bool = False
+    timestamp: datetime, version: Version, developmode: bool = False
 ) -> str:
     # get data Software/Code citation for FloPy
     citation = yaml.safe_load((project_root_path / "CITATION.cff").read_text())
 
     sb = ""
-    if not full:
+    if developmode:
         sb = " (preliminary)"
     # format author names
     authors = []
@@ -203,7 +202,7 @@ def update_meson_build(version: Version):
     log_update(path, version)
 
 
-def update_version_tex(version: Version, timestamp: datetime, full: bool = True):
+def update_version_tex(version: Version, timestamp: datetime, developmode: bool = True):
     path = project_root_path / "doc" / "version.tex"
     with open(path, "w") as f:
         lines = [
@@ -214,7 +213,7 @@ def update_version_tex(version: Version, timestamp: datetime, full: bool = True)
                 "{Version \\modflowversion---\\modflowdate}"
             ),
             "\\newif\\ifdevelopmode",
-            f"\\developmode{'false' if full else 'true'}",
+            f"\\developmode{'true' if developmode else 'false'}",
         ]
         for line in lines:
             f.write(f"{line}\n")
@@ -225,7 +224,7 @@ def update_version_tex(version: Version, timestamp: datetime, full: bool = True)
 def update_version_f90(
     version: Optional[Version],
     timestamp: datetime,
-    full: bool = False,
+    developmode: bool = False,
 ):
     path = project_root_path / "src" / "Utilities" / "version.f90"
     lines = open(path, "r").read().splitlines()
@@ -248,34 +247,34 @@ def update_version_f90(
             elif ":: IDEVELOPMODE =" in line:
                 line = (
                     "  integer(I4B), parameter :: "
-                    + f"IDEVELOPMODE = {0 if full else 1}"
+                    + f"IDEVELOPMODE = {1 if developmode else 0}"
                 )
             elif ":: VERSIONNUMBER =" in line:
                 line = line.rpartition("::")[0] + f":: VERSIONNUMBER = '{version_num}'"
             elif ":: VERSIONTAG =" in line:
                 fmat_tstmp = timestamp.strftime("%m/%d/%Y")
                 label_clause = version_label if version_label else ""
-                label_clause += " (preliminary)" if not full else ""
+                label_clause += " (preliminary)" if developmode else ""
                 line = (
                     line.rpartition("::")[0]
                     + f":: VERSIONTAG = '{label_clause} {fmat_tstmp}'"
                 )
             elif ":: FMTDISCLAIMER =" in line:
-                line = get_disclaimer(full, formatted=True)
+                line = get_disclaimer(developmode=developmode, formatted=True)
                 skip = True
             f.write(f"{line}\n")
     log_update(path, version)
 
 
-def update_readme_and_disclaimer(version: Version, full: bool = False):
-    disclaimer = get_disclaimer(full, formatted=False)
+def update_readme_and_disclaimer(version: Version, developmode: bool = False):
+    disclaimer = get_disclaimer(developmode, formatted=False)
     readme_path = str(project_root_path / "README.md")
     readme_lines = open(readme_path, "r").read().splitlines()
     with open(readme_path, "w") as f:
         for line in readme_lines:
             if "## Version " in line:
                 version_line = f"### Version {version}"
-                if not full:
+                if developmode:
                     version_line += " (preliminary)"
                 f.write(f"{version_line}\n")
             elif "Disclaimer" in line:
@@ -304,14 +303,14 @@ def update_citation_cff(version: Version, timestamp: datetime):
     log_update(path, version)
 
 
-def update_codejson(version: Version, timestamp: datetime, full: bool = False):
+def update_codejson(version: Version, timestamp: datetime, developmode: bool = False):
     path = project_root_path / "code.json"
     with open(path, "r") as f:
         data = json.load(f, object_pairs_hook=OrderedDict)
 
     data[0]["date"]["metadataLastUpdated"] = timestamp.strftime("%Y-%m-%d")
     data[0]["version"] = str(version)
-    data[0]["status"] = "Release" if full else "Preliminary"
+    data[0]["status"] = "Preliminary" if developmode else "Release"
     with open(path, "w") as f:
         json.dump(data, f, indent=4)
         f.write("\n")
@@ -344,7 +343,7 @@ def update_pixi(version: Version):
 def update_version(
     version: Version = None,
     timestamp: datetime = datetime.now(),
-    full: bool = False,
+    developmode: bool = False,
 ):
     """
     Update version information stored in version.txt in the project root,
@@ -364,11 +363,11 @@ def update_version(
         with lock:
             update_version_txt_and_py(version, timestamp)
             update_meson_build(version)
-            update_version_tex(version, timestamp, full)
-            update_version_f90(version, timestamp, full)
-            update_readme_and_disclaimer(version, full)
+            update_version_tex(version, timestamp, developmode)
+            update_version_f90(version, timestamp, developmode)
+            update_readme_and_disclaimer(version, developmode)
             update_citation_cff(version, timestamp)
-            update_codejson(version, timestamp, full)
+            update_codejson(version, timestamp, developmode)
             update_doxyfile(version)
             update_pixi(version)
 
@@ -398,7 +397,7 @@ def test_update_version(version, full):
     timestamp = datetime.now()
 
     try:
-        update_version(timestamp=timestamp, version=version, full=full)
+        update_version(timestamp=timestamp, version=version, developmode=full)
         updated = Version(version_file_path.read_text().strip())
 
         # check files containing version info were modified
@@ -451,45 +450,52 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
-        "-v",
-        "--version",
-        required=False,
-        help="Specify the release version",
-    )
-    parser.add_argument(
-        "-a",
-        "--full",
+        "-c",
+        "--citation",
         required=False,
         action="store_true",
-        help="Approve the release version, modifying disclaimer language "
-        "and setting IDEVELOPMODE to 0. Defaults to false for preliminary "
-        "development distributions.",
+        help="Show the citation, don't update anything. Defaults to false.",
     )
     parser.add_argument(
         "-g",
         "--get",
         required=False,
         action="store_true",
-        help="Get the current version number, don't update anything "
-        "(defaults to false)",
+        help="Show the version, don't update anything. Defaults to false",
     )
     parser.add_argument(
-        "-c",
-        "--citation",
+        "-a",
+        "--releasemode",
         required=False,
         action="store_true",
-        help="Show the citation, don't update anything (defaults to False)",
+        help="Enable release mode for a full, standard release. Modifies "
+        "disclaimer language reflecting approval. Sets IDEVELOPMODE = 0. "
+        "Defaults to false for preliminary development distributions.",
     )
+    parser.add_argument(
+        "-v",
+        "--version",
+        required=False,
+        help="Specify the release version. Value must follow PEP 440.",
+    )
+
     args = parser.parse_args()
-    full = args.full
+    get = args.get
+    citation = args.citation
+    developmode = not args.releasemode
     version = Version(args.version) if args.version else _current_version
-    if args.get:
+
+    if get:
         print(Version((project_root_path / "version.txt").read_text().strip()))
-    elif args.citation:
+    elif citation:
         print(
-            get_software_citation(timestamp=datetime.now(), version=version, full=full)
+            get_software_citation(
+                timestamp=datetime.now(), version=version, developmode=developmode
+            )
         )
     else:
-        print(f"Updating to version {version} with options")
-        print(f"    full: {full}")
-        update_version(version=version, timestamp=datetime.now(), full=full)
+        mode = "develop" if developmode else "release"
+        print(f"Updating to version {version} in {mode} mode")
+        update_version(
+            version=version, timestamp=datetime.now(), developmode=developmode
+        )

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -23,12 +23,12 @@ version numbers, and an optional label. Version numbers are substituted into sou
 code, latex files, markdown files, etc. The version number can be provided explicitly
 using --version, short -v.
 
-If --releasemode is provided, IDEVELOPMODE is set to 0 in
-src/Utilities/version.f90.  Otherwise, IDEVELOPMODE is set to 1.
+If --releasemode is provided, IDEVELOPMODE is set to 0 in src/Utilities/version.f90.
+Otherwise, IDEVELOPMODE is set to 1.
 
-if --releasemode is provided, the disclaimer in
-src/Utilities/version.f90 and the README/DISCLAIMER markdown files is modified to
-reflect review and approval. Otherwise the language reflects preliminary/provisional
+if --releasemode is provided, the disclaimer in src/Utilities/version.f90 and the
+README/DISCLAIMER markdown files is modified to reflect review and approval.
+Otherwise the language reflects preliminary/provisional
 status, and version strings contain "(preliminary)".
 """
 
@@ -437,15 +437,32 @@ if __name__ == "__main__":
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent(
             """\
-            Update version information stored in version.txt in the project root,
-            as well as several other files in the repository. If --version is not
-            provided, the version number will not be changed. A file lock is held
-            to synchronize file access. To indicate a version is production-ready
-            use --approve. This will change the disclaimer and version tag label,
-            removing '(preliminary)' from the latter, and modifying the former to
-            reflect approval The --releasemode flag controls whether IDEVELOPMODE
-            is set to 0 instead of the default 1. The version tag must follow the
-            '<major>.<minor>.<patch>' format conventions for semantic versioning.
+Update version information stored in version.txt in the project root,
+as well as several other files in the repository:
+
+  ../version.txt
+  ../meson.build
+  ../doc/version.tex
+  ../README.md
+  ../DISCLAIMER.md
+  ../code.json
+  ../src/Utilities/version.f90
+
+These include a combination of version strings, build timestamps, disclaimer
+text, text indicating whether the release is provisional or approved, source
+code setting the variable IDEVELOPMODE to either 0 or 1, and other data.
+
+Provide a `--version` string following semantic versioning conventions.
+If --version is not provided, the version number will not be changed,
+just timestamps.
+
+Use `--get` (`-g`) to show the current version without making changes.
+The version number is read from version.txt in the project root.
+
+Use `--releasemode` to control whether IDEVELOPMODE is set to 0 instead
+of 1, and to alter mf6's output and disclaimer text reflecting approval.
+
+Use `--citation` (`-c`) to render the current software citation.
             """
         ),
     )

--- a/doc/mf6io/body.tex
+++ b/doc/mf6io/body.tex
@@ -56,18 +56,18 @@
 \input{prt/prt.tex}
 
 %CHF Model Input Instructions
-\IfFileExists{develop.version}{
+\ifdevelopmode
 \newpage
 \SECTION{Channel Flow (CHF) Model Input}
 \input{chf/chf.tex}
-}{}
+\fi
 
 %OLF Model Input Instructions
-\IfFileExists{develop.version}{
+\ifdevelopmode
 \newpage
 \SECTION{Overland Flow (OLF) Model Input}
 \input{olf/olf.tex}
-}{}
+\fi
 
 %Sparse Matrix Solution (IMS)
 \newpage

--- a/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
@@ -96,7 +96,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
@@ -107,7 +107,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/gwe-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-disu.dfn
@@ -106,7 +106,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
@@ -107,7 +107,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/gwe-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-nam.dfn
@@ -41,7 +41,7 @@ optional true
 longname flag to scale X and RHS
 description flag to scale X and RHS to avoid very large positive or negative dependent variable values
 mf6internal idv_scale
-prerelease true
+developmode true
 
 block options
 name nc_mesh2d_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwf-chdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-chdg.dfn
@@ -7,7 +7,7 @@ name readarraygrid
 type keyword
 reader urword
 optional false
-prerelease true
+developmode true
 longname use array-based grid input
 description indicates that array-based grid input will be used for the constant head package.  This keyword must be specified to use array-based grid input.  When READARRAYGRID is specified, values must be provided for every cell within a model grid, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. No data cells should contain the value DNODATA (3.0E+30).
 default_value true

--- a/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
@@ -107,7 +107,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
@@ -106,7 +106,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
@@ -107,7 +107,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
@@ -7,7 +7,7 @@ name readarraygrid
 type keyword
 reader urword
 optional false
-prerelease true
+developmode true
 longname use array-based grid input
 description indicates that array-based grid input will be used for the drain package.  This keyword must be specified to use array-based grid input.  When READARRAYGRID is specified, values must be provided for every cell within a model grid, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. No data cells should contain the value DNODATA (3.0E+30). 
 default_value true

--- a/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
@@ -7,7 +7,7 @@ name readarraygrid
 type keyword
 reader urword
 optional false
-prerelease true
+developmode true
 longname use array-based grid input
 description indicates that array-based grid input will be used for the general-head boundary package.  This keyword must be specified to use array-based grid input.  When READARRAYGRID is specified, values must be provided for every cell within a model grid, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. No data cells should contain the value DNODATA (3.0E+30). 
 default_value true

--- a/doc/mf6io/mf6ivar/dfn/gwf-rivg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rivg.dfn
@@ -7,7 +7,7 @@ name readarraygrid
 type keyword
 reader urword
 optional false
-prerelease true
+developmode true
 longname use array-based grid input
 description indicates that array-based grid input will be used for the river package.  This keyword must be specified to use array-based grid input.  When READARRAYGRID is specified, values must be provided for every cell within a model grid, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. No data cells should contain the value DNODATA (3.0E+30).
 default_value True

--- a/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
@@ -7,7 +7,7 @@ name readarraygrid
 type keyword
 reader urword
 optional false
-prerelease true
+developmode true
 longname use array-based grid input
 description indicates that array-based grid input will be used for the well boundary package.  This keyword must be specified to use array-based grid input.  When READARRAYGRID is specified, values must be provided for every cell within a model grid, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. No data cells should contain the value DNODATA (3.0E+30).
 default_value true

--- a/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
@@ -107,7 +107,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
@@ -106,7 +106,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
@@ -107,7 +107,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/gwt-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-nam.dfn
@@ -41,7 +41,7 @@ optional true
 longname flag to scale X and RHS
 description flag to scale X and RHS to avoid very large positive or negative dependent variable values
 mf6internal idv_scale
-prerelease true
+developmode true
 
 block options
 name nc_mesh2d_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwt-src.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-src.dfn
@@ -135,7 +135,7 @@ name highest_saturated
 type keyword
 reader urword
 optional true
-prerelease true
+developmode true
 mf6internal highest_sat
 longname apply source to highest saturated cell
 description Apply mass source loading rate to specified CELLID or highest underlying cell with a cell saturation greater than zero. The highest\_saturated option has an additional complication for certain types of grids specified using the DISU Package. When the DISU Package is used, a cell may have more than one cell underlying it. If the overlying cell were to become inactive, there is no straightforward method for determining how to apportion the mass source loading rate to the underlying cells. In this case, the approach described by \cite{modflowusg} is used. The mass source loading rate is assigned to the first active cell encountered (determined by searching through the underlying cell numbers from the lowest number to the highest number). In this manner, the total mass source loading rate is conserved; however, the spatial distribution of the applied mass source loading rate may not be maintained as layers become dry or wet during a simulation.

--- a/doc/mf6io/mf6ivar/dfn/olf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-dis2d.dfn
@@ -96,7 +96,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/olf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-disv1d.dfn
@@ -96,7 +96,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/olf-disv2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-disv2d.dfn
@@ -96,7 +96,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
@@ -105,7 +105,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
@@ -105,7 +105,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -290,7 +290,7 @@ type string
 valid none eager
 reader urword
 optional true
-prerelease true
+developmode true
 mf6internal ichkmeth
 longname coordinate checking method
 description approach for verifying that release point coordinates are in the cell with the specified ID. By default, release point coordinates are checked at release time.

--- a/doc/mf6io/mf6ivar/dfn/swf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-dis2d.dfn
@@ -96,7 +96,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/swf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-disv1d.dfn
@@ -96,7 +96,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/dfn/swf-disv2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-disv2d.dfn
@@ -96,7 +96,7 @@ shape lenbigline
 preserve_case true
 reader urword
 optional true
-prerelease true
+developmode true
 longname CRS user input string
 description is a real-world coordinate reference system (CRS) for the model, for example, an EPSG integer code (e.g. 26915), authority string (i.e. epsg:26915), or Open Geospatial Consortium Well-Known Text (WKT) specification. Limited to 5000 characters. The entry for CRS does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 

--- a/doc/mf6io/mf6ivar/mf6ivar.py
+++ b/doc/mf6io/mf6ivar/mf6ivar.py
@@ -407,7 +407,8 @@ def write_desc(vardict, block, blk_var_list, varexcludeprefix=None, developmode=
                             or "deprecated" in vardict[(vn, block)]
                             or (
                                 not developmode
-                                and vardict[(vn, block)].get("developmode", "") == "true"
+                                and vardict[(vn, block)].get("developmode", "")
+                                == "true"
                             )
                         ):
                             continue

--- a/doc/mf6io/mf6ivar/mf6ivar.py
+++ b/doc/mf6io/mf6ivar/mf6ivar.py
@@ -309,7 +309,7 @@ def write_block(
             if (
                 v.get("deprecated", "") != ""
                 or v.get("removed", "") != ""
-                or (not developmode and v.get("prerelease", "") == "true")
+                or (not developmode and v.get("developmode", "") == "true")
             ):
                 addv = False
             if addv:
@@ -359,7 +359,7 @@ def write_desc(vardict, block, blk_var_list, varexcludeprefix=None, developmode=
                 addv = False
             if v.get("removed", "") != "":
                 addv = False
-            if not developmode and v.get("prerelease", "") != "":
+            if not developmode and v.get("developmode", "") != "":
                 addv = False
             if addv:
                 if v["type"] == "keyword":
@@ -407,7 +407,7 @@ def write_desc(vardict, block, blk_var_list, varexcludeprefix=None, developmode=
                             or "deprecated" in vardict[(vn, block)]
                             or (
                                 not developmode
-                                and vardict[(vn, block)].get("prerelease", "") == "true"
+                                and vardict[(vn, block)].get("developmode", "") == "true"
                             )
                         ):
                             continue
@@ -442,7 +442,7 @@ def write_desc_md(
                 addv = False
             if v.get("removed", "") != "":
                 addv = False
-            if not developmode and v.get("prerelease", "") == "true":
+            if not developmode and v.get("developmode", "") == "true":
                 addv = False
             if addv:
                 if v["type"] == "keyword":
@@ -900,7 +900,7 @@ if __name__ == "__main__":
         "--releasemode",
         required=False,
         action="store_true",
-        help="Omit prerelease variables from documentation "
+        help="Omit developmode variables from documentation "
         "(defaults to false for development distributions)",
     )
     parser.add_argument(

--- a/doc/mf6io/mf6ivar/mf6ivar.py
+++ b/doc/mf6io/mf6ivar/mf6ivar.py
@@ -124,6 +124,9 @@ import textwrap
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from collections import OrderedDict
 from pathlib import Path
+from typing import get_args
+
+from modflow_devtools.dfn import FieldType
 
 
 def parse_mf6var_file(fname):
@@ -183,18 +186,8 @@ RTD_DOC_DIR_PATH = Path(__file__).parents[3] / ".build_rtd_docs" / "_mf6io"
 COMMON_DFN_PATH = parse_mf6var_file(DFNS_DIR_PATH / "common.dfn")
 COMMON_DIR_PATH = MF6IVAR_DIR_PATH.parent.parent / "Common"
 DEFAULT_MODELS = ["gwf", "gwt", "gwe", "prt"]
-DEVELOP_MODELS = ["chf", "olf"]
-if (MF6IO_DIR_PATH / "develop.version").is_file():
-    DEFAULT_MODELS += DEVELOP_MODELS
-VALID_TYPES = [
-    "integer",
-    "double precision",
-    "string",
-    "keystring",
-    "keyword",
-    "recarray",
-    "record",
-]
+DEVELOP_MODELS = ["chf", "olf", "swf"]
+VALID_TYPES = list(get_args(FieldType))
 
 MD_DIR_PATH.mkdir(exist_ok=True)
 TEX_DIR_PATH.mkdir(exist_ok=True)
@@ -884,14 +877,12 @@ def write_variables(developmode=True):
                         s += "\n\n"
                         f.write(s)
 
-            # write markdown
             write_md(fmd, vardict, component, package)
 
     return allblocks
 
 
 if __name__ == "__main__":
-    # parse arguments
     parser = ArgumentParser(
         prog="Generate MF6 IO documentation files from DFN files",
         formatter_class=RawDescriptionHelpFormatter,
@@ -905,11 +896,12 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
-        "-m",
-        "--model",
+        "-r",
+        "--releasemode",
         required=False,
-        action="append",
-        help="Filter models to include",
+        action="store_true",
+        help="Omit prerelease variables from documentation "
+        "(defaults to false for development distributions)",
     )
     parser.add_argument(
         "-v",
@@ -919,29 +911,23 @@ if __name__ == "__main__":
         action="store_true",
         help="Whether to show verbose output",
     )
-    parser.add_argument(
-        "-r",
-        "--releasemode",
-        required=False,
-        action="store_true",
-        help="Omit prerelease variables from documentation "
-        "(defaults to false for development distributions)",
-    )
-    args = parser.parse_args()
-    models = args.model if args.model else DEFAULT_MODELS
-    verbose = args.verbose
-    developmode = not args.releasemode
 
-    # clean/recreate docdir
+    args = parser.parse_args()
+    developmode = not args.releasemode
+    verbose = args.verbose
+
     if os.path.isdir(RTD_DOC_DIR_PATH):
         shutil.rmtree(RTD_DOC_DIR_PATH)
-    os.makedirs(RTD_DOC_DIR_PATH)
+    RTD_DOC_DIR_PATH.mkdir(parents=True)
 
-    # filter dfn files corresponding to the selected set of models
-    # and write variables and appendix to markdown and latex files
+    models = DEFAULT_MODELS
+    if developmode:
+        models.extend(DEVELOP_MODELS)
+
     dfns = get_dfn_files(models)
     blocks = write_variables(developmode=developmode)
     write_appendix(blocks)
+
     if verbose:
         for block in blocks:
             print(block)

--- a/doc/mf6io/mf6ivar/readme.md
+++ b/doc/mf6io/mf6ivar/readme.md
@@ -76,7 +76,7 @@ A MODFLOW 6 input variable is described by a set of attributes. Some attributes 
 | numeric_index | Indicates that this is an index variable.                              | No       | False   | Indicates that FloPy should treat the parameter as zero-based.                                                                                                |
 | deprecated    | Indicates that the parameter has been deprecated.                      | No       | None    | Should be a semantic version number, the version in which the parameter was deprecated. If this attribute is provided without a value, it is ignored.            |
 | removed       | Indicates that the parameter has been removed.                         | No       | None    | Should be a semantic version number, the version in which the parameter was removed. If this attribute is provided without a value, it is ignored.               |
-| prerelease    | Indicates that the parameter should not be released yet.               | No       | False   | Should be set to true to indicate that a parameter is not ready for inclusion in releases. The parameter will be omitted from the generated IO guide.   |
+| developmode    | Indicates that the parameter should be omitted from releases.               | No       | False   | Should be set to true to indicate that a parameter is not ready for inclusion in releases. The parameter will be omitted from the generated IO guide.   |
 
 ### Reader Attribute
 

--- a/make/makefile
+++ b/make/makefile
@@ -245,7 +245,7 @@ $(OBJDIR)/chf-chdidm.o \
 $(OBJDIR)/chf-cdbidm.o \
 $(OBJDIR)/List.o \
 $(OBJDIR)/LongLineReader.o \
-$(OBJDIR)/DevFeature.o \
+$(OBJDIR)/FeatureFlags.o \
 $(OBJDIR)/MemoryStore.o \
 $(OBJDIR)/IdmUtlDfnSelector.o \
 $(OBJDIR)/IdmSwfDfnSelector.o \

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -680,7 +680,7 @@
 			<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
 			<FileConfiguration Name="Release|Win32">
 			<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\src\Utilities\DevFeature.f90"/>
+		<File RelativePath="..\src\Utilities\FeatureFlags.f90"/>
 		<File RelativePath="..\src\Utilities\ErrorUtil.f90"/>
 		<File RelativePath="..\src\Utilities\GeomUtil.f90"/>
 		<File RelativePath="..\src\Utilities\GridFileReader.f90"/>

--- a/pixi.toml
+++ b/pixi.toml
@@ -115,8 +115,8 @@ prepare-pull-request = {depends-on = ["fix-style", "fix-python-style", "build-ma
 
 # dist/docs
 benchmark = { cmd = "python benchmark.py", cwd = "distribution" }
-build-docs = { cmd = "python build_docs.py", cwd = "distribution" }
-build-dist = { cmd = "python build_dist.py", cwd = "distribution" }
+build-docs = { cmd = "python build_docs.py" }
+build-dist = { cmd = "python build_dist.py" }
 check-dist = { cmd = "pytest -v -s check_dist.py", cwd = "distribution" }
 test-dist-scripts = { cmd = "pytest -v --durations 0", cwd = "distribution" }
 update-version = { cmd = "python update_version.py", cwd = "distribution" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -115,8 +115,8 @@ prepare-pull-request = {depends-on = ["fix-style", "fix-python-style", "build-ma
 
 # dist/docs
 benchmark = { cmd = "python benchmark.py", cwd = "distribution" }
-build-docs = { cmd = "python build_docs.py" }
-build-dist = { cmd = "python build_dist.py" }
+build-docs = { cmd = "python build_docs.py", cwd = "distribution" }
+build-dist = { cmd = "python build_dist.py", cwd = "distribution" }
 check-dist = { cmd = "pytest -v -s check_dist.py", cwd = "distribution" }
 test-dist-scripts = { cmd = "pytest -v --durations 0", cwd = "distribution" }
 update-version = { cmd = "python update_version.py", cwd = "distribution" }

--- a/src/Idm/chf-cdbidm.f90
+++ b/src/Idm/chf-cdbidm.f90
@@ -49,7 +49,7 @@ module ChfCdbInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -68,7 +68,7 @@ module ChfCdbInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -87,7 +87,7 @@ module ChfCdbInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -106,7 +106,7 @@ module ChfCdbInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -125,7 +125,7 @@ module ChfCdbInputModule
     '', & ! shape
     'save flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -144,7 +144,7 @@ module ChfCdbInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -163,7 +163,7 @@ module ChfCdbInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -182,7 +182,7 @@ module ChfCdbInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -201,7 +201,7 @@ module ChfCdbInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -220,7 +220,7 @@ module ChfCdbInputModule
     '', & ! shape
     'maximum number of critical depth boundaries', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -239,7 +239,7 @@ module ChfCdbInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -258,7 +258,7 @@ module ChfCdbInputModule
     '', & ! shape
     'cross section identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -277,7 +277,7 @@ module ChfCdbInputModule
     '', & ! shape
     'width of the zero-depth gradient boundary', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -296,7 +296,7 @@ module ChfCdbInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -315,7 +315,7 @@ module ChfCdbInputModule
     '', & ! shape
     'zero-depth-gradient boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -354,7 +354,7 @@ module ChfCdbInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-chdidm.f90
+++ b/src/Idm/chf-chdidm.f90
@@ -52,7 +52,7 @@ module ChfChdInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module ChfChdInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module ChfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module ChfChdInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module ChfChdInputModule
     '', & ! shape
     'print CHD flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module ChfChdInputModule
     '', & ! shape
     'save CHD flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module ChfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module ChfChdInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module ChfChdInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module ChfChdInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module ChfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module ChfChdInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module ChfChdInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module ChfChdInputModule
     '', & ! shape
     'maximum number of constant heads', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module ChfChdInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module ChfChdInputModule
     '', & ! shape
     'head value assigned to constant head', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module ChfChdInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module ChfChdInputModule
     '', & ! shape
     'constant head boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module ChfChdInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-cxsidm.f90
+++ b/src/Idm/chf-cxsidm.f90
@@ -42,7 +42,7 @@ module ChfCxsInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -61,7 +61,7 @@ module ChfCxsInputModule
     '', & ! shape
     'number of reaches', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -80,7 +80,7 @@ module ChfCxsInputModule
     '', & ! shape
     'total number of points defined for all reaches', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -99,7 +99,7 @@ module ChfCxsInputModule
     '', & ! shape
     'reach number for this entry', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -118,7 +118,7 @@ module ChfCxsInputModule
     '', & ! shape
     'number of points used to define cross section', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -137,7 +137,7 @@ module ChfCxsInputModule
     '', & ! shape
     'fractional width', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -156,7 +156,7 @@ module ChfCxsInputModule
     '', & ! shape
     'depth', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -175,7 +175,7 @@ module ChfCxsInputModule
     '', & ! shape
     'Mannings roughness coefficient', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -207,7 +207,7 @@ module ChfCxsInputModule
     'NSECTIONS', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -226,7 +226,7 @@ module ChfCxsInputModule
     'NPOINTS', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-dfwidm.f90
+++ b/src/Idm/chf-dfwidm.f90
@@ -48,7 +48,7 @@ module ChfDfwInputModule
     '', & ! shape
     'use central in space weighting', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -67,7 +67,7 @@ module ChfDfwInputModule
     '', & ! shape
     'length conversion factor', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -86,7 +86,7 @@ module ChfDfwInputModule
     '', & ! shape
     'time conversion factor', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -105,7 +105,7 @@ module ChfDfwInputModule
     '', & ! shape
     'keyword to save DFW flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -124,7 +124,7 @@ module ChfDfwInputModule
     '', & ! shape
     'keyword to print DFW flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -143,7 +143,7 @@ module ChfDfwInputModule
     '', & ! shape
     'keyword to save velocity', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -162,7 +162,7 @@ module ChfDfwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -181,7 +181,7 @@ module ChfDfwInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -200,7 +200,7 @@ module ChfDfwInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -219,7 +219,7 @@ module ChfDfwInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -238,7 +238,7 @@ module ChfDfwInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -257,7 +257,7 @@ module ChfDfwInputModule
     '', & ! shape
     'use SWR conductance formulation', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -276,7 +276,7 @@ module ChfDfwInputModule
     'NODES', & ! shape
     'mannings roughness coefficient', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -295,7 +295,7 @@ module ChfDfwInputModule
     'NODES', & ! shape
     'cross section number', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -335,7 +335,7 @@ module ChfDfwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-disv1didm.f90
+++ b/src/Idm/chf-disv1didm.f90
@@ -57,7 +57,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -76,7 +76,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -95,7 +95,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -114,7 +114,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -133,7 +133,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -152,7 +152,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -171,7 +171,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'x-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -190,7 +190,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'y-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -209,7 +209,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -228,7 +228,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -247,7 +247,7 @@ module ChfDisv1DInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -266,7 +266,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'number of linear features', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -285,7 +285,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'number of columns', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -304,7 +304,7 @@ module ChfDisv1DInputModule
     'NODES', & ! shape
     'width', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -323,7 +323,7 @@ module ChfDisv1DInputModule
     'NODES', & ! shape
     'bottom elevation for the one-dimensional cell', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -342,7 +342,7 @@ module ChfDisv1DInputModule
     'NODES', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -361,7 +361,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -380,7 +380,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -399,7 +399,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -418,7 +418,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'cell1d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -437,7 +437,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'fractional distance to the cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -456,7 +456,7 @@ module ChfDisv1DInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -475,7 +475,7 @@ module ChfDisv1DInputModule
     'NCVERT', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -522,7 +522,7 @@ module ChfDisv1DInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -541,7 +541,7 @@ module ChfDisv1DInputModule
     'NODES', & ! shape
     'cell1d data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-evpidm.f90
+++ b/src/Idm/chf-evpidm.f90
@@ -52,7 +52,7 @@ module ChfEvpInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module ChfEvpInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module ChfEvpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module ChfEvpInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module ChfEvpInputModule
     '', & ! shape
     'print evaporation rates to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module ChfEvpInputModule
     '', & ! shape
     'save evaporation to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module ChfEvpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module ChfEvpInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module ChfEvpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module ChfEvpInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module ChfEvpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module ChfEvpInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module ChfEvpInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module ChfEvpInputModule
     '', & ! shape
     'maximum number of evaporation cells', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module ChfEvpInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module ChfEvpInputModule
     '', & ! shape
     'evaporation rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module ChfEvpInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module ChfEvpInputModule
     '', & ! shape
     'evaporation name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module ChfEvpInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-flwidm.f90
+++ b/src/Idm/chf-flwidm.f90
@@ -52,7 +52,7 @@ module ChfFlwInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module ChfFlwInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module ChfFlwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module ChfFlwInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module ChfFlwInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module ChfFlwInputModule
     '', & ! shape
     'save well flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module ChfFlwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module ChfFlwInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module ChfFlwInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module ChfFlwInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module ChfFlwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module ChfFlwInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module ChfFlwInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module ChfFlwInputModule
     '', & ! shape
     'maximum number of inflow', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module ChfFlwInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module ChfFlwInputModule
     '', & ! shape
     'well rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module ChfFlwInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module ChfFlwInputModule
     '', & ! shape
     'inflow name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module ChfFlwInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-icidm.f90
+++ b/src/Idm/chf-icidm.f90
@@ -36,7 +36,7 @@ module ChfIcInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -55,7 +55,7 @@ module ChfIcInputModule
     'NODES', & ! shape
     'starting concentration', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -83,7 +83,7 @@ module ChfIcInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-namidm.f90
+++ b/src/Idm/chf-namidm.f90
@@ -44,7 +44,7 @@ module ChfNamInputModule
     '', & ! shape
     'name of listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -63,7 +63,7 @@ module ChfNamInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -82,7 +82,7 @@ module ChfNamInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -101,7 +101,7 @@ module ChfNamInputModule
     '', & ! shape
     'save flows for all packages to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -120,7 +120,7 @@ module ChfNamInputModule
     '', & ! shape
     'newton keyword and options', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -139,7 +139,7 @@ module ChfNamInputModule
     '', & ! shape
     'keyword to activate Newton-Raphson formulation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -158,7 +158,7 @@ module ChfNamInputModule
     '', & ! shape
     'keyword to activate Newton-Raphson UNDER_RELAXATION option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -177,7 +177,7 @@ module ChfNamInputModule
     '', & ! shape
     'package type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -196,7 +196,7 @@ module ChfNamInputModule
     '', & ! shape
     'file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -215,7 +215,7 @@ module ChfNamInputModule
     '', & ! shape
     'user name for package', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -249,7 +249,7 @@ module ChfNamInputModule
     '', & ! shape
     'package list', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-pcpidm.f90
+++ b/src/Idm/chf-pcpidm.f90
@@ -52,7 +52,7 @@ module ChfPcpInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module ChfPcpInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module ChfPcpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module ChfPcpInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module ChfPcpInputModule
     '', & ! shape
     'print precipitation rates to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module ChfPcpInputModule
     '', & ! shape
     'save precipitation to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module ChfPcpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module ChfPcpInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module ChfPcpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module ChfPcpInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module ChfPcpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module ChfPcpInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module ChfPcpInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module ChfPcpInputModule
     '', & ! shape
     'maximum number of precipitation cells', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module ChfPcpInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module ChfPcpInputModule
     '', & ! shape
     'precipitation rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module ChfPcpInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module ChfPcpInputModule
     '', & ! shape
     'precipitation name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module ChfPcpInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-stoidm.f90
+++ b/src/Idm/chf-stoidm.f90
@@ -38,7 +38,7 @@ module ChfStoInputModule
     '', & ! shape
     'keyword to save NPF flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -57,7 +57,7 @@ module ChfStoInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -76,7 +76,7 @@ module ChfStoInputModule
     '', & ! shape
     'steady state indicator', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -95,7 +95,7 @@ module ChfStoInputModule
     '', & ! shape
     'transient indicator', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -125,7 +125,7 @@ module ChfStoInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/chf-zdgidm.f90
+++ b/src/Idm/chf-zdgidm.f90
@@ -54,7 +54,7 @@ module ChfZdgInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -73,7 +73,7 @@ module ChfZdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -92,7 +92,7 @@ module ChfZdgInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -111,7 +111,7 @@ module ChfZdgInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -130,7 +130,7 @@ module ChfZdgInputModule
     '', & ! shape
     'save flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -149,7 +149,7 @@ module ChfZdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -168,7 +168,7 @@ module ChfZdgInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -187,7 +187,7 @@ module ChfZdgInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -206,7 +206,7 @@ module ChfZdgInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -225,7 +225,7 @@ module ChfZdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -244,7 +244,7 @@ module ChfZdgInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -263,7 +263,7 @@ module ChfZdgInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -282,7 +282,7 @@ module ChfZdgInputModule
     '', & ! shape
     'maximum number of zero-depth-gradient boundaries', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -301,7 +301,7 @@ module ChfZdgInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -320,7 +320,7 @@ module ChfZdgInputModule
     '', & ! shape
     'cross section identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -339,7 +339,7 @@ module ChfZdgInputModule
     '', & ! shape
     'width of the zero-depth gradient boundary', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -358,7 +358,7 @@ module ChfZdgInputModule
     '', & ! shape
     'channel slope', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -377,7 +377,7 @@ module ChfZdgInputModule
     '', & ! shape
     'channel roughness', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -396,7 +396,7 @@ module ChfZdgInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -415,7 +415,7 @@ module ChfZdgInputModule
     '', & ! shape
     'zero-depth-gradient boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -459,7 +459,7 @@ module ChfZdgInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/exg-chfgwfidm.f90
+++ b/src/Idm/exg-chfgwfidm.f90
@@ -46,7 +46,7 @@ module ExgChfgwfInputModule
     '', & ! shape
     'keyword to print input to list file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -65,7 +65,7 @@ module ExgChfgwfInputModule
     '', & ! shape
     'keyword to print chfgwf flows to list file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -84,7 +84,7 @@ module ExgChfgwfInputModule
     '', & ! shape
     'keyword to indicate conductance is fixed', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -103,7 +103,7 @@ module ExgChfgwfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -122,7 +122,7 @@ module ExgChfgwfInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -141,7 +141,7 @@ module ExgChfgwfInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -160,7 +160,7 @@ module ExgChfgwfInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -179,7 +179,7 @@ module ExgChfgwfInputModule
     '', & ! shape
     'number of exchanges', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -198,7 +198,7 @@ module ExgChfgwfInputModule
     'NCELLDIM', & ! shape
     'cellid of cell in surface water model', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -217,7 +217,7 @@ module ExgChfgwfInputModule
     'NCELLDIM', & ! shape
     'cellid of cell in groundwater model', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -236,7 +236,7 @@ module ExgChfgwfInputModule
     '', & ! shape
     'bed leakance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -255,7 +255,7 @@ module ExgChfgwfInputModule
     '', & ! shape
     'factor used for conductance calculation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -291,7 +291,7 @@ module ExgChfgwfInputModule
     'NEXG', & ! shape
     'exchange data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/exg-gwegweidm.f90
+++ b/src/Idm/exg-gwegweidm.f90
@@ -61,7 +61,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'keyword to specify name of first corresponding GWF Model', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -80,7 +80,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'keyword to specify name of second corresponding GWF Model', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -99,7 +99,7 @@ module ExgGwegweInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -118,7 +118,7 @@ module ExgGwegweInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -137,7 +137,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'keyword to print input to list file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -156,7 +156,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'keyword to print gwfgwf flows to list file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -175,7 +175,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'keyword to save GWFGWF flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -194,7 +194,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'advective scheme', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -213,7 +213,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'deactivate xt3d', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -232,7 +232,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'xt3d on right-hand side', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -251,7 +251,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -270,7 +270,7 @@ module ExgGwegweInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -289,7 +289,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -308,7 +308,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'mve6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -327,7 +327,7 @@ module ExgGwegweInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -346,7 +346,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -365,7 +365,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -384,7 +384,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'activate interface model on exchange', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -403,7 +403,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'number of exchanges', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -422,7 +422,7 @@ module ExgGwegweInputModule
     'NCELLDIM', & ! shape
     'cellid of first cell', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -441,7 +441,7 @@ module ExgGwegweInputModule
     'NCELLDIM', & ! shape
     'cellid of second cell', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -460,7 +460,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'integer flag for connection type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -479,7 +479,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'connection distance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -498,7 +498,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'connection distance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -517,7 +517,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'horizontal cell width or area for vertical flow', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -536,7 +536,7 @@ module ExgGwegweInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -555,7 +555,7 @@ module ExgGwegweInputModule
     '', & ! shape
     'exchange boundname', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -606,7 +606,7 @@ module ExgGwegweInputModule
     'NEXG', & ! shape
     'exchange data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/exg-gwfgweidm.f90
+++ b/src/Idm/exg-gwfgweidm.f90
@@ -36,7 +36,7 @@ module ExgGwfgweInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -58,7 +58,7 @@ module ExgGwfgweInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/exg-gwfgwfidm.f90
+++ b/src/Idm/exg-gwfgwfidm.f90
@@ -65,7 +65,7 @@ module ExgGwfgwfInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -84,7 +84,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -103,7 +103,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'keyword to print input to list file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -122,7 +122,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'keyword to print gwfgwf flows to list file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -141,7 +141,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'keyword to save GWFGWF flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -160,7 +160,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'conductance weighting option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -179,7 +179,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'vertical conductance options', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -198,7 +198,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'keyword to activate VARIABLECV option', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -217,7 +217,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'keyword to activate DEWATERED option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -236,7 +236,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'keyword to activate Newton-Raphson', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -255,7 +255,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'keyword to activate XT3D', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -274,7 +274,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -293,7 +293,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -312,7 +312,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'gnc6 keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -331,7 +331,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'gnc6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -350,7 +350,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -369,7 +369,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -388,7 +388,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'mvr6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -407,7 +407,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -426,7 +426,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -445,7 +445,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -464,7 +464,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'activate interface model on exchange', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -483,7 +483,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'number of exchanges', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -502,7 +502,7 @@ module ExgGwfgwfInputModule
     'NCELLDIM', & ! shape
     'cellid of first cell', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -521,7 +521,7 @@ module ExgGwfgwfInputModule
     'NCELLDIM', & ! shape
     'cellid of second cell', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -540,7 +540,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'integer flag for connection type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -559,7 +559,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'connection distance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -578,7 +578,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'connection distance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -597,7 +597,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'horizontal cell width or area for vertical flow', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -616,7 +616,7 @@ module ExgGwfgwfInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -635,7 +635,7 @@ module ExgGwfgwfInputModule
     '', & ! shape
     'exchange boundname', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -690,7 +690,7 @@ module ExgGwfgwfInputModule
     'NEXG', & ! shape
     'exchange data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/exg-gwfgwtidm.f90
+++ b/src/Idm/exg-gwfgwtidm.f90
@@ -36,7 +36,7 @@ module ExgGwfgwtInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -58,7 +58,7 @@ module ExgGwfgwtInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/exg-gwfprtidm.f90
+++ b/src/Idm/exg-gwfprtidm.f90
@@ -36,7 +36,7 @@ module ExgGwfprtInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -58,7 +58,7 @@ module ExgGwfprtInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/exg-gwtgwtidm.f90
+++ b/src/Idm/exg-gwtgwtidm.f90
@@ -61,7 +61,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'keyword to specify name of first corresponding GWF Model', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -80,7 +80,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'keyword to specify name of second corresponding GWF Model', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -99,7 +99,7 @@ module ExgGwtgwtInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -118,7 +118,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -137,7 +137,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'keyword to print input to list file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -156,7 +156,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'keyword to print gwfgwf flows to list file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -175,7 +175,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'keyword to save GWFGWF flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -194,7 +194,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'advective scheme', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -213,7 +213,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'deactivate xt3d', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -232,7 +232,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'xt3d on right-hand side', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -251,7 +251,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -270,7 +270,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -289,7 +289,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -308,7 +308,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'mvt6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -327,7 +327,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -346,7 +346,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -365,7 +365,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -384,7 +384,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'activate interface model on exchange', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -403,7 +403,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'number of exchanges', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -422,7 +422,7 @@ module ExgGwtgwtInputModule
     'NCELLDIM', & ! shape
     'cellid of first cell', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -441,7 +441,7 @@ module ExgGwtgwtInputModule
     'NCELLDIM', & ! shape
     'cellid of second cell', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -460,7 +460,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'integer flag for connection type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -479,7 +479,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'connection distance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -498,7 +498,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'connection distance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -517,7 +517,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'horizontal cell width or area for vertical flow', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -536,7 +536,7 @@ module ExgGwtgwtInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -555,7 +555,7 @@ module ExgGwtgwtInputModule
     '', & ! shape
     'exchange boundname', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -606,7 +606,7 @@ module ExgGwtgwtInputModule
     'NEXG', & ! shape
     'exchange data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/exg-olfgwfidm.f90
+++ b/src/Idm/exg-olfgwfidm.f90
@@ -46,7 +46,7 @@ module ExgOlfgwfInputModule
     '', & ! shape
     'keyword to print input to list file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -65,7 +65,7 @@ module ExgOlfgwfInputModule
     '', & ! shape
     'keyword to print olfgwf flows to list file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -84,7 +84,7 @@ module ExgOlfgwfInputModule
     '', & ! shape
     'keyword to indicate conductance is fixed', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -103,7 +103,7 @@ module ExgOlfgwfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -122,7 +122,7 @@ module ExgOlfgwfInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -141,7 +141,7 @@ module ExgOlfgwfInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -160,7 +160,7 @@ module ExgOlfgwfInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -179,7 +179,7 @@ module ExgOlfgwfInputModule
     '', & ! shape
     'number of exchanges', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -198,7 +198,7 @@ module ExgOlfgwfInputModule
     'NCELLDIM', & ! shape
     'cellid of cell in surface water model', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -217,7 +217,7 @@ module ExgOlfgwfInputModule
     'NCELLDIM', & ! shape
     'cellid of cell in groundwater model', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -236,7 +236,7 @@ module ExgOlfgwfInputModule
     '', & ! shape
     'bed leakance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -255,7 +255,7 @@ module ExgOlfgwfInputModule
     '', & ! shape
     'factor used for conductance calculation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -291,7 +291,7 @@ module ExgOlfgwfInputModule
     'NEXG', & ! shape
     'exchange data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-advidm.f90
+++ b/src/Idm/gwe-advidm.f90
@@ -36,7 +36,7 @@ module GweAdvInputModule
     '', & ! shape
     'advective scheme', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -55,7 +55,7 @@ module GweAdvInputModule
     '', & ! shape
     'fractional cell distance used for time step calculation', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -83,7 +83,7 @@ module GweAdvInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-cndidm.f90
+++ b/src/Idm/gwe-cndidm.f90
@@ -45,7 +45,7 @@ module GweCndInputModule
     '', & ! shape
     'deactivate xt3d', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -64,7 +64,7 @@ module GweCndInputModule
     '', & ! shape
     'xt3d on right-hand side', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -83,7 +83,7 @@ module GweCndInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -102,7 +102,7 @@ module GweCndInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -121,7 +121,7 @@ module GweCndInputModule
     'NODES', & ! shape
     'longitudinal dispersivity in horizontal direction', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -140,7 +140,7 @@ module GweCndInputModule
     'NODES', & ! shape
     'longitudinal dispersivity in vertical direction', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -159,7 +159,7 @@ module GweCndInputModule
     'NODES', & ! shape
     'transverse dispersivity in horizontal direction', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -178,7 +178,7 @@ module GweCndInputModule
     'NODES', & ! shape
     'transverse dispersivity in horizontal direction', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -197,7 +197,7 @@ module GweCndInputModule
     'NODES', & ! shape
     'transverse dispersivity when flow is in vertical direction', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -216,7 +216,7 @@ module GweCndInputModule
     'NODES', & ! shape
     'thermal conductivity of the simulated fluid', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -235,7 +235,7 @@ module GweCndInputModule
     'NODES', & ! shape
     'thermal conductivity of the aquifer material', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -272,7 +272,7 @@ module GweCndInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-ctpidm.f90
+++ b/src/Idm/gwe-ctpidm.f90
@@ -52,7 +52,7 @@ module GweCtpInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module GweCtpInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module GweCtpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module GweCtpInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module GweCtpInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module GweCtpInputModule
     '', & ! shape
     'save constant temperature flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module GweCtpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module GweCtpInputModule
     '', & ! shape
     'time series keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module GweCtpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module GweCtpInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module GweCtpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module GweCtpInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module GweCtpInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module GweCtpInputModule
     '', & ! shape
     'maximum number of constant temperatures', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module GweCtpInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module GweCtpInputModule
     '', & ! shape
     'constant temperature value', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module GweCtpInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module GweCtpInputModule
     '', & ! shape
     'constant temperature name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module GweCtpInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-disidm.f90
+++ b/src/Idm/gwe-disidm.f90
@@ -58,7 +58,7 @@ module GweDisInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -77,7 +77,7 @@ module GweDisInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -96,7 +96,7 @@ module GweDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -115,7 +115,7 @@ module GweDisInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -134,7 +134,7 @@ module GweDisInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -153,7 +153,7 @@ module GweDisInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -172,7 +172,7 @@ module GweDisInputModule
     '', & ! shape
     'x-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -191,7 +191,7 @@ module GweDisInputModule
     '', & ! shape
     'y-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -210,7 +210,7 @@ module GweDisInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -229,7 +229,7 @@ module GweDisInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -248,7 +248,7 @@ module GweDisInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -267,7 +267,7 @@ module GweDisInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -286,7 +286,7 @@ module GweDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -305,7 +305,7 @@ module GweDisInputModule
     '', & ! shape
     'ncf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -324,7 +324,7 @@ module GweDisInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -343,7 +343,7 @@ module GweDisInputModule
     '', & ! shape
     'file name of NCF information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -362,7 +362,7 @@ module GweDisInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -381,7 +381,7 @@ module GweDisInputModule
     '', & ! shape
     'number of rows', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -400,7 +400,7 @@ module GweDisInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -419,7 +419,7 @@ module GweDisInputModule
     'NCOL', & ! shape
     'spacing along a row', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -438,7 +438,7 @@ module GweDisInputModule
     'NROW', & ! shape
     'spacing along a column', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -457,7 +457,7 @@ module GweDisInputModule
     'NCOL NROW', & ! shape
     'cell top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -476,7 +476,7 @@ module GweDisInputModule
     'NCOL NROW NLAY', & ! shape
     'cell bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -495,7 +495,7 @@ module GweDisInputModule
     'NCOL NROW NLAY', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -545,7 +545,7 @@ module GweDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-disuidm.f90
+++ b/src/Idm/gwe-disuidm.f90
@@ -67,7 +67,7 @@ module GweDisuInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -86,7 +86,7 @@ module GweDisuInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -105,7 +105,7 @@ module GweDisuInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -124,7 +124,7 @@ module GweDisuInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -143,7 +143,7 @@ module GweDisuInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -162,7 +162,7 @@ module GweDisuInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -181,7 +181,7 @@ module GweDisuInputModule
     '', & ! shape
     'x-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -200,7 +200,7 @@ module GweDisuInputModule
     '', & ! shape
     'y-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -219,7 +219,7 @@ module GweDisuInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -238,7 +238,7 @@ module GweDisuInputModule
     '', & ! shape
     'vertical length dimension for top and bottom checking', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -257,7 +257,7 @@ module GweDisuInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -276,7 +276,7 @@ module GweDisuInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -295,7 +295,7 @@ module GweDisuInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -314,7 +314,7 @@ module GweDisuInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -333,7 +333,7 @@ module GweDisuInputModule
     '', & ! shape
     'number of vertices', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -352,7 +352,7 @@ module GweDisuInputModule
     'NODES', & ! shape
     'cell top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -371,7 +371,7 @@ module GweDisuInputModule
     'NODES', & ! shape
     'cell bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -390,7 +390,7 @@ module GweDisuInputModule
     'NODES', & ! shape
     'cell surface area', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -409,7 +409,7 @@ module GweDisuInputModule
     'NODES', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -428,7 +428,7 @@ module GweDisuInputModule
     'NODES', & ! shape
     'number of cell connections', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -447,7 +447,7 @@ module GweDisuInputModule
     'NJA', & ! shape
     'grid connectivity', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -466,7 +466,7 @@ module GweDisuInputModule
     'NJA', & ! shape
     'connection type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -485,7 +485,7 @@ module GweDisuInputModule
     'NJA', & ! shape
     'connection lengths', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -504,7 +504,7 @@ module GweDisuInputModule
     'NJA', & ! shape
     'connection lengths', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -523,7 +523,7 @@ module GweDisuInputModule
     'NJA', & ! shape
     'angle of face normal to connection', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -542,7 +542,7 @@ module GweDisuInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -561,7 +561,7 @@ module GweDisuInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -580,7 +580,7 @@ module GweDisuInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -599,7 +599,7 @@ module GweDisuInputModule
     '', & ! shape
     'cell2d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -618,7 +618,7 @@ module GweDisuInputModule
     '', & ! shape
     'x-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -637,7 +637,7 @@ module GweDisuInputModule
     '', & ! shape
     'y-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -656,7 +656,7 @@ module GweDisuInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -675,7 +675,7 @@ module GweDisuInputModule
     'NCVERT', & ! shape
     'array of vertex numbers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -732,7 +732,7 @@ module GweDisuInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -751,7 +751,7 @@ module GweDisuInputModule
     'NODES', & ! shape
     'cell2d data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-disvidm.f90
+++ b/src/Idm/gwe-disvidm.f90
@@ -64,7 +64,7 @@ module GweDisvInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -83,7 +83,7 @@ module GweDisvInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -102,7 +102,7 @@ module GweDisvInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -121,7 +121,7 @@ module GweDisvInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -140,7 +140,7 @@ module GweDisvInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -159,7 +159,7 @@ module GweDisvInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -178,7 +178,7 @@ module GweDisvInputModule
     '', & ! shape
     'x-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -197,7 +197,7 @@ module GweDisvInputModule
     '', & ! shape
     'y-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -216,7 +216,7 @@ module GweDisvInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -235,7 +235,7 @@ module GweDisvInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -254,7 +254,7 @@ module GweDisvInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -273,7 +273,7 @@ module GweDisvInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -292,7 +292,7 @@ module GweDisvInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -311,7 +311,7 @@ module GweDisvInputModule
     '', & ! shape
     'ncf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -330,7 +330,7 @@ module GweDisvInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -349,7 +349,7 @@ module GweDisvInputModule
     '', & ! shape
     'file name of NCF information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -368,7 +368,7 @@ module GweDisvInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -387,7 +387,7 @@ module GweDisvInputModule
     '', & ! shape
     'number of cells per layer', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -406,7 +406,7 @@ module GweDisvInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -425,7 +425,7 @@ module GweDisvInputModule
     'NCPL', & ! shape
     'model top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -444,7 +444,7 @@ module GweDisvInputModule
     'NCPL NLAY', & ! shape
     'model bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -463,7 +463,7 @@ module GweDisvInputModule
     'NCPL NLAY', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -482,7 +482,7 @@ module GweDisvInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -501,7 +501,7 @@ module GweDisvInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -520,7 +520,7 @@ module GweDisvInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -539,7 +539,7 @@ module GweDisvInputModule
     '', & ! shape
     'cell2d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -558,7 +558,7 @@ module GweDisvInputModule
     '', & ! shape
     'x-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -577,7 +577,7 @@ module GweDisvInputModule
     '', & ! shape
     'y-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -596,7 +596,7 @@ module GweDisvInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -615,7 +615,7 @@ module GweDisvInputModule
     'NCVERT', & ! shape
     'array of vertex numbers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -669,7 +669,7 @@ module GweDisvInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -688,7 +688,7 @@ module GweDisvInputModule
     'NCPL', & ! shape
     'cell2d data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-eslidm.f90
+++ b/src/Idm/gwe-eslidm.f90
@@ -52,7 +52,7 @@ module GweEslInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module GweEslInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module GweEslInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module GweEslInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module GweEslInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module GweEslInputModule
     '', & ! shape
     'save well flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module GweEslInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module GweEslInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module GweEslInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module GweEslInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module GweEslInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module GweEslInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module GweEslInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module GweEslInputModule
     '', & ! shape
     'maximum number of sources', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module GweEslInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module GweEslInputModule
     '', & ! shape
     'energy source loading rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module GweEslInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module GweEslInputModule
     '', & ! shape
     'well name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module GweEslInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-estidm.f90
+++ b/src/Idm/gwe-estidm.f90
@@ -45,7 +45,7 @@ module GweEstInputModule
     '', & ! shape
     'save calculated flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -64,7 +64,7 @@ module GweEstInputModule
     '', & ! shape
     'activate zero-order decay in aqueous phase', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -83,7 +83,7 @@ module GweEstInputModule
     '', & ! shape
     'activate zero-order decay in solid phase', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -102,7 +102,7 @@ module GweEstInputModule
     '', & ! shape
     'density of water', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -121,7 +121,7 @@ module GweEstInputModule
     '', & ! shape
     'heat capacity of water', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -140,7 +140,7 @@ module GweEstInputModule
     '', & ! shape
     'latent heat of vaporization', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -159,7 +159,7 @@ module GweEstInputModule
     'NODES', & ! shape
     'porosity', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -178,7 +178,7 @@ module GweEstInputModule
     'NODES', & ! shape
     'aqueous phase decay rate coefficient', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -197,7 +197,7 @@ module GweEstInputModule
     'NODES', & ! shape
     'solid phase decay rate coefficient', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -216,7 +216,7 @@ module GweEstInputModule
     'NODES', & ! shape
     'heat capacity of the aquifer material', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -235,7 +235,7 @@ module GweEstInputModule
     'NODES', & ! shape
     'density of aquifer material', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -272,7 +272,7 @@ module GweEstInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-fmiidm.f90
+++ b/src/Idm/gwe-fmiidm.f90
@@ -39,7 +39,7 @@ module GweFmiInputModule
     '', & ! shape
     'save calculated flow imbalance correction to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -58,7 +58,7 @@ module GweFmiInputModule
     '', & ! shape
     'correct for flow imbalance', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -77,7 +77,7 @@ module GweFmiInputModule
     '', & ! shape
     'flow type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -96,7 +96,7 @@ module GweFmiInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -115,7 +115,7 @@ module GweFmiInputModule
     '', & ! shape
     'file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -144,7 +144,7 @@ module GweFmiInputModule
     '', & ! shape
     'flowtype list', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-icidm.f90
+++ b/src/Idm/gwe-icidm.f90
@@ -37,7 +37,7 @@ module GweIcInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -56,7 +56,7 @@ module GweIcInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -75,7 +75,7 @@ module GweIcInputModule
     'NODES', & ! shape
     'starting temperature', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -104,7 +104,7 @@ module GweIcInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-namidm.f90
+++ b/src/Idm/gwe-namidm.f90
@@ -53,7 +53,7 @@ module GweNamInputModule
     '', & ! shape
     'name of listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -72,7 +72,7 @@ module GweNamInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -91,7 +91,7 @@ module GweNamInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -110,7 +110,7 @@ module GweNamInputModule
     '', & ! shape
     'save flows for all packages to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -129,7 +129,7 @@ module GweNamInputModule
     '', & ! shape
     'flag to scale X and RHS', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -148,7 +148,7 @@ module GweNamInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -167,7 +167,7 @@ module GweNamInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -186,7 +186,7 @@ module GweNamInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -205,7 +205,7 @@ module GweNamInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -224,7 +224,7 @@ module GweNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -243,7 +243,7 @@ module GweNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -262,7 +262,7 @@ module GweNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -281,7 +281,7 @@ module GweNamInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -300,7 +300,7 @@ module GweNamInputModule
     '', & ! shape
     'netcdf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -319,7 +319,7 @@ module GweNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -338,7 +338,7 @@ module GweNamInputModule
     '', & ! shape
     'netcdf input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -357,7 +357,7 @@ module GweNamInputModule
     '', & ! shape
     'package type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -376,7 +376,7 @@ module GweNamInputModule
     '', & ! shape
     'file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -395,7 +395,7 @@ module GweNamInputModule
     '', & ! shape
     'user name for package', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -438,7 +438,7 @@ module GweNamInputModule
     '', & ! shape
     'package list', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwe-ssmidm.f90
+++ b/src/Idm/gwe-ssmidm.f90
@@ -44,7 +44,7 @@ module GweSsmInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -63,7 +63,7 @@ module GweSsmInputModule
     '', & ! shape
     'save calculated flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -82,7 +82,7 @@ module GweSsmInputModule
     '', & ! shape
     'package name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -101,7 +101,7 @@ module GweSsmInputModule
     '', & ! shape
     'source type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -120,7 +120,7 @@ module GweSsmInputModule
     '', & ! shape
     'auxiliary variable name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -139,7 +139,7 @@ module GweSsmInputModule
     '', & ! shape
     'package name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -158,7 +158,7 @@ module GweSsmInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -177,7 +177,7 @@ module GweSsmInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -196,7 +196,7 @@ module GweSsmInputModule
     '', & ! shape
     'spc file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -215,7 +215,7 @@ module GweSsmInputModule
     '', & ! shape
     'mixed keyword', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -249,7 +249,7 @@ module GweSsmInputModule
     '', & ! shape
     'package list', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -268,7 +268,7 @@ module GweSsmInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-apiidm.f90
+++ b/src/Idm/gwf-apiidm.f90
@@ -44,7 +44,7 @@ module GwfApiInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -63,7 +63,7 @@ module GwfApiInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -82,7 +82,7 @@ module GwfApiInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -101,7 +101,7 @@ module GwfApiInputModule
     '', & ! shape
     'save api flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -120,7 +120,7 @@ module GwfApiInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -139,7 +139,7 @@ module GwfApiInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -158,7 +158,7 @@ module GwfApiInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -177,7 +177,7 @@ module GwfApiInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -196,7 +196,7 @@ module GwfApiInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -215,7 +215,7 @@ module GwfApiInputModule
     '', & ! shape
     'maximum number of user-defined api boundaries', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -251,7 +251,7 @@ module GwfApiInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-buyidm.f90
+++ b/src/Idm/gwf-buyidm.f90
@@ -47,7 +47,7 @@ module GwfBuyInputModule
     '', & ! shape
     'hh formulation on right-hand side', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -66,7 +66,7 @@ module GwfBuyInputModule
     '', & ! shape
     'reference density', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -85,7 +85,7 @@ module GwfBuyInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -104,7 +104,7 @@ module GwfBuyInputModule
     '', & ! shape
     'density keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -123,7 +123,7 @@ module GwfBuyInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -142,7 +142,7 @@ module GwfBuyInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -161,7 +161,7 @@ module GwfBuyInputModule
     '', & ! shape
     'use equivalent freshwater head formulation', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -180,7 +180,7 @@ module GwfBuyInputModule
     '', & ! shape
     'number of species used in density equation of state', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -199,7 +199,7 @@ module GwfBuyInputModule
     '', & ! shape
     'species number for this entry', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -218,7 +218,7 @@ module GwfBuyInputModule
     '', & ! shape
     'slope of the density-concentration line', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -237,7 +237,7 @@ module GwfBuyInputModule
     '', & ! shape
     'reference concentration value', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -256,7 +256,7 @@ module GwfBuyInputModule
     '', & ! shape
     'modelname', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -275,7 +275,7 @@ module GwfBuyInputModule
     '', & ! shape
     'auxspeciesname', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -312,7 +312,7 @@ module GwfBuyInputModule
     'NRHOSPECIES', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-chdgidm.f90
+++ b/src/Idm/gwf-chdgidm.f90
@@ -49,7 +49,7 @@ module GwfChdgInputModule
     '', & ! shape
     'use array-based grid input', & ! longname
     .true., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -68,7 +68,7 @@ module GwfChdgInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -87,7 +87,7 @@ module GwfChdgInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -106,7 +106,7 @@ module GwfChdgInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -125,7 +125,7 @@ module GwfChdgInputModule
     '', & ! shape
     'print CHD flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -144,7 +144,7 @@ module GwfChdgInputModule
     '', & ! shape
     'save CHD flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -163,7 +163,7 @@ module GwfChdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -182,7 +182,7 @@ module GwfChdgInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -201,7 +201,7 @@ module GwfChdgInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -220,7 +220,7 @@ module GwfChdgInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -239,7 +239,7 @@ module GwfChdgInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -258,7 +258,7 @@ module GwfChdgInputModule
     '', & ! shape
     'turn off Newton for unconfined cells', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -277,7 +277,7 @@ module GwfChdgInputModule
     '', & ! shape
     'maximum number of constant head cells in any stress period', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -296,7 +296,7 @@ module GwfChdgInputModule
     'NODES', & ! shape
     'head value assigned to constant head', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -315,7 +315,7 @@ module GwfChdgInputModule
     'NAUX NODES', & ! shape
     'constant head auxiliary variable iaux', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -356,7 +356,7 @@ module GwfChdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-chdidm.f90
+++ b/src/Idm/gwf-chdidm.f90
@@ -53,7 +53,7 @@ module GwfChdInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -72,7 +72,7 @@ module GwfChdInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -91,7 +91,7 @@ module GwfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -110,7 +110,7 @@ module GwfChdInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -129,7 +129,7 @@ module GwfChdInputModule
     '', & ! shape
     'print CHD flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -148,7 +148,7 @@ module GwfChdInputModule
     '', & ! shape
     'save CHD flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -167,7 +167,7 @@ module GwfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -186,7 +186,7 @@ module GwfChdInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -205,7 +205,7 @@ module GwfChdInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -224,7 +224,7 @@ module GwfChdInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -243,7 +243,7 @@ module GwfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -262,7 +262,7 @@ module GwfChdInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -281,7 +281,7 @@ module GwfChdInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -300,7 +300,7 @@ module GwfChdInputModule
     '', & ! shape
     'turn off Newton for unconfined cells', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -319,7 +319,7 @@ module GwfChdInputModule
     '', & ! shape
     'maximum number of constant heads', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -338,7 +338,7 @@ module GwfChdInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -357,7 +357,7 @@ module GwfChdInputModule
     '', & ! shape
     'head value assigned to constant head', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -376,7 +376,7 @@ module GwfChdInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -395,7 +395,7 @@ module GwfChdInputModule
     '', & ! shape
     'constant head boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -438,7 +438,7 @@ module GwfChdInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-csubidm.f90
+++ b/src/Idm/gwf-csubidm.f90
@@ -104,7 +104,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -123,7 +123,7 @@ module GwfCsubInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -142,7 +142,7 @@ module GwfCsubInputModule
     '', & ! shape
     'keyword to save CSUB flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -161,7 +161,7 @@ module GwfCsubInputModule
     '', & ! shape
     'unit weight of water', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -180,7 +180,7 @@ module GwfCsubInputModule
     '', & ! shape
     'compressibility of water', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -199,7 +199,7 @@ module GwfCsubInputModule
     '', & ! shape
     'keyword to indicate the head-based formulation will be used', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -218,7 +218,7 @@ module GwfCsubInputModule
     '', & ! shape
     'keyword to indicate that preconsolidation heads will be specified', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -237,7 +237,7 @@ module GwfCsubInputModule
     '', & ! shape
     'number of interbed cell nodes', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -256,7 +256,7 @@ module GwfCsubInputModule
     '', & ! shape
     'keyword to indicate CR and CC are read instead of SSE and SSV', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -276,7 +276,7 @@ module GwfCsubInputModule
     'keyword to indicate material properties can change during the&
      & simulations', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -295,7 +295,7 @@ module GwfCsubInputModule
     '', & ! shape
     'keyword to indicate cell fraction interbed thickness', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -314,7 +314,7 @@ module GwfCsubInputModule
     '', & ! shape
     'keyword to indicate that absolute initial states will be specified', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -334,7 +334,7 @@ module GwfCsubInputModule
     'keyword to indicate that absolute initial preconsolidation stresses&
      & (head) will be specified', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -354,7 +354,7 @@ module GwfCsubInputModule
     'keyword to indicate that absolute initial delay bed heads will be&
      & specified', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -374,7 +374,7 @@ module GwfCsubInputModule
     'keyword to indicate that specific storage will be calculate using the&
      & effective stress from the previous time step', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -393,7 +393,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -412,7 +412,7 @@ module GwfCsubInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -431,7 +431,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -450,7 +450,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -469,7 +469,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -488,7 +488,7 @@ module GwfCsubInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -507,7 +507,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -526,7 +526,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -545,7 +545,7 @@ module GwfCsubInputModule
     '', & ! shape
     'compaction keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -564,7 +564,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -583,7 +583,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -602,7 +602,7 @@ module GwfCsubInputModule
     '', & ! shape
     'elastic interbed compaction keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -621,7 +621,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -640,7 +640,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -659,7 +659,7 @@ module GwfCsubInputModule
     '', & ! shape
     'inelastic interbed compaction keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -678,7 +678,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -697,7 +697,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -716,7 +716,7 @@ module GwfCsubInputModule
     '', & ! shape
     'interbed compaction keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -735,7 +735,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -754,7 +754,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -773,7 +773,7 @@ module GwfCsubInputModule
     '', & ! shape
     'coarse compaction keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -792,7 +792,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -811,7 +811,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -830,7 +830,7 @@ module GwfCsubInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -849,7 +849,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -868,7 +868,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -887,7 +887,7 @@ module GwfCsubInputModule
     '', & ! shape
     'package_convergence keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -906,7 +906,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -925,7 +925,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -944,7 +944,7 @@ module GwfCsubInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -963,7 +963,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -982,7 +982,7 @@ module GwfCsubInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -1001,7 +1001,7 @@ module GwfCsubInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1020,7 +1020,7 @@ module GwfCsubInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1039,7 +1039,7 @@ module GwfCsubInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -1058,7 +1058,7 @@ module GwfCsubInputModule
     '', & ! shape
     'number of CSUB interbed systems', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1077,7 +1077,7 @@ module GwfCsubInputModule
     '', & ! shape
     'maximum number of stress offset cells', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1096,7 +1096,7 @@ module GwfCsubInputModule
     'NODES', & ! shape
     'elastic coarse specific storage', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -1115,7 +1115,7 @@ module GwfCsubInputModule
     'NODES', & ! shape
     'initial coarse-grained material porosity', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -1134,7 +1134,7 @@ module GwfCsubInputModule
     'NODES', & ! shape
     'specific gravity of moist sediments', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -1153,7 +1153,7 @@ module GwfCsubInputModule
     'NODES', & ! shape
     'specific gravity of saturated sediments', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -1172,7 +1172,7 @@ module GwfCsubInputModule
     '', & ! shape
     'CSUB id number for this entry', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1191,7 +1191,7 @@ module GwfCsubInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1210,7 +1210,7 @@ module GwfCsubInputModule
     '', & ! shape
     'delay type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1229,7 +1229,7 @@ module GwfCsubInputModule
     '', & ! shape
     'initial stress', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1248,7 +1248,7 @@ module GwfCsubInputModule
     '', & ! shape
     'interbed thickness or cell fraction', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1267,7 +1267,7 @@ module GwfCsubInputModule
     '', & ! shape
     'delay interbed material factor', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1286,7 +1286,7 @@ module GwfCsubInputModule
     '', & ! shape
     'initial interbed inelastic specific storage', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1305,7 +1305,7 @@ module GwfCsubInputModule
     '', & ! shape
     'initial interbed elastic specific storage', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1324,7 +1324,7 @@ module GwfCsubInputModule
     '', & ! shape
     'initial interbed porosity', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1343,7 +1343,7 @@ module GwfCsubInputModule
     '', & ! shape
     'delay interbed vertical hydraulic conductivity', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1362,7 +1362,7 @@ module GwfCsubInputModule
     '', & ! shape
     'initial delay interbed head', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1381,7 +1381,7 @@ module GwfCsubInputModule
     '', & ! shape
     'well name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1400,7 +1400,7 @@ module GwfCsubInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1419,7 +1419,7 @@ module GwfCsubInputModule
     '', & ! shape
     'well stress offset', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1513,7 +1513,7 @@ module GwfCsubInputModule
     'NINTERBEDS', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1532,7 +1532,7 @@ module GwfCsubInputModule
     'MAXSIG0', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-disidm.f90
+++ b/src/Idm/gwf-disidm.f90
@@ -58,7 +58,7 @@ module GwfDisInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -77,7 +77,7 @@ module GwfDisInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -96,7 +96,7 @@ module GwfDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -115,7 +115,7 @@ module GwfDisInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -134,7 +134,7 @@ module GwfDisInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -153,7 +153,7 @@ module GwfDisInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -172,7 +172,7 @@ module GwfDisInputModule
     '', & ! shape
     'x-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -191,7 +191,7 @@ module GwfDisInputModule
     '', & ! shape
     'y-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -210,7 +210,7 @@ module GwfDisInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -229,7 +229,7 @@ module GwfDisInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -248,7 +248,7 @@ module GwfDisInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -267,7 +267,7 @@ module GwfDisInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -286,7 +286,7 @@ module GwfDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -305,7 +305,7 @@ module GwfDisInputModule
     '', & ! shape
     'ncf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -324,7 +324,7 @@ module GwfDisInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -343,7 +343,7 @@ module GwfDisInputModule
     '', & ! shape
     'file name of NCF information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -362,7 +362,7 @@ module GwfDisInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -381,7 +381,7 @@ module GwfDisInputModule
     '', & ! shape
     'number of rows', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -400,7 +400,7 @@ module GwfDisInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -419,7 +419,7 @@ module GwfDisInputModule
     'NCOL', & ! shape
     'spacing along a row', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -438,7 +438,7 @@ module GwfDisInputModule
     'NROW', & ! shape
     'spacing along a column', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -457,7 +457,7 @@ module GwfDisInputModule
     'NCOL NROW', & ! shape
     'cell top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -476,7 +476,7 @@ module GwfDisInputModule
     'NCOL NROW NLAY', & ! shape
     'cell bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -495,7 +495,7 @@ module GwfDisInputModule
     'NCOL NROW NLAY', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -545,7 +545,7 @@ module GwfDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-disuidm.f90
+++ b/src/Idm/gwf-disuidm.f90
@@ -67,7 +67,7 @@ module GwfDisuInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -86,7 +86,7 @@ module GwfDisuInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -105,7 +105,7 @@ module GwfDisuInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -124,7 +124,7 @@ module GwfDisuInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -143,7 +143,7 @@ module GwfDisuInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -162,7 +162,7 @@ module GwfDisuInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -181,7 +181,7 @@ module GwfDisuInputModule
     '', & ! shape
     'x-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -200,7 +200,7 @@ module GwfDisuInputModule
     '', & ! shape
     'y-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -219,7 +219,7 @@ module GwfDisuInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -238,7 +238,7 @@ module GwfDisuInputModule
     '', & ! shape
     'vertical length dimension for top and bottom checking', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -257,7 +257,7 @@ module GwfDisuInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -276,7 +276,7 @@ module GwfDisuInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -295,7 +295,7 @@ module GwfDisuInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -314,7 +314,7 @@ module GwfDisuInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -333,7 +333,7 @@ module GwfDisuInputModule
     '', & ! shape
     'number of vertices', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -352,7 +352,7 @@ module GwfDisuInputModule
     'NODES', & ! shape
     'cell top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -371,7 +371,7 @@ module GwfDisuInputModule
     'NODES', & ! shape
     'cell bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -390,7 +390,7 @@ module GwfDisuInputModule
     'NODES', & ! shape
     'cell surface area', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -409,7 +409,7 @@ module GwfDisuInputModule
     'NODES', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -428,7 +428,7 @@ module GwfDisuInputModule
     'NODES', & ! shape
     'number of cell connections', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -447,7 +447,7 @@ module GwfDisuInputModule
     'NJA', & ! shape
     'grid connectivity', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -466,7 +466,7 @@ module GwfDisuInputModule
     'NJA', & ! shape
     'connection type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -485,7 +485,7 @@ module GwfDisuInputModule
     'NJA', & ! shape
     'connection lengths', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -504,7 +504,7 @@ module GwfDisuInputModule
     'NJA', & ! shape
     'connection lengths', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -523,7 +523,7 @@ module GwfDisuInputModule
     'NJA', & ! shape
     'angle of face normal to connection', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -542,7 +542,7 @@ module GwfDisuInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -561,7 +561,7 @@ module GwfDisuInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -580,7 +580,7 @@ module GwfDisuInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -599,7 +599,7 @@ module GwfDisuInputModule
     '', & ! shape
     'cell2d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -618,7 +618,7 @@ module GwfDisuInputModule
     '', & ! shape
     'x-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -637,7 +637,7 @@ module GwfDisuInputModule
     '', & ! shape
     'y-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -656,7 +656,7 @@ module GwfDisuInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -675,7 +675,7 @@ module GwfDisuInputModule
     'NCVERT', & ! shape
     'array of vertex numbers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -732,7 +732,7 @@ module GwfDisuInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -751,7 +751,7 @@ module GwfDisuInputModule
     'NODES', & ! shape
     'cell2d data', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-disvidm.f90
+++ b/src/Idm/gwf-disvidm.f90
@@ -64,7 +64,7 @@ module GwfDisvInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -83,7 +83,7 @@ module GwfDisvInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -102,7 +102,7 @@ module GwfDisvInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -121,7 +121,7 @@ module GwfDisvInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -140,7 +140,7 @@ module GwfDisvInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -159,7 +159,7 @@ module GwfDisvInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -178,7 +178,7 @@ module GwfDisvInputModule
     '', & ! shape
     'x-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -197,7 +197,7 @@ module GwfDisvInputModule
     '', & ! shape
     'y-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -216,7 +216,7 @@ module GwfDisvInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -235,7 +235,7 @@ module GwfDisvInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -254,7 +254,7 @@ module GwfDisvInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -273,7 +273,7 @@ module GwfDisvInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -292,7 +292,7 @@ module GwfDisvInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -311,7 +311,7 @@ module GwfDisvInputModule
     '', & ! shape
     'ncf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -330,7 +330,7 @@ module GwfDisvInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -349,7 +349,7 @@ module GwfDisvInputModule
     '', & ! shape
     'file name of NCF information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -368,7 +368,7 @@ module GwfDisvInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -387,7 +387,7 @@ module GwfDisvInputModule
     '', & ! shape
     'number of cells per layer', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -406,7 +406,7 @@ module GwfDisvInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -425,7 +425,7 @@ module GwfDisvInputModule
     'NCPL', & ! shape
     'model top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -444,7 +444,7 @@ module GwfDisvInputModule
     'NCPL NLAY', & ! shape
     'model bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -463,7 +463,7 @@ module GwfDisvInputModule
     'NCPL NLAY', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -482,7 +482,7 @@ module GwfDisvInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -501,7 +501,7 @@ module GwfDisvInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -520,7 +520,7 @@ module GwfDisvInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -539,7 +539,7 @@ module GwfDisvInputModule
     '', & ! shape
     'cell2d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -558,7 +558,7 @@ module GwfDisvInputModule
     '', & ! shape
     'x-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -577,7 +577,7 @@ module GwfDisvInputModule
     '', & ! shape
     'y-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -596,7 +596,7 @@ module GwfDisvInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -615,7 +615,7 @@ module GwfDisvInputModule
     'NCVERT', & ! shape
     'array of vertex numbers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -669,7 +669,7 @@ module GwfDisvInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -688,7 +688,7 @@ module GwfDisvInputModule
     'NCPL', & ! shape
     'cell2d data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-drngidm.f90
+++ b/src/Idm/gwf-drngidm.f90
@@ -52,7 +52,7 @@ module GwfDrngInputModule
     '', & ! shape
     'use array-based grid input', & ! longname
     .true., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module GwfDrngInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module GwfDrngInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module GwfDrngInputModule
     '', & ! shape
     'name of auxiliary variable for drainage depth', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module GwfDrngInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module GwfDrngInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module GwfDrngInputModule
     '', & ! shape
     'save DRNG flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module GwfDrngInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module GwfDrngInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module GwfDrngInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module GwfDrngInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module GwfDrngInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module GwfDrngInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module GwfDrngInputModule
     '', & ! shape
     'cubic-scaling', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module GwfDrngInputModule
     '', & ! shape
     'maximum number of drain cells in any stress period', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module GwfDrngInputModule
     'NODES', & ! shape
     'drain elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -356,7 +356,7 @@ module GwfDrngInputModule
     'NODES', & ! shape
     'drain conductance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -375,7 +375,7 @@ module GwfDrngInputModule
     'NAUX NODES', & ! shape
     'drain auxiliary variable iaux', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -419,7 +419,7 @@ module GwfDrngInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-drnidm.f90
+++ b/src/Idm/gwf-drnidm.f90
@@ -56,7 +56,7 @@ module GwfDrnInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -75,7 +75,7 @@ module GwfDrnInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -94,7 +94,7 @@ module GwfDrnInputModule
     '', & ! shape
     'name of auxiliary variable for drainage depth', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -113,7 +113,7 @@ module GwfDrnInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -132,7 +132,7 @@ module GwfDrnInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -151,7 +151,7 @@ module GwfDrnInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -170,7 +170,7 @@ module GwfDrnInputModule
     '', & ! shape
     'save CHD flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -189,7 +189,7 @@ module GwfDrnInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -208,7 +208,7 @@ module GwfDrnInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -227,7 +227,7 @@ module GwfDrnInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -246,7 +246,7 @@ module GwfDrnInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -265,7 +265,7 @@ module GwfDrnInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -284,7 +284,7 @@ module GwfDrnInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -303,7 +303,7 @@ module GwfDrnInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -322,7 +322,7 @@ module GwfDrnInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -341,7 +341,7 @@ module GwfDrnInputModule
     '', & ! shape
     'cubic-scaling', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -360,7 +360,7 @@ module GwfDrnInputModule
     '', & ! shape
     'maximum number of drains', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -379,7 +379,7 @@ module GwfDrnInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -398,7 +398,7 @@ module GwfDrnInputModule
     '', & ! shape
     'drain elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module GwfDrnInputModule
     '', & ! shape
     'drain conductance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -436,7 +436,7 @@ module GwfDrnInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -455,7 +455,7 @@ module GwfDrnInputModule
     '', & ! shape
     'drain name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -501,7 +501,7 @@ module GwfDrnInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-evtaidm.f90
+++ b/src/Idm/gwf-evtaidm.f90
@@ -54,7 +54,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'use array-based input', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -73,7 +73,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'if cell is dry do not apply evapotranspiration to underlying cell', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -92,7 +92,7 @@ module GwfEvtaInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -111,7 +111,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -130,7 +130,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -149,7 +149,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'print evapotranspiration rates to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -168,7 +168,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'save CHD flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -187,7 +187,7 @@ module GwfEvtaInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -206,7 +206,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -225,7 +225,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -244,7 +244,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -263,7 +263,7 @@ module GwfEvtaInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -282,7 +282,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -301,7 +301,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -320,7 +320,7 @@ module GwfEvtaInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -339,7 +339,7 @@ module GwfEvtaInputModule
     'NCPL', & ! shape
     'layer number for evapotranspiration', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -358,7 +358,7 @@ module GwfEvtaInputModule
     'NCPL', & ! shape
     'evapotranspiration surface', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -377,7 +377,7 @@ module GwfEvtaInputModule
     'NCPL', & ! shape
     'evapotranspiration surface', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -396,7 +396,7 @@ module GwfEvtaInputModule
     'NCPL', & ! shape
     'extinction depth', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -415,7 +415,7 @@ module GwfEvtaInputModule
     'NAUX NCPL', & ! shape
     'evapotranspiration auxiliary variable iaux', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -461,7 +461,7 @@ module GwfEvtaInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-evtidm.f90
+++ b/src/Idm/gwf-evtidm.f90
@@ -60,7 +60,7 @@ module GwfEvtInputModule
     '', & ! shape
     'if cell is dry do not apply evapotranspiration to underlying cell', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -79,7 +79,7 @@ module GwfEvtInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -98,7 +98,7 @@ module GwfEvtInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -117,7 +117,7 @@ module GwfEvtInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -136,7 +136,7 @@ module GwfEvtInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -155,7 +155,7 @@ module GwfEvtInputModule
     '', & ! shape
     'print evapotranspiration rates to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -174,7 +174,7 @@ module GwfEvtInputModule
     '', & ! shape
     'save evapotranspiration rates to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -193,7 +193,7 @@ module GwfEvtInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -212,7 +212,7 @@ module GwfEvtInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -231,7 +231,7 @@ module GwfEvtInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -250,7 +250,7 @@ module GwfEvtInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -269,7 +269,7 @@ module GwfEvtInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -288,7 +288,7 @@ module GwfEvtInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -307,7 +307,7 @@ module GwfEvtInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -326,7 +326,7 @@ module GwfEvtInputModule
     '', & ! shape
     'specify proportion of evapotranspiration rate at ET surface', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -345,7 +345,7 @@ module GwfEvtInputModule
     '', & ! shape
     'maximum number of evapotranspiration cells', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -364,7 +364,7 @@ module GwfEvtInputModule
     '', & ! shape
     'number of ET segments', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -383,7 +383,7 @@ module GwfEvtInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -402,7 +402,7 @@ module GwfEvtInputModule
     '', & ! shape
     'ET surface', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -421,7 +421,7 @@ module GwfEvtInputModule
     '', & ! shape
     'maximum ET rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -440,7 +440,7 @@ module GwfEvtInputModule
     '', & ! shape
     'ET extinction depth', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -459,7 +459,7 @@ module GwfEvtInputModule
     'NSEG-1', & ! shape
     'proportion of ET extinction depth', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -478,7 +478,7 @@ module GwfEvtInputModule
     'NSEG-1', & ! shape
     'proportion of maximum ET rate', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -497,7 +497,7 @@ module GwfEvtInputModule
     '', & ! shape
     'proportion of maximum ET rate at ET surface', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -516,7 +516,7 @@ module GwfEvtInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -535,7 +535,7 @@ module GwfEvtInputModule
     '', & ! shape
     'evapotranspiration name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -585,7 +585,7 @@ module GwfEvtInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-ghbgidm.f90
+++ b/src/Idm/gwf-ghbgidm.f90
@@ -50,7 +50,7 @@ module GwfGhbgInputModule
     '', & ! shape
     'use array-based grid input', & ! longname
     .true., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -69,7 +69,7 @@ module GwfGhbgInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -88,7 +88,7 @@ module GwfGhbgInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -107,7 +107,7 @@ module GwfGhbgInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -126,7 +126,7 @@ module GwfGhbgInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -145,7 +145,7 @@ module GwfGhbgInputModule
     '', & ! shape
     'save GHBG flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -164,7 +164,7 @@ module GwfGhbgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -183,7 +183,7 @@ module GwfGhbgInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -202,7 +202,7 @@ module GwfGhbgInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -221,7 +221,7 @@ module GwfGhbgInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -240,7 +240,7 @@ module GwfGhbgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -259,7 +259,7 @@ module GwfGhbgInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -278,7 +278,7 @@ module GwfGhbgInputModule
     '', & ! shape
     'maximum number of general-head boundaries in any stress period', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -297,7 +297,7 @@ module GwfGhbgInputModule
     'NODES', & ! shape
     'boundary head', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -316,7 +316,7 @@ module GwfGhbgInputModule
     'NODES', & ! shape
     'boundary conductance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -335,7 +335,7 @@ module GwfGhbgInputModule
     'NAUX NODES', & ! shape
     'general-head boundary auxiliary variable iaux', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -377,7 +377,7 @@ module GwfGhbgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-ghbidm.f90
+++ b/src/Idm/gwf-ghbidm.f90
@@ -54,7 +54,7 @@ module GwfGhbInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -73,7 +73,7 @@ module GwfGhbInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -92,7 +92,7 @@ module GwfGhbInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -111,7 +111,7 @@ module GwfGhbInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -130,7 +130,7 @@ module GwfGhbInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -149,7 +149,7 @@ module GwfGhbInputModule
     '', & ! shape
     'save CHD flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -168,7 +168,7 @@ module GwfGhbInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -187,7 +187,7 @@ module GwfGhbInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -206,7 +206,7 @@ module GwfGhbInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -225,7 +225,7 @@ module GwfGhbInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -244,7 +244,7 @@ module GwfGhbInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -263,7 +263,7 @@ module GwfGhbInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -282,7 +282,7 @@ module GwfGhbInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -301,7 +301,7 @@ module GwfGhbInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -320,7 +320,7 @@ module GwfGhbInputModule
     '', & ! shape
     'maximum number of general-head boundaries', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -339,7 +339,7 @@ module GwfGhbInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -358,7 +358,7 @@ module GwfGhbInputModule
     '', & ! shape
     'boundary head', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -377,7 +377,7 @@ module GwfGhbInputModule
     '', & ! shape
     'boundary conductance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -396,7 +396,7 @@ module GwfGhbInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -415,7 +415,7 @@ module GwfGhbInputModule
     '', & ! shape
     'general-head boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -459,7 +459,7 @@ module GwfGhbInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-hfbidm.f90
+++ b/src/Idm/gwf-hfbidm.f90
@@ -39,7 +39,7 @@ module GwfHfbInputModule
     '', & ! shape
     'model print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -58,7 +58,7 @@ module GwfHfbInputModule
     '', & ! shape
     'maximum number of barriers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -77,7 +77,7 @@ module GwfHfbInputModule
     'NCELLDIM', & ! shape
     'first cell adjacent to barrier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -96,7 +96,7 @@ module GwfHfbInputModule
     'NCELLDIM', & ! shape
     'second cell adjacent to barrier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -115,7 +115,7 @@ module GwfHfbInputModule
     '', & ! shape
     'barrier hydraulic characteristic', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -144,7 +144,7 @@ module GwfHfbInputModule
     'MAXHFB', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-icidm.f90
+++ b/src/Idm/gwf-icidm.f90
@@ -37,7 +37,7 @@ module GwfIcInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -56,7 +56,7 @@ module GwfIcInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -75,7 +75,7 @@ module GwfIcInputModule
     'NODES', & ! shape
     'starting head', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -104,7 +104,7 @@ module GwfIcInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-namidm.f90
+++ b/src/Idm/gwf-namidm.f90
@@ -55,7 +55,7 @@ module GwfNamInputModule
     '', & ! shape
     'name of listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -74,7 +74,7 @@ module GwfNamInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -93,7 +93,7 @@ module GwfNamInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -112,7 +112,7 @@ module GwfNamInputModule
     '', & ! shape
     'save flows for all packages to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -131,7 +131,7 @@ module GwfNamInputModule
     '', & ! shape
     'newton keyword and options', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -150,7 +150,7 @@ module GwfNamInputModule
     '', & ! shape
     'keyword to activate Newton-Raphson formulation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -169,7 +169,7 @@ module GwfNamInputModule
     '', & ! shape
     'keyword to activate Newton-Raphson UNDER_RELAXATION option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -188,7 +188,7 @@ module GwfNamInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -207,7 +207,7 @@ module GwfNamInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -226,7 +226,7 @@ module GwfNamInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -245,7 +245,7 @@ module GwfNamInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -264,7 +264,7 @@ module GwfNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -283,7 +283,7 @@ module GwfNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -302,7 +302,7 @@ module GwfNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -321,7 +321,7 @@ module GwfNamInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -340,7 +340,7 @@ module GwfNamInputModule
     '', & ! shape
     'netcdf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -359,7 +359,7 @@ module GwfNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -378,7 +378,7 @@ module GwfNamInputModule
     '', & ! shape
     'netcdf input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -397,7 +397,7 @@ module GwfNamInputModule
     '', & ! shape
     'package type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -416,7 +416,7 @@ module GwfNamInputModule
     '', & ! shape
     'file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -435,7 +435,7 @@ module GwfNamInputModule
     '', & ! shape
     'user name for package', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -480,7 +480,7 @@ module GwfNamInputModule
     '', & ! shape
     'package list', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-npfidm.f90
+++ b/src/Idm/gwf-npfidm.f90
@@ -70,7 +70,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to save NPF flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -89,7 +89,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to print NPF flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -108,7 +108,7 @@ module GwfNpfInputModule
     '', & ! shape
     'conductance weighting option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -127,7 +127,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to activate THICKSTRT option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -146,7 +146,7 @@ module GwfNpfInputModule
     '', & ! shape
     'vertical conductance options', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -165,7 +165,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to activate VARIABLECV option', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -184,7 +184,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to activate DEWATERED option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -203,7 +203,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to activate PERCHED option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -222,7 +222,7 @@ module GwfNpfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -241,7 +241,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to activate rewetting', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -260,7 +260,7 @@ module GwfNpfInputModule
     '', & ! shape
     'wetting factor to use for rewetting', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -279,7 +279,7 @@ module GwfNpfInputModule
     '', & ! shape
     'interval to use for rewetting', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -298,7 +298,7 @@ module GwfNpfInputModule
     '', & ! shape
     'flag to determine wetting equation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -317,7 +317,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to activate XT3D', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -336,7 +336,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to activate XT3D', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -355,7 +355,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to XT3D on right hand side', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -374,7 +374,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to save specific discharge', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -393,7 +393,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to save saturation', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -412,7 +412,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to indicate that specified K22 is a ratio', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -431,7 +431,7 @@ module GwfNpfInputModule
     '', & ! shape
     'keyword to indicate that specified K33 is a ratio', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -450,7 +450,7 @@ module GwfNpfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -469,7 +469,7 @@ module GwfNpfInputModule
     '', & ! shape
     'tvk keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -488,7 +488,7 @@ module GwfNpfInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -507,7 +507,7 @@ module GwfNpfInputModule
     '', & ! shape
     'file name of TVK information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -526,7 +526,7 @@ module GwfNpfInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -545,7 +545,7 @@ module GwfNpfInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -564,7 +564,7 @@ module GwfNpfInputModule
     '', & ! shape
     'turn off Newton for unconfined cells', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -583,7 +583,7 @@ module GwfNpfInputModule
     '', & ! shape
     'set saturation omega value', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -602,7 +602,7 @@ module GwfNpfInputModule
     'NODES', & ! shape
     'confined or convertible indicator', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -621,7 +621,7 @@ module GwfNpfInputModule
     'NODES', & ! shape
     'hydraulic conductivity (L/T)', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -640,7 +640,7 @@ module GwfNpfInputModule
     'NODES', & ! shape
     'hydraulic conductivity of second ellipsoid axis', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -659,7 +659,7 @@ module GwfNpfInputModule
     'NODES', & ! shape
     'hydraulic conductivity of third ellipsoid axis (L/T)', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -678,7 +678,7 @@ module GwfNpfInputModule
     'NODES', & ! shape
     'first anisotropy rotation angle (degrees)', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -697,7 +697,7 @@ module GwfNpfInputModule
     'NODES', & ! shape
     'second anisotropy rotation angle (degrees)', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -716,7 +716,7 @@ module GwfNpfInputModule
     'NODES', & ! shape
     'third anisotropy rotation angle (degrees)', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -735,7 +735,7 @@ module GwfNpfInputModule
     'NODES', & ! shape
     'wetdry threshold and factor', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -797,7 +797,7 @@ module GwfNpfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-rchaidm.f90
+++ b/src/Idm/gwf-rchaidm.f90
@@ -52,7 +52,7 @@ module GwfRchaInputModule
     '', & ! shape
     'use array-based input', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module GwfRchaInputModule
     '', & ! shape
     'if cell is dry do not apply recharge to underlying cell', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module GwfRchaInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module GwfRchaInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module GwfRchaInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module GwfRchaInputModule
     '', & ! shape
     'print recharge rates to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module GwfRchaInputModule
     '', & ! shape
     'save CHD flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module GwfRchaInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module GwfRchaInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module GwfRchaInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module GwfRchaInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module GwfRchaInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module GwfRchaInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module GwfRchaInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module GwfRchaInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module GwfRchaInputModule
     'NCPL', & ! shape
     'layer number for recharge', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module GwfRchaInputModule
     'NCPL', & ! shape
     'recharge rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module GwfRchaInputModule
     'NAUX NCPL', & ! shape
     'recharge auxiliary variable iaux', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -419,7 +419,7 @@ module GwfRchaInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-rchidm.f90
+++ b/src/Idm/gwf-rchidm.f90
@@ -53,7 +53,7 @@ module GwfRchInputModule
     '', & ! shape
     'if cell is dry do not apply recharge to underlying cell', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -72,7 +72,7 @@ module GwfRchInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -91,7 +91,7 @@ module GwfRchInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -110,7 +110,7 @@ module GwfRchInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -129,7 +129,7 @@ module GwfRchInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -148,7 +148,7 @@ module GwfRchInputModule
     '', & ! shape
     'print recharge rates to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -167,7 +167,7 @@ module GwfRchInputModule
     '', & ! shape
     'save recharge to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -186,7 +186,7 @@ module GwfRchInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -205,7 +205,7 @@ module GwfRchInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -224,7 +224,7 @@ module GwfRchInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -243,7 +243,7 @@ module GwfRchInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -262,7 +262,7 @@ module GwfRchInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -281,7 +281,7 @@ module GwfRchInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -300,7 +300,7 @@ module GwfRchInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -319,7 +319,7 @@ module GwfRchInputModule
     '', & ! shape
     'maximum number of recharge cells', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -338,7 +338,7 @@ module GwfRchInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -357,7 +357,7 @@ module GwfRchInputModule
     '', & ! shape
     'recharge rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -376,7 +376,7 @@ module GwfRchInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -395,7 +395,7 @@ module GwfRchInputModule
     '', & ! shape
     'recharge name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -438,7 +438,7 @@ module GwfRchInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-rivgidm.f90
+++ b/src/Idm/gwf-rivgidm.f90
@@ -51,7 +51,7 @@ module GwfRivgInputModule
     '', & ! shape
     'use array-based grid input', & ! longname
     .true., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -70,7 +70,7 @@ module GwfRivgInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -89,7 +89,7 @@ module GwfRivgInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -108,7 +108,7 @@ module GwfRivgInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -127,7 +127,7 @@ module GwfRivgInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -146,7 +146,7 @@ module GwfRivgInputModule
     '', & ! shape
     'save RIV flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -165,7 +165,7 @@ module GwfRivgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -184,7 +184,7 @@ module GwfRivgInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -203,7 +203,7 @@ module GwfRivgInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -222,7 +222,7 @@ module GwfRivgInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -241,7 +241,7 @@ module GwfRivgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -260,7 +260,7 @@ module GwfRivgInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -279,7 +279,7 @@ module GwfRivgInputModule
     '', & ! shape
     'maximum number of river cells in any stress period', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -298,7 +298,7 @@ module GwfRivgInputModule
     'NODES', & ! shape
     'river stage', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -317,7 +317,7 @@ module GwfRivgInputModule
     'NODES', & ! shape
     'river conductnace', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -336,7 +336,7 @@ module GwfRivgInputModule
     'NODES', & ! shape
     'river bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -355,7 +355,7 @@ module GwfRivgInputModule
     'NAUX NODES', & ! shape
     'river auxiliary variable iaux', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -398,7 +398,7 @@ module GwfRivgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-rividm.f90
+++ b/src/Idm/gwf-rividm.f90
@@ -55,7 +55,7 @@ module GwfRivInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -74,7 +74,7 @@ module GwfRivInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -93,7 +93,7 @@ module GwfRivInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -112,7 +112,7 @@ module GwfRivInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -131,7 +131,7 @@ module GwfRivInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -150,7 +150,7 @@ module GwfRivInputModule
     '', & ! shape
     'save CHD flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -169,7 +169,7 @@ module GwfRivInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -188,7 +188,7 @@ module GwfRivInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -207,7 +207,7 @@ module GwfRivInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -226,7 +226,7 @@ module GwfRivInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -245,7 +245,7 @@ module GwfRivInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -264,7 +264,7 @@ module GwfRivInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -283,7 +283,7 @@ module GwfRivInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -302,7 +302,7 @@ module GwfRivInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -321,7 +321,7 @@ module GwfRivInputModule
     '', & ! shape
     'maximum number of rivers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -340,7 +340,7 @@ module GwfRivInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -359,7 +359,7 @@ module GwfRivInputModule
     '', & ! shape
     'river stage', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -378,7 +378,7 @@ module GwfRivInputModule
     '', & ! shape
     'river conductance', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -397,7 +397,7 @@ module GwfRivInputModule
     '', & ! shape
     'river bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -416,7 +416,7 @@ module GwfRivInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -435,7 +435,7 @@ module GwfRivInputModule
     '', & ! shape
     'drain name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -480,7 +480,7 @@ module GwfRivInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-stoidm.f90
+++ b/src/Idm/gwf-stoidm.f90
@@ -50,7 +50,7 @@ module GwfStoInputModule
     '', & ! shape
     'keyword to save NPF flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -69,7 +69,7 @@ module GwfStoInputModule
     '', & ! shape
     'keyword to indicate SS is read as storage coefficient', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -89,7 +89,7 @@ module GwfStoInputModule
     'keyword to indicate specific storage only applied under confined&
      & conditions', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -108,7 +108,7 @@ module GwfStoInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -127,7 +127,7 @@ module GwfStoInputModule
     '', & ! shape
     'tvs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -146,7 +146,7 @@ module GwfStoInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -165,7 +165,7 @@ module GwfStoInputModule
     '', & ! shape
     'file name of TVS information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -184,7 +184,7 @@ module GwfStoInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -203,7 +203,7 @@ module GwfStoInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -222,7 +222,7 @@ module GwfStoInputModule
     '', & ! shape
     'development option for original specific storage', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -241,7 +241,7 @@ module GwfStoInputModule
     '', & ! shape
     'development option flag for old storage formulation', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -260,7 +260,7 @@ module GwfStoInputModule
     'NODES', & ! shape
     'convertible indicator', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -279,7 +279,7 @@ module GwfStoInputModule
     'NODES', & ! shape
     'specific storage', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -298,7 +298,7 @@ module GwfStoInputModule
     'NODES', & ! shape
     'specific yield', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -317,7 +317,7 @@ module GwfStoInputModule
     '', & ! shape
     'steady state indicator', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -336,7 +336,7 @@ module GwfStoInputModule
     '', & ! shape
     'transient indicator', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -378,7 +378,7 @@ module GwfStoInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-vscidm.f90
+++ b/src/Idm/gwf-vscidm.f90
@@ -50,7 +50,7 @@ module GwfVscInputModule
     '', & ! shape
     'reference viscosity', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -69,7 +69,7 @@ module GwfVscInputModule
     '', & ! shape
     'auxspeciesname that corresponds to temperature', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -88,7 +88,7 @@ module GwfVscInputModule
     '', & ! shape
     'keyword to specify viscosity formulation for the temperature species', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -107,7 +107,7 @@ module GwfVscInputModule
     '', & ! shape
     'coefficient used in nonlinear viscosity function', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -126,7 +126,7 @@ module GwfVscInputModule
     '', & ! shape
     'coefficient used in nonlinear viscosity function', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -145,7 +145,7 @@ module GwfVscInputModule
     '', & ! shape
     'coefficient used in nonlinear viscosity function', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -164,7 +164,7 @@ module GwfVscInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -183,7 +183,7 @@ module GwfVscInputModule
     '', & ! shape
     'viscosity keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -202,7 +202,7 @@ module GwfVscInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -221,7 +221,7 @@ module GwfVscInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -240,7 +240,7 @@ module GwfVscInputModule
     '', & ! shape
     'number of species used in viscosity equation of state', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -259,7 +259,7 @@ module GwfVscInputModule
     '', & ! shape
     'species number for this entry', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module GwfVscInputModule
      & viscosity and temperature or between viscosity and concentration,&
      & depending on the type of species entered on each line.', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module GwfVscInputModule
     '', & ! shape
     'reference temperature value or reference concentration value', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module GwfVscInputModule
     '', & ! shape
     'modelname', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module GwfVscInputModule
     '', & ! shape
     'auxspeciesname', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -377,7 +377,7 @@ module GwfVscInputModule
     'NVISCSPECIES', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-welgidm.f90
+++ b/src/Idm/gwf-welgidm.f90
@@ -54,7 +54,7 @@ module GwfWelgInputModule
     '', & ! shape
     'use array-based grid input', & ! longname
     .true., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -73,7 +73,7 @@ module GwfWelgInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -92,7 +92,7 @@ module GwfWelgInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -111,7 +111,7 @@ module GwfWelgInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -130,7 +130,7 @@ module GwfWelgInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -149,7 +149,7 @@ module GwfWelgInputModule
     '', & ! shape
     'save well flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -168,7 +168,7 @@ module GwfWelgInputModule
     '', & ! shape
     'cell fractional thickness for reduced pumping', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -187,7 +187,7 @@ module GwfWelgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -206,7 +206,7 @@ module GwfWelgInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -225,7 +225,7 @@ module GwfWelgInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -244,7 +244,7 @@ module GwfWelgInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -263,7 +263,7 @@ module GwfWelgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -282,7 +282,7 @@ module GwfWelgInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -301,7 +301,7 @@ module GwfWelgInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -320,7 +320,7 @@ module GwfWelgInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -339,7 +339,7 @@ module GwfWelgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -358,7 +358,7 @@ module GwfWelgInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -377,7 +377,7 @@ module GwfWelgInputModule
     '', & ! shape
     'maximum number of wells in any stress period', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -396,7 +396,7 @@ module GwfWelgInputModule
     'NODES', & ! shape
     'well rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -415,7 +415,7 @@ module GwfWelgInputModule
     'NAUX NODES', & ! shape
     'well auxiliary variable iaux', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -461,7 +461,7 @@ module GwfWelgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwf-welidm.f90
+++ b/src/Idm/gwf-welidm.f90
@@ -58,7 +58,7 @@ module GwfWelInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -77,7 +77,7 @@ module GwfWelInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -96,7 +96,7 @@ module GwfWelInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -115,7 +115,7 @@ module GwfWelInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -134,7 +134,7 @@ module GwfWelInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -153,7 +153,7 @@ module GwfWelInputModule
     '', & ! shape
     'save well flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -172,7 +172,7 @@ module GwfWelInputModule
     '', & ! shape
     'cell fractional thickness for reduced pumping', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -191,7 +191,7 @@ module GwfWelInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -210,7 +210,7 @@ module GwfWelInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -229,7 +229,7 @@ module GwfWelInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -248,7 +248,7 @@ module GwfWelInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -267,7 +267,7 @@ module GwfWelInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -286,7 +286,7 @@ module GwfWelInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -305,7 +305,7 @@ module GwfWelInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -324,7 +324,7 @@ module GwfWelInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -343,7 +343,7 @@ module GwfWelInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -362,7 +362,7 @@ module GwfWelInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -381,7 +381,7 @@ module GwfWelInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -400,7 +400,7 @@ module GwfWelInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -419,7 +419,7 @@ module GwfWelInputModule
     '', & ! shape
     'maximum number of wells', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -438,7 +438,7 @@ module GwfWelInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -457,7 +457,7 @@ module GwfWelInputModule
     '', & ! shape
     'well rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -476,7 +476,7 @@ module GwfWelInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -495,7 +495,7 @@ module GwfWelInputModule
     '', & ! shape
     'well name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -543,7 +543,7 @@ module GwfWelInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-advidm.f90
+++ b/src/Idm/gwt-advidm.f90
@@ -36,7 +36,7 @@ module GwtAdvInputModule
     '', & ! shape
     'advective scheme', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -55,7 +55,7 @@ module GwtAdvInputModule
     '', & ! shape
     'fractional cell distance used for time step calculation', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -83,7 +83,7 @@ module GwtAdvInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-apiidm.f90
+++ b/src/Idm/gwt-apiidm.f90
@@ -44,7 +44,7 @@ module GwtApiInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -63,7 +63,7 @@ module GwtApiInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -82,7 +82,7 @@ module GwtApiInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -101,7 +101,7 @@ module GwtApiInputModule
     '', & ! shape
     'save api flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -120,7 +120,7 @@ module GwtApiInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -139,7 +139,7 @@ module GwtApiInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -158,7 +158,7 @@ module GwtApiInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -177,7 +177,7 @@ module GwtApiInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -196,7 +196,7 @@ module GwtApiInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -215,7 +215,7 @@ module GwtApiInputModule
     '', & ! shape
     'maximum number of user-defined api boundaries', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -251,7 +251,7 @@ module GwtApiInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-cncidm.f90
+++ b/src/Idm/gwt-cncidm.f90
@@ -52,7 +52,7 @@ module GwtCncInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module GwtCncInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module GwtCncInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module GwtCncInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module GwtCncInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module GwtCncInputModule
     '', & ! shape
     'save constant concentration flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module GwtCncInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module GwtCncInputModule
     '', & ! shape
     'time series keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module GwtCncInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module GwtCncInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module GwtCncInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module GwtCncInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module GwtCncInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module GwtCncInputModule
     '', & ! shape
     'maximum number of constant concentrations', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module GwtCncInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module GwtCncInputModule
     '', & ! shape
     'constant concentration value', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module GwtCncInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module GwtCncInputModule
     '', & ! shape
     'constant concentration name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module GwtCncInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-disidm.f90
+++ b/src/Idm/gwt-disidm.f90
@@ -58,7 +58,7 @@ module GwtDisInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -77,7 +77,7 @@ module GwtDisInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -96,7 +96,7 @@ module GwtDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -115,7 +115,7 @@ module GwtDisInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -134,7 +134,7 @@ module GwtDisInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -153,7 +153,7 @@ module GwtDisInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -172,7 +172,7 @@ module GwtDisInputModule
     '', & ! shape
     'x-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -191,7 +191,7 @@ module GwtDisInputModule
     '', & ! shape
     'y-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -210,7 +210,7 @@ module GwtDisInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -229,7 +229,7 @@ module GwtDisInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -248,7 +248,7 @@ module GwtDisInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -267,7 +267,7 @@ module GwtDisInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -286,7 +286,7 @@ module GwtDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -305,7 +305,7 @@ module GwtDisInputModule
     '', & ! shape
     'ncf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -324,7 +324,7 @@ module GwtDisInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -343,7 +343,7 @@ module GwtDisInputModule
     '', & ! shape
     'file name of NCF information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -362,7 +362,7 @@ module GwtDisInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -381,7 +381,7 @@ module GwtDisInputModule
     '', & ! shape
     'number of rows', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -400,7 +400,7 @@ module GwtDisInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -419,7 +419,7 @@ module GwtDisInputModule
     'NCOL', & ! shape
     'spacing along a row', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -438,7 +438,7 @@ module GwtDisInputModule
     'NROW', & ! shape
     'spacing along a column', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -457,7 +457,7 @@ module GwtDisInputModule
     'NCOL NROW', & ! shape
     'cell top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -476,7 +476,7 @@ module GwtDisInputModule
     'NCOL NROW NLAY', & ! shape
     'cell bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -495,7 +495,7 @@ module GwtDisInputModule
     'NCOL NROW NLAY', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -545,7 +545,7 @@ module GwtDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-disuidm.f90
+++ b/src/Idm/gwt-disuidm.f90
@@ -67,7 +67,7 @@ module GwtDisuInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -86,7 +86,7 @@ module GwtDisuInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -105,7 +105,7 @@ module GwtDisuInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -124,7 +124,7 @@ module GwtDisuInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -143,7 +143,7 @@ module GwtDisuInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -162,7 +162,7 @@ module GwtDisuInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -181,7 +181,7 @@ module GwtDisuInputModule
     '', & ! shape
     'x-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -200,7 +200,7 @@ module GwtDisuInputModule
     '', & ! shape
     'y-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -219,7 +219,7 @@ module GwtDisuInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -238,7 +238,7 @@ module GwtDisuInputModule
     '', & ! shape
     'vertical length dimension for top and bottom checking', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -257,7 +257,7 @@ module GwtDisuInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -276,7 +276,7 @@ module GwtDisuInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -295,7 +295,7 @@ module GwtDisuInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -314,7 +314,7 @@ module GwtDisuInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -333,7 +333,7 @@ module GwtDisuInputModule
     '', & ! shape
     'number of vertices', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -352,7 +352,7 @@ module GwtDisuInputModule
     'NODES', & ! shape
     'cell top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -371,7 +371,7 @@ module GwtDisuInputModule
     'NODES', & ! shape
     'cell bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -390,7 +390,7 @@ module GwtDisuInputModule
     'NODES', & ! shape
     'cell surface area', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -409,7 +409,7 @@ module GwtDisuInputModule
     'NODES', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -428,7 +428,7 @@ module GwtDisuInputModule
     'NODES', & ! shape
     'number of cell connections', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -447,7 +447,7 @@ module GwtDisuInputModule
     'NJA', & ! shape
     'grid connectivity', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -466,7 +466,7 @@ module GwtDisuInputModule
     'NJA', & ! shape
     'connection type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -485,7 +485,7 @@ module GwtDisuInputModule
     'NJA', & ! shape
     'connection lengths', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -504,7 +504,7 @@ module GwtDisuInputModule
     'NJA', & ! shape
     'connection lengths', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -523,7 +523,7 @@ module GwtDisuInputModule
     'NJA', & ! shape
     'angle of face normal to connection', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -542,7 +542,7 @@ module GwtDisuInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -561,7 +561,7 @@ module GwtDisuInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -580,7 +580,7 @@ module GwtDisuInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -599,7 +599,7 @@ module GwtDisuInputModule
     '', & ! shape
     'cell2d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -618,7 +618,7 @@ module GwtDisuInputModule
     '', & ! shape
     'x-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -637,7 +637,7 @@ module GwtDisuInputModule
     '', & ! shape
     'y-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -656,7 +656,7 @@ module GwtDisuInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -675,7 +675,7 @@ module GwtDisuInputModule
     'NCVERT', & ! shape
     'array of vertex numbers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -732,7 +732,7 @@ module GwtDisuInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -751,7 +751,7 @@ module GwtDisuInputModule
     'NODES', & ! shape
     'cell2d data', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-disvidm.f90
+++ b/src/Idm/gwt-disvidm.f90
@@ -64,7 +64,7 @@ module GwtDisvInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -83,7 +83,7 @@ module GwtDisvInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -102,7 +102,7 @@ module GwtDisvInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -121,7 +121,7 @@ module GwtDisvInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -140,7 +140,7 @@ module GwtDisvInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -159,7 +159,7 @@ module GwtDisvInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -178,7 +178,7 @@ module GwtDisvInputModule
     '', & ! shape
     'x-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -197,7 +197,7 @@ module GwtDisvInputModule
     '', & ! shape
     'y-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -216,7 +216,7 @@ module GwtDisvInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -235,7 +235,7 @@ module GwtDisvInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -254,7 +254,7 @@ module GwtDisvInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -273,7 +273,7 @@ module GwtDisvInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -292,7 +292,7 @@ module GwtDisvInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -311,7 +311,7 @@ module GwtDisvInputModule
     '', & ! shape
     'ncf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -330,7 +330,7 @@ module GwtDisvInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -349,7 +349,7 @@ module GwtDisvInputModule
     '', & ! shape
     'file name of NCF information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -368,7 +368,7 @@ module GwtDisvInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -387,7 +387,7 @@ module GwtDisvInputModule
     '', & ! shape
     'number of cells per layer', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -406,7 +406,7 @@ module GwtDisvInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -425,7 +425,7 @@ module GwtDisvInputModule
     'NCPL', & ! shape
     'model top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -444,7 +444,7 @@ module GwtDisvInputModule
     'NCPL NLAY', & ! shape
     'model bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -463,7 +463,7 @@ module GwtDisvInputModule
     'NCPL NLAY', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -482,7 +482,7 @@ module GwtDisvInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -501,7 +501,7 @@ module GwtDisvInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -520,7 +520,7 @@ module GwtDisvInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -539,7 +539,7 @@ module GwtDisvInputModule
     '', & ! shape
     'cell2d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -558,7 +558,7 @@ module GwtDisvInputModule
     '', & ! shape
     'x-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -577,7 +577,7 @@ module GwtDisvInputModule
     '', & ! shape
     'y-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -596,7 +596,7 @@ module GwtDisvInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -615,7 +615,7 @@ module GwtDisvInputModule
     'NCVERT', & ! shape
     'array of vertex numbers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -669,7 +669,7 @@ module GwtDisvInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -688,7 +688,7 @@ module GwtDisvInputModule
     'NCPL', & ! shape
     'cell2d data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-dspidm.f90
+++ b/src/Idm/gwt-dspidm.f90
@@ -44,7 +44,7 @@ module GwtDspInputModule
     '', & ! shape
     'deactivate xt3d', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -63,7 +63,7 @@ module GwtDspInputModule
     '', & ! shape
     'xt3d on right-hand side', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -82,7 +82,7 @@ module GwtDspInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -101,7 +101,7 @@ module GwtDspInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -120,7 +120,7 @@ module GwtDspInputModule
     'NODES', & ! shape
     'effective molecular diffusion coefficient', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -139,7 +139,7 @@ module GwtDspInputModule
     'NODES', & ! shape
     'longitudinal dispersivity in horizontal direction', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -158,7 +158,7 @@ module GwtDspInputModule
     'NODES', & ! shape
     'longitudinal dispersivity in vertical direction', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -177,7 +177,7 @@ module GwtDspInputModule
     'NODES', & ! shape
     'transverse dispersivity in horizontal direction', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -196,7 +196,7 @@ module GwtDspInputModule
     'NODES', & ! shape
     'transverse dispersivity in horizontal direction', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -215,7 +215,7 @@ module GwtDspInputModule
     'NODES', & ! shape
     'transverse dispersivity when flow is in vertical direction', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -251,7 +251,7 @@ module GwtDspInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-fmiidm.f90
+++ b/src/Idm/gwt-fmiidm.f90
@@ -39,7 +39,7 @@ module GwtFmiInputModule
     '', & ! shape
     'save calculated flow imbalance correction to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -58,7 +58,7 @@ module GwtFmiInputModule
     '', & ! shape
     'correct for flow imbalance', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -77,7 +77,7 @@ module GwtFmiInputModule
     '', & ! shape
     'flow type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -96,7 +96,7 @@ module GwtFmiInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -115,7 +115,7 @@ module GwtFmiInputModule
     '', & ! shape
     'file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -144,7 +144,7 @@ module GwtFmiInputModule
     '', & ! shape
     'flowtype list', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-icidm.f90
+++ b/src/Idm/gwt-icidm.f90
@@ -37,7 +37,7 @@ module GwtIcInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -56,7 +56,7 @@ module GwtIcInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -75,7 +75,7 @@ module GwtIcInputModule
     'NODES', & ! shape
     'starting concentration', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -104,7 +104,7 @@ module GwtIcInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-istidm.f90
+++ b/src/Idm/gwt-istidm.f90
@@ -69,7 +69,7 @@ module GwtIstInputModule
     '', & ! shape
     'save calculated flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -88,7 +88,7 @@ module GwtIstInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -107,7 +107,7 @@ module GwtIstInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -126,7 +126,7 @@ module GwtIstInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -145,7 +145,7 @@ module GwtIstInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -164,7 +164,7 @@ module GwtIstInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -183,7 +183,7 @@ module GwtIstInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -202,7 +202,7 @@ module GwtIstInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -221,7 +221,7 @@ module GwtIstInputModule
     '', & ! shape
     'activate sorption', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -240,7 +240,7 @@ module GwtIstInputModule
     '', & ! shape
     'activate first-order decay', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -259,7 +259,7 @@ module GwtIstInputModule
     '', & ! shape
     'activate zero-order decay', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -278,7 +278,7 @@ module GwtIstInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -297,7 +297,7 @@ module GwtIstInputModule
     '', & ! shape
     'cim keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -316,7 +316,7 @@ module GwtIstInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -335,7 +335,7 @@ module GwtIstInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -354,7 +354,7 @@ module GwtIstInputModule
     '', & ! shape
     'keyword to indicate that a print format follows', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -373,7 +373,7 @@ module GwtIstInputModule
     '', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -392,7 +392,7 @@ module GwtIstInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -411,7 +411,7 @@ module GwtIstInputModule
     '', & ! shape
     'width for each number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -430,7 +430,7 @@ module GwtIstInputModule
     '', & ! shape
     'number of digits', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -449,7 +449,7 @@ module GwtIstInputModule
     '', & ! shape
     'write format', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -468,7 +468,7 @@ module GwtIstInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -487,7 +487,7 @@ module GwtIstInputModule
     '', & ! shape
     'sorbate keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -506,7 +506,7 @@ module GwtIstInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -525,7 +525,7 @@ module GwtIstInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -544,7 +544,7 @@ module GwtIstInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -563,7 +563,7 @@ module GwtIstInputModule
     'NODES', & ! shape
     'porosity of the immobile domain', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -582,7 +582,7 @@ module GwtIstInputModule
     'NODES', & ! shape
     'volume fraction of this immobile domain', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -601,7 +601,7 @@ module GwtIstInputModule
     'NODES', & ! shape
     'mass transfer rate coefficient between the mobile and immobile domains', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -620,7 +620,7 @@ module GwtIstInputModule
     'NODES', & ! shape
     'initial concentration of the immobile domain', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -639,7 +639,7 @@ module GwtIstInputModule
     'NODES', & ! shape
     'first rate coefficient', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -658,7 +658,7 @@ module GwtIstInputModule
     'NODES', & ! shape
     'second rate coefficient', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -677,7 +677,7 @@ module GwtIstInputModule
     'NODES', & ! shape
     'bulk density', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -696,7 +696,7 @@ module GwtIstInputModule
     'NODES', & ! shape
     'distribution coefficient', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -715,7 +715,7 @@ module GwtIstInputModule
     'NODES', & ! shape
     'second sorption parameter', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -776,7 +776,7 @@ module GwtIstInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-mstidm.f90
+++ b/src/Idm/gwt-mstidm.f90
@@ -50,7 +50,7 @@ module GwtMstInputModule
     '', & ! shape
     'save calculated flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -69,7 +69,7 @@ module GwtMstInputModule
     '', & ! shape
     'activate first-order decay', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -88,7 +88,7 @@ module GwtMstInputModule
     '', & ! shape
     'activate zero-order decay', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -107,7 +107,7 @@ module GwtMstInputModule
     '', & ! shape
     'activate sorption', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -126,7 +126,7 @@ module GwtMstInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -145,7 +145,7 @@ module GwtMstInputModule
     '', & ! shape
     'sorbate keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -164,7 +164,7 @@ module GwtMstInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -183,7 +183,7 @@ module GwtMstInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -202,7 +202,7 @@ module GwtMstInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -221,7 +221,7 @@ module GwtMstInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -240,7 +240,7 @@ module GwtMstInputModule
     'NODES', & ! shape
     'porosity', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -259,7 +259,7 @@ module GwtMstInputModule
     'NODES', & ! shape
     'aqueous phase decay rate coefficient', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -278,7 +278,7 @@ module GwtMstInputModule
     'NODES', & ! shape
     'sorbed phase decay rate coefficient', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -297,7 +297,7 @@ module GwtMstInputModule
     'NODES', & ! shape
     'bulk density', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -316,7 +316,7 @@ module GwtMstInputModule
     'NODES', & ! shape
     'distribution coefficient', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -335,7 +335,7 @@ module GwtMstInputModule
     'NODES', & ! shape
     'second sorption parameter', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -377,7 +377,7 @@ module GwtMstInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-namidm.f90
+++ b/src/Idm/gwt-namidm.f90
@@ -53,7 +53,7 @@ module GwtNamInputModule
     '', & ! shape
     'name of listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -72,7 +72,7 @@ module GwtNamInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -91,7 +91,7 @@ module GwtNamInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -110,7 +110,7 @@ module GwtNamInputModule
     '', & ! shape
     'save flows for all packages to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -129,7 +129,7 @@ module GwtNamInputModule
     '', & ! shape
     'flag to scale X and RHS', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -148,7 +148,7 @@ module GwtNamInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -167,7 +167,7 @@ module GwtNamInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -186,7 +186,7 @@ module GwtNamInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -205,7 +205,7 @@ module GwtNamInputModule
     '', & ! shape
     'budget keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -224,7 +224,7 @@ module GwtNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -243,7 +243,7 @@ module GwtNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -262,7 +262,7 @@ module GwtNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -281,7 +281,7 @@ module GwtNamInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -300,7 +300,7 @@ module GwtNamInputModule
     '', & ! shape
     'netcdf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -319,7 +319,7 @@ module GwtNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -338,7 +338,7 @@ module GwtNamInputModule
     '', & ! shape
     'netcdf input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -357,7 +357,7 @@ module GwtNamInputModule
     '', & ! shape
     'package type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -376,7 +376,7 @@ module GwtNamInputModule
     '', & ! shape
     'file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -395,7 +395,7 @@ module GwtNamInputModule
     '', & ! shape
     'user name for package', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -438,7 +438,7 @@ module GwtNamInputModule
     '', & ! shape
     'package list', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-srcidm.f90
+++ b/src/Idm/gwt-srcidm.f90
@@ -53,7 +53,7 @@ module GwtSrcInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -72,7 +72,7 @@ module GwtSrcInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -91,7 +91,7 @@ module GwtSrcInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -110,7 +110,7 @@ module GwtSrcInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -129,7 +129,7 @@ module GwtSrcInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -148,7 +148,7 @@ module GwtSrcInputModule
     '', & ! shape
     'save well flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -167,7 +167,7 @@ module GwtSrcInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -186,7 +186,7 @@ module GwtSrcInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -205,7 +205,7 @@ module GwtSrcInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -224,7 +224,7 @@ module GwtSrcInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -243,7 +243,7 @@ module GwtSrcInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -262,7 +262,7 @@ module GwtSrcInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -281,7 +281,7 @@ module GwtSrcInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -300,7 +300,7 @@ module GwtSrcInputModule
     '', & ! shape
     'apply source to highest saturated cell', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -319,7 +319,7 @@ module GwtSrcInputModule
     '', & ! shape
     'maximum number of sources', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -338,7 +338,7 @@ module GwtSrcInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -357,7 +357,7 @@ module GwtSrcInputModule
     '', & ! shape
     'mass source loading rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -376,7 +376,7 @@ module GwtSrcInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -395,7 +395,7 @@ module GwtSrcInputModule
     '', & ! shape
     'well name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -438,7 +438,7 @@ module GwtSrcInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/gwt-ssmidm.f90
+++ b/src/Idm/gwt-ssmidm.f90
@@ -44,7 +44,7 @@ module GwtSsmInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -63,7 +63,7 @@ module GwtSsmInputModule
     '', & ! shape
     'save calculated flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -82,7 +82,7 @@ module GwtSsmInputModule
     '', & ! shape
     'package name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -101,7 +101,7 @@ module GwtSsmInputModule
     '', & ! shape
     'source type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -120,7 +120,7 @@ module GwtSsmInputModule
     '', & ! shape
     'auxiliary variable name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -139,7 +139,7 @@ module GwtSsmInputModule
     '', & ! shape
     'package name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -158,7 +158,7 @@ module GwtSsmInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -177,7 +177,7 @@ module GwtSsmInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -196,7 +196,7 @@ module GwtSsmInputModule
     '', & ! shape
     'spc file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -215,7 +215,7 @@ module GwtSsmInputModule
     '', & ! shape
     'mixed keyword', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -249,7 +249,7 @@ module GwtSsmInputModule
     '', & ! shape
     'package list', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -268,7 +268,7 @@ module GwtSsmInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-cdbidm.f90
+++ b/src/Idm/olf-cdbidm.f90
@@ -49,7 +49,7 @@ module OlfCdbInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -68,7 +68,7 @@ module OlfCdbInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -87,7 +87,7 @@ module OlfCdbInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -106,7 +106,7 @@ module OlfCdbInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -125,7 +125,7 @@ module OlfCdbInputModule
     '', & ! shape
     'save flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -144,7 +144,7 @@ module OlfCdbInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -163,7 +163,7 @@ module OlfCdbInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -182,7 +182,7 @@ module OlfCdbInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -201,7 +201,7 @@ module OlfCdbInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -220,7 +220,7 @@ module OlfCdbInputModule
     '', & ! shape
     'maximum number of critical depth boundaries', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -239,7 +239,7 @@ module OlfCdbInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -258,7 +258,7 @@ module OlfCdbInputModule
     '', & ! shape
     'cross section identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -277,7 +277,7 @@ module OlfCdbInputModule
     '', & ! shape
     'width of the zero-depth gradient boundary', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -296,7 +296,7 @@ module OlfCdbInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -315,7 +315,7 @@ module OlfCdbInputModule
     '', & ! shape
     'zero-depth-gradient boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -354,7 +354,7 @@ module OlfCdbInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-chdidm.f90
+++ b/src/Idm/olf-chdidm.f90
@@ -52,7 +52,7 @@ module OlfChdInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module OlfChdInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module OlfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module OlfChdInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module OlfChdInputModule
     '', & ! shape
     'print CHD flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module OlfChdInputModule
     '', & ! shape
     'save CHD flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module OlfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module OlfChdInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module OlfChdInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module OlfChdInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module OlfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module OlfChdInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module OlfChdInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module OlfChdInputModule
     '', & ! shape
     'maximum number of constant heads', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module OlfChdInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module OlfChdInputModule
     '', & ! shape
     'head value assigned to constant head', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module OlfChdInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module OlfChdInputModule
     '', & ! shape
     'constant head boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module OlfChdInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-dfwidm.f90
+++ b/src/Idm/olf-dfwidm.f90
@@ -48,7 +48,7 @@ module OlfDfwInputModule
     '', & ! shape
     'use central in space weighting', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -67,7 +67,7 @@ module OlfDfwInputModule
     '', & ! shape
     'length conversion factor', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -86,7 +86,7 @@ module OlfDfwInputModule
     '', & ! shape
     'time conversion factor', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -105,7 +105,7 @@ module OlfDfwInputModule
     '', & ! shape
     'keyword to save DFW flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -124,7 +124,7 @@ module OlfDfwInputModule
     '', & ! shape
     'keyword to print DFW flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -143,7 +143,7 @@ module OlfDfwInputModule
     '', & ! shape
     'keyword to save velocity', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -162,7 +162,7 @@ module OlfDfwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -181,7 +181,7 @@ module OlfDfwInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -200,7 +200,7 @@ module OlfDfwInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -219,7 +219,7 @@ module OlfDfwInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -238,7 +238,7 @@ module OlfDfwInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -257,7 +257,7 @@ module OlfDfwInputModule
     '', & ! shape
     'use SWR conductance formulation', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -276,7 +276,7 @@ module OlfDfwInputModule
     'NODES', & ! shape
     'mannings roughness coefficient', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -295,7 +295,7 @@ module OlfDfwInputModule
     'NODES', & ! shape
     'cross section number', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -335,7 +335,7 @@ module OlfDfwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-dis2didm.f90
+++ b/src/Idm/olf-dis2didm.f90
@@ -51,7 +51,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -70,7 +70,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -89,7 +89,7 @@ module OlfDis2DInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -108,7 +108,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -127,7 +127,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -146,7 +146,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -165,7 +165,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'x-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -184,7 +184,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'y-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -203,7 +203,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -222,7 +222,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -241,7 +241,7 @@ module OlfDis2DInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -260,7 +260,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'number of rows', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -279,7 +279,7 @@ module OlfDis2DInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -298,7 +298,7 @@ module OlfDis2DInputModule
     'NCOL', & ! shape
     'spacing along a row', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -317,7 +317,7 @@ module OlfDis2DInputModule
     'NROW', & ! shape
     'spacing along a column', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -336,7 +336,7 @@ module OlfDis2DInputModule
     'NCOL NROW', & ! shape
     'cell bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -355,7 +355,7 @@ module OlfDis2DInputModule
     'NCOL NROW', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -398,7 +398,7 @@ module OlfDis2DInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-disv2didm.f90
+++ b/src/Idm/olf-disv2didm.f90
@@ -57,7 +57,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -76,7 +76,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -95,7 +95,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -114,7 +114,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -133,7 +133,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -152,7 +152,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -171,7 +171,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'x-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -190,7 +190,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'y-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -209,7 +209,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -228,7 +228,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -247,7 +247,7 @@ module OlfDisv2DInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -266,7 +266,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'number of cells per layer', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -285,7 +285,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -304,7 +304,7 @@ module OlfDisv2DInputModule
     'NODES', & ! shape
     'model bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -323,7 +323,7 @@ module OlfDisv2DInputModule
     'NODES', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -342,7 +342,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -361,7 +361,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -380,7 +380,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -399,7 +399,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'cell2d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -418,7 +418,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'x-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -437,7 +437,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'y-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -456,7 +456,7 @@ module OlfDisv2DInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -475,7 +475,7 @@ module OlfDisv2DInputModule
     'NCVERT', & ! shape
     'array of vertex numbers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -522,7 +522,7 @@ module OlfDisv2DInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -541,7 +541,7 @@ module OlfDisv2DInputModule
     'NODES', & ! shape
     'cell2d data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-evpidm.f90
+++ b/src/Idm/olf-evpidm.f90
@@ -52,7 +52,7 @@ module OlfEvpInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module OlfEvpInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module OlfEvpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module OlfEvpInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module OlfEvpInputModule
     '', & ! shape
     'print evaporation rates to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module OlfEvpInputModule
     '', & ! shape
     'save evaporation to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module OlfEvpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module OlfEvpInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module OlfEvpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module OlfEvpInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module OlfEvpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module OlfEvpInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module OlfEvpInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module OlfEvpInputModule
     '', & ! shape
     'maximum number of evaporation cells', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module OlfEvpInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module OlfEvpInputModule
     '', & ! shape
     'evaporation rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module OlfEvpInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module OlfEvpInputModule
     '', & ! shape
     'evaporation name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module OlfEvpInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-flwidm.f90
+++ b/src/Idm/olf-flwidm.f90
@@ -52,7 +52,7 @@ module OlfFlwInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module OlfFlwInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module OlfFlwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module OlfFlwInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module OlfFlwInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module OlfFlwInputModule
     '', & ! shape
     'save well flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module OlfFlwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module OlfFlwInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module OlfFlwInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module OlfFlwInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module OlfFlwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module OlfFlwInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module OlfFlwInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module OlfFlwInputModule
     '', & ! shape
     'maximum number of inflow', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module OlfFlwInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module OlfFlwInputModule
     '', & ! shape
     'flow rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module OlfFlwInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module OlfFlwInputModule
     '', & ! shape
     'inflow name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module OlfFlwInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-icidm.f90
+++ b/src/Idm/olf-icidm.f90
@@ -36,7 +36,7 @@ module OlfIcInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -55,7 +55,7 @@ module OlfIcInputModule
     'NODES', & ! shape
     'starting concentration', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -83,7 +83,7 @@ module OlfIcInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-namidm.f90
+++ b/src/Idm/olf-namidm.f90
@@ -44,7 +44,7 @@ module OlfNamInputModule
     '', & ! shape
     'name of listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -63,7 +63,7 @@ module OlfNamInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -82,7 +82,7 @@ module OlfNamInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -101,7 +101,7 @@ module OlfNamInputModule
     '', & ! shape
     'save flows for all packages to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -120,7 +120,7 @@ module OlfNamInputModule
     '', & ! shape
     'newton keyword and options', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -139,7 +139,7 @@ module OlfNamInputModule
     '', & ! shape
     'keyword to activate Newton-Raphson formulation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -158,7 +158,7 @@ module OlfNamInputModule
     '', & ! shape
     'keyword to activate Newton-Raphson UNDER_RELAXATION option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -177,7 +177,7 @@ module OlfNamInputModule
     '', & ! shape
     'package type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -196,7 +196,7 @@ module OlfNamInputModule
     '', & ! shape
     'file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -215,7 +215,7 @@ module OlfNamInputModule
     '', & ! shape
     'user name for package', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -249,7 +249,7 @@ module OlfNamInputModule
     '', & ! shape
     'package list', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-pcpidm.f90
+++ b/src/Idm/olf-pcpidm.f90
@@ -52,7 +52,7 @@ module OlfPcpInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module OlfPcpInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module OlfPcpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module OlfPcpInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module OlfPcpInputModule
     '', & ! shape
     'print precipitation rates to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module OlfPcpInputModule
     '', & ! shape
     'save precipitation to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module OlfPcpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module OlfPcpInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module OlfPcpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module OlfPcpInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module OlfPcpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module OlfPcpInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module OlfPcpInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module OlfPcpInputModule
     '', & ! shape
     'maximum number of precipitation cells', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module OlfPcpInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module OlfPcpInputModule
     '', & ! shape
     'precipitation rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module OlfPcpInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module OlfPcpInputModule
     '', & ! shape
     'precipitation name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module OlfPcpInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-stoidm.f90
+++ b/src/Idm/olf-stoidm.f90
@@ -38,7 +38,7 @@ module OlfStoInputModule
     '', & ! shape
     'keyword to save NPF flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -57,7 +57,7 @@ module OlfStoInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -76,7 +76,7 @@ module OlfStoInputModule
     '', & ! shape
     'steady state indicator', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -95,7 +95,7 @@ module OlfStoInputModule
     '', & ! shape
     'transient indicator', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -125,7 +125,7 @@ module OlfStoInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/olf-zdgidm.f90
+++ b/src/Idm/olf-zdgidm.f90
@@ -54,7 +54,7 @@ module OlfZdgInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -73,7 +73,7 @@ module OlfZdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -92,7 +92,7 @@ module OlfZdgInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -111,7 +111,7 @@ module OlfZdgInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -130,7 +130,7 @@ module OlfZdgInputModule
     '', & ! shape
     'save flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -149,7 +149,7 @@ module OlfZdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -168,7 +168,7 @@ module OlfZdgInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -187,7 +187,7 @@ module OlfZdgInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -206,7 +206,7 @@ module OlfZdgInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -225,7 +225,7 @@ module OlfZdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -244,7 +244,7 @@ module OlfZdgInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -263,7 +263,7 @@ module OlfZdgInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -282,7 +282,7 @@ module OlfZdgInputModule
     '', & ! shape
     'maximum number of zero-depth-gradient boundaries', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -301,7 +301,7 @@ module OlfZdgInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -320,7 +320,7 @@ module OlfZdgInputModule
     '', & ! shape
     'cross section identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -339,7 +339,7 @@ module OlfZdgInputModule
     '', & ! shape
     'width of the zero-depth gradient boundary', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -358,7 +358,7 @@ module OlfZdgInputModule
     '', & ! shape
     'channel slope', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -377,7 +377,7 @@ module OlfZdgInputModule
     '', & ! shape
     'channel roughness', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -396,7 +396,7 @@ module OlfZdgInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -415,7 +415,7 @@ module OlfZdgInputModule
     '', & ! shape
     'zero-depth-gradient boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -459,7 +459,7 @@ module OlfZdgInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/prt-disidm.f90
+++ b/src/Idm/prt-disidm.f90
@@ -58,7 +58,7 @@ module PrtDisInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -77,7 +77,7 @@ module PrtDisInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -96,7 +96,7 @@ module PrtDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -115,7 +115,7 @@ module PrtDisInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -134,7 +134,7 @@ module PrtDisInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -153,7 +153,7 @@ module PrtDisInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -172,7 +172,7 @@ module PrtDisInputModule
     '', & ! shape
     'x-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -191,7 +191,7 @@ module PrtDisInputModule
     '', & ! shape
     'y-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -210,7 +210,7 @@ module PrtDisInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -229,7 +229,7 @@ module PrtDisInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -248,7 +248,7 @@ module PrtDisInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -267,7 +267,7 @@ module PrtDisInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -286,7 +286,7 @@ module PrtDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -305,7 +305,7 @@ module PrtDisInputModule
     '', & ! shape
     'ncf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -324,7 +324,7 @@ module PrtDisInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -343,7 +343,7 @@ module PrtDisInputModule
     '', & ! shape
     'file name of NCF information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -362,7 +362,7 @@ module PrtDisInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -381,7 +381,7 @@ module PrtDisInputModule
     '', & ! shape
     'number of rows', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -400,7 +400,7 @@ module PrtDisInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -419,7 +419,7 @@ module PrtDisInputModule
     'NCOL', & ! shape
     'spacing along a row', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -438,7 +438,7 @@ module PrtDisInputModule
     'NROW', & ! shape
     'spacing along a column', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -457,7 +457,7 @@ module PrtDisInputModule
     'NCOL NROW', & ! shape
     'cell top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -476,7 +476,7 @@ module PrtDisInputModule
     'NCOL NROW NLAY', & ! shape
     'cell bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -495,7 +495,7 @@ module PrtDisInputModule
     'NCOL NROW NLAY', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -545,7 +545,7 @@ module PrtDisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/prt-disvidm.f90
+++ b/src/Idm/prt-disvidm.f90
@@ -64,7 +64,7 @@ module PrtDisvInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -83,7 +83,7 @@ module PrtDisvInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -102,7 +102,7 @@ module PrtDisvInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -121,7 +121,7 @@ module PrtDisvInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -140,7 +140,7 @@ module PrtDisvInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -159,7 +159,7 @@ module PrtDisvInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -178,7 +178,7 @@ module PrtDisvInputModule
     '', & ! shape
     'x-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -197,7 +197,7 @@ module PrtDisvInputModule
     '', & ! shape
     'y-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -216,7 +216,7 @@ module PrtDisvInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -235,7 +235,7 @@ module PrtDisvInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -254,7 +254,7 @@ module PrtDisvInputModule
     '', & ! shape
     'export array variables to netcdf output files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -273,7 +273,7 @@ module PrtDisvInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -292,7 +292,7 @@ module PrtDisvInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -311,7 +311,7 @@ module PrtDisvInputModule
     '', & ! shape
     'ncf keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -330,7 +330,7 @@ module PrtDisvInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -349,7 +349,7 @@ module PrtDisvInputModule
     '', & ! shape
     'file name of NCF information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -368,7 +368,7 @@ module PrtDisvInputModule
     '', & ! shape
     'number of layers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -387,7 +387,7 @@ module PrtDisvInputModule
     '', & ! shape
     'number of cells per layer', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -406,7 +406,7 @@ module PrtDisvInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -425,7 +425,7 @@ module PrtDisvInputModule
     'NCPL', & ! shape
     'model top elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -444,7 +444,7 @@ module PrtDisvInputModule
     'NCPL NLAY', & ! shape
     'model bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -463,7 +463,7 @@ module PrtDisvInputModule
     'NCPL NLAY', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -482,7 +482,7 @@ module PrtDisvInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -501,7 +501,7 @@ module PrtDisvInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -520,7 +520,7 @@ module PrtDisvInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -539,7 +539,7 @@ module PrtDisvInputModule
     '', & ! shape
     'cell2d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -558,7 +558,7 @@ module PrtDisvInputModule
     '', & ! shape
     'x-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -577,7 +577,7 @@ module PrtDisvInputModule
     '', & ! shape
     'y-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -596,7 +596,7 @@ module PrtDisvInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -615,7 +615,7 @@ module PrtDisvInputModule
     'NCVERT', & ! shape
     'array of vertex numbers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -669,7 +669,7 @@ module PrtDisvInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -688,7 +688,7 @@ module PrtDisvInputModule
     'NCPL', & ! shape
     'cell2d data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/prt-fmiidm.f90
+++ b/src/Idm/prt-fmiidm.f90
@@ -38,7 +38,7 @@ module PrtFmiInputModule
     '', & ! shape
     'save cell-by-cell flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -57,7 +57,7 @@ module PrtFmiInputModule
     '', & ! shape
     'flow type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -76,7 +76,7 @@ module PrtFmiInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -95,7 +95,7 @@ module PrtFmiInputModule
     '', & ! shape
     'file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -123,7 +123,7 @@ module PrtFmiInputModule
     '', & ! shape
     'flowtype list', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/prt-mipidm.f90
+++ b/src/Idm/prt-mipidm.f90
@@ -38,7 +38,7 @@ module PrtMipInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -57,7 +57,7 @@ module PrtMipInputModule
     'NODES', & ! shape
     'porosity', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -76,7 +76,7 @@ module PrtMipInputModule
     'NODES', & ! shape
     'retardation factor', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -95,7 +95,7 @@ module PrtMipInputModule
     'NODES', & ! shape
     'zone number', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -125,7 +125,7 @@ module PrtMipInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/prt-namidm.f90
+++ b/src/Idm/prt-namidm.f90
@@ -41,7 +41,7 @@ module PrtNamInputModule
     '', & ! shape
     'name of listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -60,7 +60,7 @@ module PrtNamInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -79,7 +79,7 @@ module PrtNamInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -98,7 +98,7 @@ module PrtNamInputModule
     '', & ! shape
     'save flows for all packages to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -117,7 +117,7 @@ module PrtNamInputModule
     '', & ! shape
     'package type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -136,7 +136,7 @@ module PrtNamInputModule
     '', & ! shape
     'file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -155,7 +155,7 @@ module PrtNamInputModule
     '', & ! shape
     'user name for package', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -186,7 +186,7 @@ module PrtNamInputModule
     '', & ! shape
     'package list', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/prt-prpidm.f90
+++ b/src/Idm/prt-prpidm.f90
@@ -80,7 +80,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -99,7 +99,7 @@ module PrtPrpInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -118,7 +118,7 @@ module PrtPrpInputModule
     '', & ! shape
     'exit solve method', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -137,7 +137,7 @@ module PrtPrpInputModule
     '', & ! shape
     'exit solve tolerance', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -156,7 +156,7 @@ module PrtPrpInputModule
     '', & ! shape
     'whether to use local z coordinates', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -175,7 +175,7 @@ module PrtPrpInputModule
     '', & ! shape
     'whether to extend tracking beyond the end of the simulation', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -194,7 +194,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -213,7 +213,7 @@ module PrtPrpInputModule
     '', & ! shape
     'track keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -232,7 +232,7 @@ module PrtPrpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -251,7 +251,7 @@ module PrtPrpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -270,7 +270,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -289,7 +289,7 @@ module PrtPrpInputModule
     '', & ! shape
     'track keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -308,7 +308,7 @@ module PrtPrpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -327,7 +327,7 @@ module PrtPrpInputModule
     '', & ! shape
     'stop time', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -346,7 +346,7 @@ module PrtPrpInputModule
     '', & ! shape
     'stop travel time', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -365,7 +365,7 @@ module PrtPrpInputModule
     '', & ! shape
     'stop at weak sink', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -384,7 +384,7 @@ module PrtPrpInputModule
     '', & ! shape
     'stop zone number', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -403,7 +403,7 @@ module PrtPrpInputModule
     '', & ! shape
     'drape', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -422,7 +422,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -441,7 +441,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -460,7 +460,7 @@ module PrtPrpInputModule
     'ANY1D', & ! shape
     'release times', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -479,7 +479,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -498,7 +498,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -517,7 +517,7 @@ module PrtPrpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -536,7 +536,7 @@ module PrtPrpInputModule
     '', & ! shape
     'what to do in dry-but-active cells', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -555,7 +555,7 @@ module PrtPrpInputModule
     '', & ! shape
     'force ternary tracking method', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -574,7 +574,7 @@ module PrtPrpInputModule
     '', & ! shape
     'release time coincidence tolerance', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -593,7 +593,7 @@ module PrtPrpInputModule
     '', & ! shape
     'release time frequency', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -612,7 +612,7 @@ module PrtPrpInputModule
     '', & ! shape
     'coordinate checking method', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -631,7 +631,7 @@ module PrtPrpInputModule
     '', & ! shape
     'cycle detection window size', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -650,7 +650,7 @@ module PrtPrpInputModule
     '', & ! shape
     'number of particle release points', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -669,7 +669,7 @@ module PrtPrpInputModule
     '', & ! shape
     'number of particle release times', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -688,7 +688,7 @@ module PrtPrpInputModule
     '', & ! shape
     'PRP id number for release point', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -707,7 +707,7 @@ module PrtPrpInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -726,7 +726,7 @@ module PrtPrpInputModule
     '', & ! shape
     'x coordinate of release point', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -745,7 +745,7 @@ module PrtPrpInputModule
     '', & ! shape
     'y coordinate of release point', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -764,7 +764,7 @@ module PrtPrpInputModule
     '', & ! shape
     'z coordinate of release point', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -783,7 +783,7 @@ module PrtPrpInputModule
     '', & ! shape
     'release point name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -802,7 +802,7 @@ module PrtPrpInputModule
     '', & ! shape
     'release time', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -821,7 +821,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -840,7 +840,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -859,7 +859,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -878,7 +878,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -897,7 +897,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -916,7 +916,7 @@ module PrtPrpInputModule
     '<NSTP', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -935,7 +935,7 @@ module PrtPrpInputModule
     '<NSTP', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1005,7 +1005,7 @@ module PrtPrpInputModule
     'NRELEASEPTS', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1024,7 +1024,7 @@ module PrtPrpInputModule
     'NRELEASETIMES', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -1043,7 +1043,7 @@ module PrtPrpInputModule
     '', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/sim-namidm.f90
+++ b/src/Idm/sim-namidm.f90
@@ -56,7 +56,7 @@ module SimNamInputModule
     '', & ! shape
     'continue if not converged', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -75,7 +75,7 @@ module SimNamInputModule
     '', & ! shape
     'turn off checking', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -94,7 +94,7 @@ module SimNamInputModule
     '', & ! shape
     'memory print option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -113,7 +113,7 @@ module SimNamInputModule
     '', & ! shape
     'profiling option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -132,7 +132,7 @@ module SimNamInputModule
     '', & ! shape
     'maximum number of errors', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -151,7 +151,7 @@ module SimNamInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -170,7 +170,7 @@ module SimNamInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -189,7 +189,7 @@ module SimNamInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -208,7 +208,7 @@ module SimNamInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -227,7 +227,7 @@ module SimNamInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -246,7 +246,7 @@ module SimNamInputModule
     '', & ! shape
     'name of tdis input file', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -265,7 +265,7 @@ module SimNamInputModule
     '', & ! shape
     'model type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -284,7 +284,7 @@ module SimNamInputModule
     '', & ! shape
     'file name for model name file', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -303,7 +303,7 @@ module SimNamInputModule
     '', & ! shape
     'name of model', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -322,7 +322,7 @@ module SimNamInputModule
     '', & ! shape
     'exchange type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -341,7 +341,7 @@ module SimNamInputModule
     '', & ! shape
     'input file for exchange', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -360,7 +360,7 @@ module SimNamInputModule
     '', & ! shape
     'name of model A', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -379,7 +379,7 @@ module SimNamInputModule
     '', & ! shape
     'name of model B', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -398,7 +398,7 @@ module SimNamInputModule
     '', & ! shape
     'maximum solution group iterations', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module SimNamInputModule
     '', & ! shape
     'type of solution', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -436,7 +436,7 @@ module SimNamInputModule
     '', & ! shape
     'file name for solution input', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -455,7 +455,7 @@ module SimNamInputModule
     'ANY1D', & ! shape
     'array of model names in this solution', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -501,7 +501,7 @@ module SimNamInputModule
     '', & ! shape
     'list of models', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -520,7 +520,7 @@ module SimNamInputModule
     '', & ! shape
     'list of exchanges', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -539,7 +539,7 @@ module SimNamInputModule
     '', & ! shape
     'solution type and models in the solution', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/sim-tdisidm.f90
+++ b/src/Idm/sim-tdisidm.f90
@@ -44,7 +44,7 @@ module SimTdisInputModule
     '', & ! shape
     'time unit', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -63,7 +63,7 @@ module SimTdisInputModule
     '', & ! shape
     'starting date and time', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -82,7 +82,7 @@ module SimTdisInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -101,7 +101,7 @@ module SimTdisInputModule
     '', & ! shape
     'ats keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -120,7 +120,7 @@ module SimTdisInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -139,7 +139,7 @@ module SimTdisInputModule
     '', & ! shape
     'file name of adaptive time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -158,7 +158,7 @@ module SimTdisInputModule
     '', & ! shape
     'number of stress periods', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -177,7 +177,7 @@ module SimTdisInputModule
     '', & ! shape
     'length of stress period', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -196,7 +196,7 @@ module SimTdisInputModule
     '', & ! shape
     'number of time steps', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -215,7 +215,7 @@ module SimTdisInputModule
     '', & ! shape
     'number of time steps', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -249,7 +249,7 @@ module SimTdisInputModule
     '', & ! shape
     'stress period time information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-cdbidm.f90
+++ b/src/Idm/swf-cdbidm.f90
@@ -49,7 +49,7 @@ module SwfCdbInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -68,7 +68,7 @@ module SwfCdbInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -87,7 +87,7 @@ module SwfCdbInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -106,7 +106,7 @@ module SwfCdbInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -125,7 +125,7 @@ module SwfCdbInputModule
     '', & ! shape
     'save flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -144,7 +144,7 @@ module SwfCdbInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -163,7 +163,7 @@ module SwfCdbInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -182,7 +182,7 @@ module SwfCdbInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -201,7 +201,7 @@ module SwfCdbInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -220,7 +220,7 @@ module SwfCdbInputModule
     '', & ! shape
     'maximum number of critical depth boundaries', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -239,7 +239,7 @@ module SwfCdbInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -258,7 +258,7 @@ module SwfCdbInputModule
     '', & ! shape
     'cross section identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -277,7 +277,7 @@ module SwfCdbInputModule
     '', & ! shape
     'width of the zero-depth gradient boundary', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -296,7 +296,7 @@ module SwfCdbInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -315,7 +315,7 @@ module SwfCdbInputModule
     '', & ! shape
     'zero-depth-gradient boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -354,7 +354,7 @@ module SwfCdbInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-chdidm.f90
+++ b/src/Idm/swf-chdidm.f90
@@ -52,7 +52,7 @@ module SwfChdInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module SwfChdInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module SwfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module SwfChdInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module SwfChdInputModule
     '', & ! shape
     'print CHD flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module SwfChdInputModule
     '', & ! shape
     'save CHD flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module SwfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module SwfChdInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module SwfChdInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module SwfChdInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module SwfChdInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module SwfChdInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module SwfChdInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module SwfChdInputModule
     '', & ! shape
     'maximum number of constant heads', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module SwfChdInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module SwfChdInputModule
     '', & ! shape
     'head value assigned to constant head', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module SwfChdInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module SwfChdInputModule
     '', & ! shape
     'constant head boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module SwfChdInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-cxsidm.f90
+++ b/src/Idm/swf-cxsidm.f90
@@ -42,7 +42,7 @@ module SwfCxsInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -61,7 +61,7 @@ module SwfCxsInputModule
     '', & ! shape
     'number of reaches', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -80,7 +80,7 @@ module SwfCxsInputModule
     '', & ! shape
     'total number of points defined for all reaches', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -99,7 +99,7 @@ module SwfCxsInputModule
     '', & ! shape
     'reach number for this entry', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -118,7 +118,7 @@ module SwfCxsInputModule
     '', & ! shape
     'number of points used to define cross section', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -137,7 +137,7 @@ module SwfCxsInputModule
     '', & ! shape
     'fractional width', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -156,7 +156,7 @@ module SwfCxsInputModule
     '', & ! shape
     'depth', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -175,7 +175,7 @@ module SwfCxsInputModule
     '', & ! shape
     'Mannings roughness coefficient', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -207,7 +207,7 @@ module SwfCxsInputModule
     'NSECTIONS', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -226,7 +226,7 @@ module SwfCxsInputModule
     'NPOINTS', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-dfwidm.f90
+++ b/src/Idm/swf-dfwidm.f90
@@ -48,7 +48,7 @@ module SwfDfwInputModule
     '', & ! shape
     'use central in space weighting', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -67,7 +67,7 @@ module SwfDfwInputModule
     '', & ! shape
     'length conversion factor', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -86,7 +86,7 @@ module SwfDfwInputModule
     '', & ! shape
     'time conversion factor', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -105,7 +105,7 @@ module SwfDfwInputModule
     '', & ! shape
     'keyword to save DFW flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -124,7 +124,7 @@ module SwfDfwInputModule
     '', & ! shape
     'keyword to print DFW flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -143,7 +143,7 @@ module SwfDfwInputModule
     '', & ! shape
     'keyword to save velocity', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -162,7 +162,7 @@ module SwfDfwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -181,7 +181,7 @@ module SwfDfwInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -200,7 +200,7 @@ module SwfDfwInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -219,7 +219,7 @@ module SwfDfwInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -238,7 +238,7 @@ module SwfDfwInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -257,7 +257,7 @@ module SwfDfwInputModule
     '', & ! shape
     'use SWR conductance formulation', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -276,7 +276,7 @@ module SwfDfwInputModule
     'NODES', & ! shape
     'mannings roughness coefficient', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -295,7 +295,7 @@ module SwfDfwInputModule
     'NODES', & ! shape
     'cross section number', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -335,7 +335,7 @@ module SwfDfwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-dis2didm.f90
+++ b/src/Idm/swf-dis2didm.f90
@@ -51,7 +51,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -70,7 +70,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -89,7 +89,7 @@ module SwfDis2DInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -108,7 +108,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -127,7 +127,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -146,7 +146,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -165,7 +165,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'x-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -184,7 +184,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'y-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -203,7 +203,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -222,7 +222,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -241,7 +241,7 @@ module SwfDis2DInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -260,7 +260,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'number of rows', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -279,7 +279,7 @@ module SwfDis2DInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -298,7 +298,7 @@ module SwfDis2DInputModule
     'NCOL', & ! shape
     'spacing along a row', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -317,7 +317,7 @@ module SwfDis2DInputModule
     'NROW', & ! shape
     'spacing along a column', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -336,7 +336,7 @@ module SwfDis2DInputModule
     'NCOL NROW', & ! shape
     'cell bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -355,7 +355,7 @@ module SwfDis2DInputModule
     'NCOL NROW', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -398,7 +398,7 @@ module SwfDis2DInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-disv1didm.f90
+++ b/src/Idm/swf-disv1didm.f90
@@ -57,7 +57,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -76,7 +76,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -95,7 +95,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -114,7 +114,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -133,7 +133,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -152,7 +152,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -171,7 +171,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'x-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -190,7 +190,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'y-position origin of the model grid coordinate system', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -209,7 +209,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -228,7 +228,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -247,7 +247,7 @@ module SwfDisv1DInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -266,7 +266,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'number of linear features', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -285,7 +285,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'number of columns', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -304,7 +304,7 @@ module SwfDisv1DInputModule
     'NODES', & ! shape
     'width', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -323,7 +323,7 @@ module SwfDisv1DInputModule
     'NODES', & ! shape
     'bottom elevation for the one-dimensional cell', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -342,7 +342,7 @@ module SwfDisv1DInputModule
     'NODES', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -361,7 +361,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -380,7 +380,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -399,7 +399,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -418,7 +418,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'cell1d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -437,7 +437,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'fractional distance to the cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -456,7 +456,7 @@ module SwfDisv1DInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -475,7 +475,7 @@ module SwfDisv1DInputModule
     'NCVERT', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -522,7 +522,7 @@ module SwfDisv1DInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -541,7 +541,7 @@ module SwfDisv1DInputModule
     'NODES', & ! shape
     'cell1d data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-disv2didm.f90
+++ b/src/Idm/swf-disv2didm.f90
@@ -57,7 +57,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'model length units', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -76,7 +76,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'do not write binary grid file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -95,7 +95,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -114,7 +114,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'grb keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -133,7 +133,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -152,7 +152,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'file name of GRB information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -171,7 +171,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'x-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -190,7 +190,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'y-position of the model grid origin', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -209,7 +209,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'rotation angle', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -228,7 +228,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -247,7 +247,7 @@ module SwfDisv2DInputModule
     'LENBIGLINE', & ! shape
     'CRS user input string', & ! longname
     .false., & ! required
-    .true., & ! prerelease
+    .true., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -266,7 +266,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'number of cells per layer', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -285,7 +285,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'number of columns', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -304,7 +304,7 @@ module SwfDisv2DInputModule
     'NODES', & ! shape
     'model bottom elevation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -323,7 +323,7 @@ module SwfDisv2DInputModule
     'NODES', & ! shape
     'idomain existence array', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -342,7 +342,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'vertex number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -361,7 +361,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'x-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -380,7 +380,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'y-coordinate for vertex', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -399,7 +399,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'cell2d number', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -418,7 +418,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'x-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -437,7 +437,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'y-coordinate for cell center', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -456,7 +456,7 @@ module SwfDisv2DInputModule
     '', & ! shape
     'number of cell vertices', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -475,7 +475,7 @@ module SwfDisv2DInputModule
     'NCVERT', & ! shape
     'array of vertex numbers', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -522,7 +522,7 @@ module SwfDisv2DInputModule
     'NVERT', & ! shape
     'vertices data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -541,7 +541,7 @@ module SwfDisv2DInputModule
     'NODES', & ! shape
     'cell2d data', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-evpidm.f90
+++ b/src/Idm/swf-evpidm.f90
@@ -52,7 +52,7 @@ module SwfEvpInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module SwfEvpInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module SwfEvpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module SwfEvpInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module SwfEvpInputModule
     '', & ! shape
     'print evaporation rates to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module SwfEvpInputModule
     '', & ! shape
     'save evaporation to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module SwfEvpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module SwfEvpInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module SwfEvpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module SwfEvpInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module SwfEvpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module SwfEvpInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module SwfEvpInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module SwfEvpInputModule
     '', & ! shape
     'maximum number of evaporation cells', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module SwfEvpInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module SwfEvpInputModule
     '', & ! shape
     'evaporation rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module SwfEvpInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module SwfEvpInputModule
     '', & ! shape
     'evaporation name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module SwfEvpInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-flwidm.f90
+++ b/src/Idm/swf-flwidm.f90
@@ -52,7 +52,7 @@ module SwfFlwInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module SwfFlwInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module SwfFlwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module SwfFlwInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module SwfFlwInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module SwfFlwInputModule
     '', & ! shape
     'save well flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module SwfFlwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module SwfFlwInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module SwfFlwInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module SwfFlwInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module SwfFlwInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module SwfFlwInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module SwfFlwInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module SwfFlwInputModule
     '', & ! shape
     'maximum number of inflow', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module SwfFlwInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module SwfFlwInputModule
     '', & ! shape
     'well rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module SwfFlwInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module SwfFlwInputModule
     '', & ! shape
     'inflow name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module SwfFlwInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-icidm.f90
+++ b/src/Idm/swf-icidm.f90
@@ -36,7 +36,7 @@ module SwfIcInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -55,7 +55,7 @@ module SwfIcInputModule
     'NODES', & ! shape
     'starting concentration', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .true., & ! layered
@@ -83,7 +83,7 @@ module SwfIcInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-namidm.f90
+++ b/src/Idm/swf-namidm.f90
@@ -44,7 +44,7 @@ module SwfNamInputModule
     '', & ! shape
     'name of listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -63,7 +63,7 @@ module SwfNamInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -82,7 +82,7 @@ module SwfNamInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -101,7 +101,7 @@ module SwfNamInputModule
     '', & ! shape
     'save flows for all packages to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -120,7 +120,7 @@ module SwfNamInputModule
     '', & ! shape
     'newton keyword and options', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -139,7 +139,7 @@ module SwfNamInputModule
     '', & ! shape
     'keyword to activate Newton-Raphson formulation', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -158,7 +158,7 @@ module SwfNamInputModule
     '', & ! shape
     'keyword to activate Newton-Raphson UNDER_RELAXATION option', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -177,7 +177,7 @@ module SwfNamInputModule
     '', & ! shape
     'package type', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -196,7 +196,7 @@ module SwfNamInputModule
     '', & ! shape
     'file name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -215,7 +215,7 @@ module SwfNamInputModule
     '', & ! shape
     'user name for package', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -249,7 +249,7 @@ module SwfNamInputModule
     '', & ! shape
     'package list', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-pcpidm.f90
+++ b/src/Idm/swf-pcpidm.f90
@@ -52,7 +52,7 @@ module SwfPcpInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -71,7 +71,7 @@ module SwfPcpInputModule
     '', & ! shape
     'name of auxiliary variable for multiplier', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -90,7 +90,7 @@ module SwfPcpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -109,7 +109,7 @@ module SwfPcpInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -128,7 +128,7 @@ module SwfPcpInputModule
     '', & ! shape
     'print precipitation rates to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -147,7 +147,7 @@ module SwfPcpInputModule
     '', & ! shape
     'save precipitation to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -166,7 +166,7 @@ module SwfPcpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -185,7 +185,7 @@ module SwfPcpInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -204,7 +204,7 @@ module SwfPcpInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -223,7 +223,7 @@ module SwfPcpInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -242,7 +242,7 @@ module SwfPcpInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -261,7 +261,7 @@ module SwfPcpInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -280,7 +280,7 @@ module SwfPcpInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -299,7 +299,7 @@ module SwfPcpInputModule
     '', & ! shape
     'maximum number of precipitation cells', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -318,7 +318,7 @@ module SwfPcpInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -337,7 +337,7 @@ module SwfPcpInputModule
     '', & ! shape
     'precipitation rate', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -356,7 +356,7 @@ module SwfPcpInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -375,7 +375,7 @@ module SwfPcpInputModule
     '', & ! shape
     'precipitation name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -417,7 +417,7 @@ module SwfPcpInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-stoidm.f90
+++ b/src/Idm/swf-stoidm.f90
@@ -38,7 +38,7 @@ module SwfStoInputModule
     '', & ! shape
     'keyword to save NPF flows', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -57,7 +57,7 @@ module SwfStoInputModule
     '', & ! shape
     'export array variables to layered ascii files.', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -76,7 +76,7 @@ module SwfStoInputModule
     '', & ! shape
     'steady state indicator', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -95,7 +95,7 @@ module SwfStoInputModule
     '', & ! shape
     'transient indicator', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -125,7 +125,7 @@ module SwfStoInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/swf-zdgidm.f90
+++ b/src/Idm/swf-zdgidm.f90
@@ -54,7 +54,7 @@ module SwfZdgInputModule
     'NAUX', & ! shape
     'keyword to specify aux variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -73,7 +73,7 @@ module SwfZdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -92,7 +92,7 @@ module SwfZdgInputModule
     '', & ! shape
     'print input to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -111,7 +111,7 @@ module SwfZdgInputModule
     '', & ! shape
     'print calculated flows to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -130,7 +130,7 @@ module SwfZdgInputModule
     '', & ! shape
     'save flows to budget file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -149,7 +149,7 @@ module SwfZdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -168,7 +168,7 @@ module SwfZdgInputModule
     '', & ! shape
     'head keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -187,7 +187,7 @@ module SwfZdgInputModule
     '', & ! shape
     'file keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -206,7 +206,7 @@ module SwfZdgInputModule
     '', & ! shape
     'file name of time series information', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -225,7 +225,7 @@ module SwfZdgInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -244,7 +244,7 @@ module SwfZdgInputModule
     '', & ! shape
     'obs keyword', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -263,7 +263,7 @@ module SwfZdgInputModule
     '', & ! shape
     'obs6 input filename', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
     .false., & ! layered
@@ -282,7 +282,7 @@ module SwfZdgInputModule
     '', & ! shape
     'maximum number of zero-depth-gradient boundaries', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -301,7 +301,7 @@ module SwfZdgInputModule
     'NCELLDIM', & ! shape
     'cell identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -320,7 +320,7 @@ module SwfZdgInputModule
     '', & ! shape
     'cross section identifier', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -339,7 +339,7 @@ module SwfZdgInputModule
     '', & ! shape
     'width of the zero-depth gradient boundary', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -358,7 +358,7 @@ module SwfZdgInputModule
     '', & ! shape
     'channel slope', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -377,7 +377,7 @@ module SwfZdgInputModule
     '', & ! shape
     'channel roughness', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -396,7 +396,7 @@ module SwfZdgInputModule
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -415,7 +415,7 @@ module SwfZdgInputModule
     '', & ! shape
     'zero-depth-gradient boundary name', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -459,7 +459,7 @@ module SwfZdgInputModule
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/utl-hpcidm.f90
+++ b/src/Idm/utl-hpcidm.f90
@@ -38,7 +38,7 @@ module UtlHpcInputModule
     '', & ! shape
     'model print table to listing file', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -57,7 +57,7 @@ module UtlHpcInputModule
     '', & ! shape
     'log mpi traffic', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -76,7 +76,7 @@ module UtlHpcInputModule
     '', & ! shape
     'model name', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -95,7 +95,7 @@ module UtlHpcInputModule
     '', & ! shape
     'model rank', & ! longname
     .true., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .true., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -123,7 +123,7 @@ module UtlHpcInputModule
     '', & ! shape
     'list of partition numbers', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Idm/utl-ncfidm.f90
+++ b/src/Idm/utl-ncfidm.f90
@@ -46,7 +46,7 @@ module UtlNcfInputModule
     'LENBIGLINE', & ! shape
     'CRS well-known text (WKT) string', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -65,7 +65,7 @@ module UtlNcfInputModule
     '', & ! shape
     'variable compression deflate level', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -84,7 +84,7 @@ module UtlNcfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -103,7 +103,7 @@ module UtlNcfInputModule
     '', & ! shape
     'chunking parameter for the time dimension', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -122,7 +122,7 @@ module UtlNcfInputModule
     '', & ! shape
     'chunking parameter for the mesh face dimension', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -141,7 +141,7 @@ module UtlNcfInputModule
     '', & ! shape
     'chunking parameter for structured z', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -160,7 +160,7 @@ module UtlNcfInputModule
     '', & ! shape
     'chunking parameter for structured y', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -179,7 +179,7 @@ module UtlNcfInputModule
     '', & ! shape
     'chunking parameter for structured x', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -198,7 +198,7 @@ module UtlNcfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -217,7 +217,7 @@ module UtlNcfInputModule
     '', & ! shape
     'number of cells in layer', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -236,7 +236,7 @@ module UtlNcfInputModule
     'NCPL', & ! shape
     'cell center latitude', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -255,7 +255,7 @@ module UtlNcfInputModule
     'NCPL', & ! shape
     'cell center longitude', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -293,7 +293,7 @@ module UtlNcfInputModule
     '', & ! shape
     '', & ! longname
     .false., & ! required
-    .false., & ! prerelease
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered

--- a/src/Model/TransportModel/tsp-adv.f90
+++ b/src/Model/TransportModel/tsp-adv.f90
@@ -2,7 +2,7 @@ module TspAdvModule
 
   use KindModule, only: DP, I4B
   use ConstantsModule, only: DONE, DZERO, DNODATA, DPREC, LINELENGTH
-  use DevFeatureModule, only: dev_feature
+  use FeatureFlagsModule, only: developmode
   use NumericalPackageModule, only: NumericalPackageType
   use BaseDisModule, only: DisBaseType
   use TspFmiModule, only: TspFmiType
@@ -376,7 +376,7 @@ contains
     end if
 
     if (this%iadvwt == ADV_SCHEME_UTVD) then
-      call dev_feature('UTVD is still under development, install the &
+      call developmode('UTVD is still under development, install the &
           &nightly build or compile from source with IDEVELOPMODE = 1.')
     end if
 

--- a/src/SimulationCreate.f90
+++ b/src/SimulationCreate.f90
@@ -1,7 +1,7 @@
 module SimulationCreateModule
 
   use KindModule, only: DP, I4B, LGP, write_kindinfo
-  use DevFeatureModule, only: dev_feature
+  use FeatureFlagsModule, only: developmode
   use ConstantsModule, only: LINELENGTH, LENMODELNAME, LENBIGLINE, &
                              DZERO, LENEXCHANGENAME, LENMEMPATH, LENPACKAGETYPE
   use CharacterStringModule, only: CharacterStringType
@@ -312,7 +312,7 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), " model ", &
             n, " will be created"
           call chf_cr(fname, n, model_names(n))
-          call dev_feature('CHF is still under development, install the &
+          call developmode('CHF is still under development, install the &
             &nightly build or compile from source with IDEVELOPMODE = 1.')
           num_model => GetNumericalModelFromList(basemodellist, im)
           model_loc_idx(n) = im
@@ -323,7 +323,7 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), " model ", &
             n, " will be created"
           call olf_cr(fname, n, model_names(n))
-          call dev_feature('OLF is still under development, install the &
+          call developmode('OLF is still under development, install the &
             &nightly build or compile from source with IDEVELOPMODE = 1.')
           num_model => GetNumericalModelFromList(basemodellist, im)
           model_loc_idx(n) = im

--- a/src/Solution/PETSc/PetscSolver.F90
+++ b/src/Solution/PETSc/PetscSolver.F90
@@ -15,7 +15,7 @@ module PetscSolverModule
   use ImsLinearSettingsModule
   use SimVariablesModule, only: iout, simulation_mode, nr_procs, proc_id
   use SimModule, only: store_error, store_warning
-  use DevFeatureModule, only: dev_feature
+  use FeatureFlagsModule, only: developmode
 
   implicit none
   private
@@ -232,7 +232,7 @@ contains
     if (this%use_ims_pc) then
       call this%set_ims_pc()
     else
-      call dev_feature('PETSc preconditioning is under development, install the &
+      call developmode('PETSc preconditioning is under development, install the &
             &nightly build or compile from source with IDEVELOPMODE = 1.')
       ! The PC options will be set from the .petscrc
       ! file in the call to KSPSetFromOptions below
@@ -300,7 +300,7 @@ contains
 
     if (.not. this%use_ims_cnvgopt) then
       ! use PETSc residual L2 norm for convergence
-      call dev_feature('Using PETSc convergence is under development, install &
+      call developmode('Using PETSc convergence is under development, install &
       &the nightly build or compile from source with IDEVELOPMODE = 1.')
       call KSPSetConvergenceTest(this%ksp_petsc, petsc_cnvg_check_internal, &
                                  this%petsc_ctx, PETSC_NULL_FUNCTION, ierr)

--- a/src/Utilities/BlockParser.f90
+++ b/src/Utilities/BlockParser.f90
@@ -7,7 +7,7 @@
 module BlockParserModule
 
   use KindModule, only: DP, I4B, LGP
-  use DevFeatureModule, only: dev_feature
+  use FeatureFlagsModule, only: developmode
   use ConstantsModule, only: LENBIGLINE, LENHUGELINE, LINELENGTH, MAXCHARLEN
   use InputOutputModule, only: urword, upcase, openfile, &
                                io_getunit => GetUnit
@@ -552,7 +552,7 @@ contains
     !
     errmsg = "Invalid keyword '"//trim(this%laststring)// &
              "' detected in block '"//trim(this%blockname)//"'."
-    call dev_feature(errmsg, this%iuext)
+    call developmode(errmsg, this%iuext)
   end subroutine DevOpt
 
   ! -- static methods previously in InputOutput

--- a/src/Utilities/FeatureFlags.f90
+++ b/src/Utilities/FeatureFlags.f90
@@ -1,11 +1,11 @@
 !> @brief Disable development features in release mode
-module DevFeatureModule
+module FeatureFlagsModule
   use KindModule, only: I4B
   use VersionModule, only: IDEVELOPMODE
   use SimModule, only: store_error, store_error_unit
   implicit none
   private
-  public :: dev_feature
+  public :: developmode
 
 contains
 
@@ -17,7 +17,7 @@ contains
   !! may be specified to associate the feature with an input file.
   !!
   !<
-  subroutine dev_feature(errmsg, iunit)
+  subroutine developmode(errmsg, iunit)
     ! -- dummy
     character(len=*), intent(in) :: errmsg
     integer(I4B), intent(in), optional :: iunit
@@ -32,6 +32,6 @@ contains
       end if
     end if
 
-  end subroutine dev_feature
+  end subroutine developmode
 
-end module DevFeatureModule
+end module FeatureFlagsModule

--- a/src/Utilities/Idm/DefinitionSelect.f90
+++ b/src/Utilities/Idm/DefinitionSelect.f90
@@ -296,7 +296,7 @@ contains
     idt%datatype = trim(datatype)
     idt%shape = ''
     idt%required = .true.
-    idt%prerelease = .false.
+    idt%developmode = .false.
     idt%in_record = .false.
     idt%preserve_case = .false.
     idt%layered = .false.

--- a/src/Utilities/Idm/InputDefinition.f90
+++ b/src/Utilities/Idm/InputDefinition.f90
@@ -30,7 +30,7 @@ module InputDefinitionModule
     character(len=LINELENGTH) :: shape = '' !< shape of data type
     character(len=LINELENGTH) :: longname = '' !< description of variable
     logical(LGP) :: required = .false. !< is the parameter required
-    logical(LGP) :: prerelease = .false. !< is the parameter prerelease
+    logical(LGP) :: developmode = .false. !< is the parameter developmode
     logical(LGP) :: in_record = .false. !< is the parameter within an input record
     logical(LGP) :: preserve_case = .false. !< should string case be preserved
     logical(LGP) :: layered = .false. !< does the parameter support a layered read

--- a/src/Utilities/Idm/LoadContext.f90
+++ b/src/Utilities/Idm/LoadContext.f90
@@ -373,8 +373,8 @@ contains
                                   this%mf6_input%subcomponent_type, &
                                   this%blockname, this%params(n), '')
 
-      ! check if input param is prerelease
-      if (idt%prerelease) then
+      ! check if input param is developmode
+      if (idt%developmode) then
         dev_msg = 'Input tag "'//trim(idt%tagname)// &
           &'" read from file "'//trim(input_name)// &
           &'" is still under development. Install the &

--- a/src/Utilities/Idm/LoadContext.f90
+++ b/src/Utilities/Idm/LoadContext.f90
@@ -341,7 +341,7 @@ contains
   !!
   !<
   subroutine tags(this, params, nparam, input_name, create)
-    use DevFeatureModule, only: dev_feature
+    use FeatureFlagsModule, only: developmode
     use SimVariablesModule, only: iout
     use DefinitionSelectModule, only: get_param_definition_type
     class(LoadContextType) :: this
@@ -379,7 +379,7 @@ contains
           &'" read from file "'//trim(input_name)// &
           &'" is still under development. Install the &
           &nightly build or compile from source with IDEVELOPMODE = 1.'
-        call dev_feature(dev_msg, iout)
+        call developmode(dev_msg, iout)
       end if
 
       params(n) = this%params(n)

--- a/src/Utilities/Idm/mf6blockfile/IdmMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/IdmMf6File.f90
@@ -272,7 +272,7 @@ contains
     use ListLoadModule, only: ListLoadType
     use Mf6FileSettingLoadModule, only: SettingLoadType
     use Mf6FileStoInputModule, only: StoInputType
-    use DevFeatureModule, only: dev_feature
+    use FeatureFlagsModule, only: developmode
     class(Mf6FileDynamicPkgLoadType), intent(inout) :: this
     class(ListLoadType), pointer :: list_loader
     class(GridArrayLoadType), pointer :: arrgrid_loader
@@ -291,7 +291,7 @@ contains
       allocate (arrlayer_loader)
       this%rp_loader => arrlayer_loader
     else if (this%readarraygrid) then
-      call dev_feature('Input file "'//trim(this%input_name)// &
+      call developmode('Input file "'//trim(this%input_name)// &
         '" READARRAYGRID option is still under development, install the &
         &nightly build or compile from source with IDEVELOPMODE = 1.', &
         this%iout)

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -445,7 +445,7 @@ contains
   !! Load input associated with tag key into the memory manager.
   !<
   subroutine load_tag(this, iblk, idt)
-    use DevFeatureModule, only: dev_feature
+    use FeatureFlagsModule, only: developmode
     use ArrayHandlersModule, only: expandarray
     class(LoadMf6FileType) :: this
     integer(I4B), intent(in) :: iblk
@@ -458,7 +458,7 @@ contains
         &'" read from file "'//trim(this%filename)// &
         &'" is still under development. Install the &
         &nightly build or compile from source with IDEVELOPMODE = 1.'
-      call dev_feature(dev_msg, this%iout)
+      call developmode(dev_msg, this%iout)
     end if
 
     ! allocate and load data type

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -452,8 +452,8 @@ contains
     type(InputParamDefinitionType), pointer, intent(in) :: idt !< input data type object describing this record
     character(len=LINELENGTH) :: dev_msg
 
-    ! check if input param is prerelease
-    if (idt%prerelease) then
+    ! check if input param is developmode
+    if (idt%developmode) then
       dev_msg = 'Input tag "'//trim(idt%tagname)// &
         &'" read from file "'//trim(this%filename)// &
         &'" is still under development. Install the &

--- a/src/meson.build
+++ b/src/meson.build
@@ -438,7 +438,7 @@ modflow_sources = files(
     'Utilities' / 'CharString.f90',
     'Utilities' / 'Constants.f90',
     'Utilities' / 'defmacro.F90',
-    'Utilities' / 'DevFeature.f90',
+    'Utilities' / 'FeatureFlags.f90',
     'Utilities' / 'ErrorUtil.f90',
     'Utilities' / 'GeomUtil.f90',
     'Utilities' / 'GridFileReader.f90',

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -274,7 +274,7 @@ class Dfn2F90:
             self._param_str += "    '', & ! shape\n"
             self._param_str += "    '', & ! longname\n"
             self._param_str += "    .false., & ! required\n"
-            self._param_str += "    .false., & ! prerelease\n"
+            self._param_str += "    .false., & ! developmode\n"
             self._param_str += "    .false., & ! multi-record\n"
             self._param_str += "    .false., & ! preserve case\n"
             self._param_str += "    .false., & ! layered\n"
@@ -293,7 +293,7 @@ class Dfn2F90:
             self._aggregate_str += "    '', & ! shape\n"
             self._aggregate_str += "    '', & ! longname\n"
             self._aggregate_str += "    .false., & ! required\n"
-            self._aggregate_str += "    .false., & ! prerelease\n"
+            self._aggregate_str += "    .false., & ! developmode\n"
             self._aggregate_str += "    .false., & ! multi-record\n"
             self._aggregate_str += "    .false., & ! preserve case\n"
             self._aggregate_str += "    .false., & ! layered\n"
@@ -408,10 +408,10 @@ class Dfn2F90:
                 else:
                     r = ".true."
 
-            prerelease = ".false."
-            if "prerelease" in v:
-                if v["prerelease"] == "true":
-                    prerelease = ".true."
+            developmode = ".false."
+            if "developmode" in v:
+                if v["developmode"] == "true":
+                    developmode = ".true."
 
             preserve_case = ".false."
             if "preserve_case" in v:
@@ -446,7 +446,7 @@ class Dfn2F90:
                 (shape, "shape"),
                 (longname, "longname"),
                 (r, "required"),
-                (prerelease, "prerelease"),
+                (developmode, "developmode"),
                 (inrec, "multi-record"),
                 (preserve_case, "preserve case"),
                 (layered, "layered"),

--- a/utils/mf5to6/make/makefile
+++ b/utils/mf5to6/make/makefile
@@ -56,7 +56,7 @@ $(OBJDIR)/SimPHMF.o \
 $(OBJDIR)/ListNode.o \
 $(OBJDIR)/MemoryStore.o \
 $(OBJDIR)/LongLineReader.o \
-$(OBJDIR)/DevFeature.o \
+$(OBJDIR)/FeatureFlags.o \
 $(OBJDIR)/Utilities.o \
 $(OBJDIR)/ListIterator.o \
 $(OBJDIR)/ConstantsPHMF.o \

--- a/utils/mf5to6/msvs/mf5to6.vfproj
+++ b/utils/mf5to6/msvs/mf5to6.vfproj
@@ -100,7 +100,7 @@
 		<File RelativePath="..\..\..\src\Utilities\defmacro.F90">
 			<FileConfiguration Name="Debug|Win32">
 				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
-		<File RelativePath="..\..\..\src\Utilities\DevFeature.f90"/>
+		<File RelativePath="..\..\..\src\Utilities\FeatureFlags.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\ErrorUtil.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\GeomUtil.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\InputOutput.f90"/>

--- a/utils/mf5to6/pymake/extrafiles.txt
+++ b/utils/mf5to6/pymake/extrafiles.txt
@@ -33,4 +33,4 @@
 ../../../src/Utilities/version.f90
 ../../../src/Utilities/Table.f90
 ../../../src/Utilities/TableTerm.f90
-../../../src/Utilities/DevFeature.f90
+../../../src/Utilities/FeatureFlags.f90

--- a/utils/mf5to6/src/meson.build
+++ b/utils/mf5to6/src/meson.build
@@ -34,7 +34,7 @@ mf6_sources = files(
     '..' / '..' / '..' / 'src' / 'Utilities' / 'version.f90',
     '..' / '..' / '..' / 'src' / 'Utilities' / 'Table.f90',
     '..' / '..' / '..' / 'src' / 'Utilities' / 'TableTerm.f90',
-    '..' / '..' / '..' / 'src' / 'Utilities' / 'DevFeature.f90',
+    '..' / '..' / '..' / 'src' / 'Utilities' / 'FeatureFlags.f90',
 )
 
 

--- a/utils/zonebudget/make/makefile
+++ b/utils/zonebudget/make/makefile
@@ -28,7 +28,7 @@ $(OBJDIR)/Sim.o \
 $(OBJDIR)/OpenSpec.o \
 $(OBJDIR)/InputOutput.o \
 $(OBJDIR)/LongLineReader.o \
-$(OBJDIR)/DevFeature.o \
+$(OBJDIR)/FeatureFlags.o \
 $(OBJDIR)/sort.o \
 $(OBJDIR)/BlockParser.o \
 $(OBJDIR)/ArrayReaders.o \

--- a/utils/zonebudget/msvs/zonebudget.vfproj
+++ b/utils/zonebudget/msvs/zonebudget.vfproj
@@ -46,7 +46,7 @@
 			<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
 		<File RelativePath="..\..\..\src\Utilities\GridFileReader.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\HashTable.f90"/>
-		<File RelativePath="..\..\..\src\Utilities\DevFeature.f90"/>
+		<File RelativePath="..\..\..\src\Utilities\FeatureFlags.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\ErrorUtil.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\GeomUtil.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\InputOutput.f90"/>

--- a/utils/zonebudget/pymake/extrafiles.txt
+++ b/utils/zonebudget/pymake/extrafiles.txt
@@ -17,7 +17,7 @@
 ../../../src/Utilities/Sim.f90
 ../../../src/Utilities/SimVariables.f90
 ../../../src/Utilities/version.f90
-../../../src/Utilities/DevFeature.f90
+../../../src/Utilities/FeatureFlags.f90
 ../../../src/Utilities/Message.f90
 ../../../src/Utilities/GridFileReader.f90
 ../../../src/Utilities/HashTable.f90


### PR DESCRIPTION
Consolidate various switches (`--full`, `--approved`, `--releasemode`) into a single switch `--releasemode` consistent across all distribution-related scripts, corresponding to the [2 release types](https://github.com/MODFLOW-ORG/modflow6/tree/develop/distribution#flavors)

- develop mode. minimal contents. preliminary language. IDEVELOPMODE=1. provisional (e.g. nightly) builds
- release mode. all contents. approved language. IDEVELOPMODE=0. extensive docs/examples. official releases

Rename the `prerelease` DFN variable attribute to `developmode` for consistency.

By default, all the scripts now run in develop mode unless `--releasemode` is enabled. A corresponding `--releasemode` switch was also [added](https://github.com/modflowpy/flopy/pull/2604) to the flopy codegen utility.

And rename `DevFeatureModule` and `dev_feature()` to `FeatureFlagsModule` and `developmode()` respectively.

Also, remove options for filtering models out of the distribution. That was overkill. Just hard code them.