### PR TITLE
docs(dfn): remove doubled word in maxbound description

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/chf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-evp.dfn
@@ -138,7 +138,7 @@ type integer
 reader urword
 optional false
 longname maximum number of evaporation cells
-description REPLACE maxbound {'{#1}': 'evaporation cells'}
+description REPLACE maxbound {'{#1}': 'evaporation'}
 
 
 # --------------------- swf evp period ---------------------

--- a/doc/mf6io/mf6ivar/dfn/chf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-pcp.dfn
@@ -138,7 +138,7 @@ type integer
 reader urword
 optional false
 longname maximum number of precipitation cells
-description REPLACE maxbound {'{#1}': 'precipitation cells'}
+description REPLACE maxbound {'{#1}': 'precipitation'}
 
 
 # --------------------- swf pcp period ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-evt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-evt.dfn
@@ -157,7 +157,7 @@ type integer
 reader urword
 optional false
 longname maximum number of evapotranspiration cells
-description REPLACE maxbound {'{#1}': 'evapotranspiration cells'}
+description REPLACE maxbound {'{#1}': 'evapotranspiration'}
 
 block dimensions
 name nseg

--- a/doc/mf6io/mf6ivar/dfn/gwf-rch.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rch.dfn
@@ -148,7 +148,7 @@ type integer
 reader urword
 optional false
 longname maximum number of recharge cells
-description REPLACE maxbound {'{#1}': 'recharge cells'}
+description REPLACE maxbound {'{#1}': 'recharge'}
 
 
 # --------------------- gwf rch period ---------------------

--- a/doc/mf6io/mf6ivar/dfn/olf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-evp.dfn
@@ -138,7 +138,7 @@ type integer
 reader urword
 optional false
 longname maximum number of evaporation cells
-description REPLACE maxbound {'{#1}': 'evaporation cells'}
+description REPLACE maxbound {'{#1}': 'evaporation'}
 
 
 # --------------------- swf evp period ---------------------

--- a/doc/mf6io/mf6ivar/dfn/olf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-pcp.dfn
@@ -138,7 +138,7 @@ type integer
 reader urword
 optional false
 longname maximum number of precipitation cells
-description REPLACE maxbound {'{#1}': 'precipitation cells'}
+description REPLACE maxbound {'{#1}': 'precipitation'}
 
 
 # --------------------- swf pcp period ---------------------

--- a/doc/mf6io/mf6ivar/dfn/swf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-evp.dfn
@@ -138,7 +138,7 @@ type integer
 reader urword
 optional false
 longname maximum number of evaporation cells
-description REPLACE maxbound {'{#1}': 'evaporation cells'}
+description REPLACE maxbound {'{#1}': 'evaporation'}
 
 
 # --------------------- swf evp period ---------------------

--- a/doc/mf6io/mf6ivar/dfn/swf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-pcp.dfn
@@ -138,7 +138,7 @@ type integer
 reader urword
 optional false
 longname maximum number of precipitation cells
-description REPLACE maxbound {'{#1}': 'precipitation cells'}
+description REPLACE maxbound {'{#1}': 'precipitation'}
 
 
 # --------------------- swf pcp period ---------------------


### PR DESCRIPTION
This PR removes double word "cells" in some `maxbound` description. For example, in the [RCH](https://modflow6.readthedocs.io/en/6.6.3/_mf6io/gwf-rch.html#block-dimensions) package:
```
maxbound - integer value specifying the maximum number of recharge cells cells that will be specified for use
during any stress period.
```