### PR TITLE
doc(prt-prp): fix coordinate_check_method attribute default -> default_value

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -294,7 +294,7 @@ prerelease true
 mf6internal ichkmeth
 longname coordinate checking method
 description approach for verifying that release point coordinates are in the cell with the specified ID. By default, release point coordinates are checked at release time.
-default eager
+default_value eager
 
 block options
 name dev_cycle_detection_window


### PR DESCRIPTION
Noticed in https://github.com/MODFLOW-ORG/modflow6/pull/2424#issuecomment-3397366686, the DFN attribute name is `default_value` even if we are going to rename it to `default` for the next generation specification schema