### PR TITLE
fix(hfb): adjust hfb count when cell(s) are inactive

### DIFF
--- a/autotest/test_gwf_npf_thickstrt.py
+++ b/autotest/test_gwf_npf_thickstrt.py
@@ -15,12 +15,10 @@ cases = [
     "gwf_npf_thickstrt07",  # icelltype=-1, using thickstrt, has hfb
     "gwf_npf_thickstrt08",  # icelltype=1, no thickstrt, has hfb
     "gwf_npf_thickstrt09",  # icelltype=-1, no thickstrt, has hfb
-    "gwf_npf_thickstrt10",  # icelltype=-1, no thickstrt, no hfb (cell (1,1,3) inactive)
 ]
-thickstrt = [False, True, True, False, False, False, True, False, False, False]
-icelltype = [0, 0, -1, 1, -1, 0, -1, 1, -1, -1]
-hfb_on = [False, False, False, False, False, True, True, True, True, True]
-icell_inactive = 9
+thickstrt = [False, True, True, False, False, False, True, False, False]
+icelltype = [0, 0, -1, 1, -1, 0, -1, 1, -1]
+hfb_on = [False, False, False, False, False, True, True, True, True]
 
 
 def build_models(idx, test):
@@ -81,10 +79,6 @@ def build_models(idx, test):
         filename=f"{name}.ims",
     )
     sim.register_ims_package(imsgwf, [gwf.name])
-    idomain = np.ones((nlay, nrow, ncol), dtype=int)
-    if idx == icell_inactive:
-        sim.simulation_data.verify_data = False
-        idomain[0, 0, 2] = 0
 
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
@@ -95,7 +89,7 @@ def build_models(idx, test):
         delc=delc,
         top=top,
         botm=botm,
-        idomain=idomain,
+        idomain=np.ones((nlay, nrow, ncol), dtype=int),
     )
 
     # initial conditions
@@ -168,8 +162,6 @@ def check_output(idx, test):
     answer_unconfined_hfb = (6.0, 5.99983342, 5.99966683, 4.00049971, 4.00024986, 4.0)
     answer_unconfined_hfb = np.array(answer_unconfined_hfb)
 
-    answer_hfb_inactive = (6.0, 6.0, 1.0e30, 4.0, 4.0, 4.0)
-
     answer_dict = {
         0: answer_linear,
         1: answer_linear,
@@ -180,7 +172,6 @@ def check_output(idx, test):
         6: answer_confined_thickstart_hfb,
         7: answer_unconfined_hfb,
         8: answer_unconfined_hfb,
-        9: answer_hfb_inactive,
     }
 
     hres = answer_dict[idx]
@@ -199,7 +190,6 @@ def check_output(idx, test):
         6: 1.9980e-03,
         7: 9.9949e-04,
         8: 9.9949e-04,
-        9: 0.0,
     }
     q_answer = q_answer_dict[idx]
     assert np.allclose(q_answer, q_simulated_inflow), (

--- a/autotest/test_gwf_npf_thickstrt.py
+++ b/autotest/test_gwf_npf_thickstrt.py
@@ -15,10 +15,12 @@ cases = [
     "gwf_npf_thickstrt07",  # icelltype=-1, using thickstrt, has hfb
     "gwf_npf_thickstrt08",  # icelltype=1, no thickstrt, has hfb
     "gwf_npf_thickstrt09",  # icelltype=-1, no thickstrt, has hfb
+    "gwf_npf_thickstrt10",  # icelltype=-1, no thickstrt, no hfb (cell (1,1,3) inactive)
 ]
-thickstrt = [False, True, True, False, False, False, True, False, False]
-icelltype = [0, 0, -1, 1, -1, 0, -1, 1, -1]
-hfb_on = [False, False, False, False, False, True, True, True, True]
+thickstrt = [False, True, True, False, False, False, True, False, False, False]
+icelltype = [0, 0, -1, 1, -1, 0, -1, 1, -1, -1]
+hfb_on = [False, False, False, False, False, True, True, True, True, True]
+icell_inactive = 9
 
 
 def build_models(idx, test):
@@ -79,6 +81,10 @@ def build_models(idx, test):
         filename=f"{name}.ims",
     )
     sim.register_ims_package(imsgwf, [gwf.name])
+    idomain = np.ones((nlay, nrow, ncol), dtype=int)
+    if idx == icell_inactive:
+        sim.simulation_data.verify_data = False
+        idomain[0, 0, 2] = 0
 
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
@@ -89,7 +95,7 @@ def build_models(idx, test):
         delc=delc,
         top=top,
         botm=botm,
-        idomain=np.ones((nlay, nrow, ncol), dtype=int),
+        idomain=idomain,
     )
 
     # initial conditions
@@ -162,6 +168,8 @@ def check_output(idx, test):
     answer_unconfined_hfb = (6.0, 5.99983342, 5.99966683, 4.00049971, 4.00024986, 4.0)
     answer_unconfined_hfb = np.array(answer_unconfined_hfb)
 
+    answer_hfb_inactive = (6.0, 6.0, 1.0e30, 4.0, 4.0, 4.0)
+
     answer_dict = {
         0: answer_linear,
         1: answer_linear,
@@ -172,6 +180,7 @@ def check_output(idx, test):
         6: answer_confined_thickstart_hfb,
         7: answer_unconfined_hfb,
         8: answer_unconfined_hfb,
+        9: answer_hfb_inactive,
     }
 
     hres = answer_dict[idx]
@@ -190,6 +199,7 @@ def check_output(idx, test):
         6: 1.9980e-03,
         7: 9.9949e-04,
         8: 9.9949e-04,
+        9: 0.0,
     }
     q_answer = q_answer_dict[idx]
     assert np.allclose(q_answer, q_simulated_inflow), (

--- a/autotest/test_gwf_vsc05_hfb.py
+++ b/autotest/test_gwf_vsc05_hfb.py
@@ -24,10 +24,11 @@ import numpy as np
 import pytest
 from framework import TestFramework
 
-cases = ["no-vsc05-hfb", "vsc05-hfb", "no-vsc05-k"]
+cases = ["no-vsc05-hfb", "vsc05-hfb", "no-vsc05-k", "hfb-idomain"]
 hyd_cond = [1205.49396942506, 864.0]  # Hydraulic conductivity (m/d)
-viscosity_on = [False, True, False]
-hydraulic_conductivity = [hyd_cond[0], hyd_cond[1], hyd_cond[1]]
+viscosity_on = [False, True, False, False]
+hydraulic_conductivity = [hyd_cond[0], hyd_cond[1], hyd_cond[1], hyd_cond[0]]
+icell_inactive = 3
 
 # Model units
 
@@ -102,6 +103,11 @@ def build_models(idx, test):
     )
     sim.register_ims_package(ims, [gwfname])
 
+    idomain = np.ones((nlay, nrow, ncol), dtype=int)
+    if idx == icell_inactive:
+        sim.simulation_data.verify_data = False
+        idomain[0, 7, 4] = 0
+
     # Instantiating DIS
     flopy.mf6.ModflowGwfdis(
         gwf,
@@ -113,6 +119,7 @@ def build_models(idx, test):
         delc=delc,
         top=top,
         botm=botm,
+        idomain=idomain,
     )
 
     # Instantiating NPF
@@ -225,6 +232,7 @@ def build_models(idx, test):
         delc=delc,
         top=top,
         botm=botm,
+        idomain=idomain,
     )
 
     # Instantiating MST for GWT
@@ -346,6 +354,17 @@ def check_output(idx, test):
         assert np.less(no_vsc_low_k_bud_last[:, 2], stored_ans[:, 2]).all(), (
             "Exit flow from model the established answer "
             "should be greater than flow existing " + cases[2] + ", but it is not."
+        )
+    elif idx == 3:
+        cell_inactive_vals = np.array(vals_to_store)
+
+        # Ensure HFB inactive cell (1,8,5) cell-to-cell flows
+        # have been excluded
+        assert np.allclose(
+            cell_inactive_vals[:, 0], [4, 14, 24, 34, 44, 54, 64, 84, 94]
+        )
+        assert np.allclose(
+            cell_inactive_vals[:, 1], [5, 15, 25, 35, 45, 55, 65, 85, 95]
         )
 
 

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -51,4 +51,4 @@ description = "Add HIGHEST\\_CELL\\_SATURATION option that changes how the satur
 [[items]]
 section = "fixes"
 subsection = "internal"
-description = "Fixed HFB behavior when a horizontal flow barrier is configured for a cell pair that includes an inactive cell. Previously the connection was excluded but not adjusted for in the defined number of horizontal flow barriers, which can lead to a segmentation fault. A workaround is to only define horizontal flow barriers for active cells. New behavior excludes the connection but adds a warning when an exclusion applies, and adjusts the number of horizontal flow barriers accordingly."
+description = "Fixed HFB behavior when a horizontal flow barrier is configured for a cell pair that includes an inactive cell. Previously the connection was excluded but not adjusted for in the defined number of horizontal flow barriers, which can lead to a segmentation fault. A workaround is to only define horizontal flow barriers for active cells. New behavior excludes the connection and adds a warning when an exclusion applies, and also adjusts the number of horizontal flow barriers accordingly."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -47,3 +47,8 @@ description = "Fixed the DEWATERED VARIABLECV option. Previously, the saturation
 section = "features"
 subsection = "internal"
 description = "Add HIGHEST\\_CELL\\_SATURATION option that changes how the saturation used to calculate the flow between two horizontally connected cell. The HIGHEST\\_CELL\\_SATURATION option uses the maximum cell bottom to calculate the saturation used to calculate the horizontal conductance between cells. This option is intended to prevent flow from leaving a dry cell. This option is only applied when the Newton-Raphson formulation is used, A warning will be issued if this option is specified and the Newton-Raphson formulation is not specified in the GWF name file. This option, in combination with the AMT-HMK ALTERNATIVE\\_CELL\\_AVERAGING option, can be used to calculate the same horizontal conductance as MODFLOW-USG when upstream weighting is used (LAYCON=4)."
+
+[[items]]
+section = "fixes"
+subsection = "internal"
+description = "Fixed HFB behavior when a horizontal flow barrier is configured for a cell pair that includes an inactive cell. Previously the connection was excluded but not adjusted for in the defined number of horizontal flow barriers, which can lead to a segmentation fault. A workaround is to only define horizontal flow barriers for active cells. New behavior excludes the connection but adds a warning when an exclusion applies, and adjusts the number of horizontal flow barriers accordingly."

--- a/src/Model/GroundWaterFlow/gwf-hfb.f90
+++ b/src/Model/GroundWaterFlow/gwf-hfb.f90
@@ -653,7 +653,7 @@ contains
           noder2 <= 0) then
         call this%dis%nodeu_to_string(nodeu1, node1str)
         call this%dis%nodeu_to_string(nodeu2, node2str)
-        write (warnmsg, '(a,i0,a,i0,a)') &
+        write (warnmsg, '(a)') &
             'HFB connection between inactive cell(s) will be excluded: '&
             &//trim(node1str)//' to '//trim(node2str)//'.'
         call store_warning(warnmsg)

--- a/src/Model/GroundWaterFlow/gwf-hfb.f90
+++ b/src/Model/GroundWaterFlow/gwf-hfb.f90
@@ -618,7 +618,7 @@ contains
     end if
 
     ! update state
-    do n = 1, this%nhfb
+    do n = 1, nbound
 
       ! set cellid
       cellid1 => cellids1(:, n)

--- a/src/Model/GroundWaterFlow/gwf-hfb.f90
+++ b/src/Model/GroundWaterFlow/gwf-hfb.f90
@@ -583,6 +583,8 @@ contains
   subroutine source_data(this)
     ! -- modules
     use TdisModule, only: kper
+    use SimVariablesModule, only: warnmsg
+    use SimModule, only: store_warning
     use ConstantsModule, only: LINELENGTH
     use MemoryManagerModule, only: mem_setptr
     use GeomUtilModule, only: get_node
@@ -648,6 +650,11 @@ contains
       noder2 = this%dis%get_nodenumber(nodeu2, 1)
       if (noder1 <= 0 .or. &
           noder2 <= 0) then
+        write (warnmsg, '(a,i0,a,i0,a)') &
+            'HFB connection between inactive cell(s) will be excluded. &
+            &Excluded node pair: ', nodeu1, ' and ', nodeu2, '.'
+        call store_warning(warnmsg)
+        this%nhfb = this%nhfb - 1
         cycle
       else
         this%noden(n) = noder1

--- a/src/Model/GroundWaterFlow/gwf-hfb.f90
+++ b/src/Model/GroundWaterFlow/gwf-hfb.f90
@@ -597,6 +597,7 @@ contains
     character(len=LINELENGTH) :: nodenstr, nodemstr
     integer(I4B), pointer :: nbound
     integer(I4B) :: n, nodeu1, nodeu2, noder1, noder2
+    character(len=20) :: node1str, node2str
     ! -- formats
     character(len=*), parameter :: fmthfb = "(i10, 2a10, 1(1pg15.6))"
 
@@ -650,9 +651,11 @@ contains
       noder2 = this%dis%get_nodenumber(nodeu2, 1)
       if (noder1 <= 0 .or. &
           noder2 <= 0) then
+        call this%dis%nodeu_to_string(nodeu1, node1str)
+        call this%dis%nodeu_to_string(nodeu2, node2str)
         write (warnmsg, '(a,i0,a,i0,a)') &
-            'HFB connection between inactive cell(s) will be excluded. &
-            &Excluded node pair: ', nodeu1, ' and ', nodeu2, '.'
+            'HFB connection between inactive cell(s) will be excluded: '&
+            &//trim(node1str)//' to '//trim(node2str)//'.'
         call store_warning(warnmsg)
         this%nhfb = this%nhfb - 1
         cycle

--- a/src/Model/GroundWaterFlow/gwf-hfb.f90
+++ b/src/Model/GroundWaterFlow/gwf-hfb.f90
@@ -596,7 +596,7 @@ contains
     real(DP), dimension(:), pointer, contiguous :: hydchr
     character(len=LINELENGTH) :: nodenstr, nodemstr
     integer(I4B), pointer :: nbound
-    integer(I4B) :: n, nodeu1, nodeu2, noder1, noder2
+    integer(I4B) :: n, nodeu1, nodeu2, noder1, noder2, hfbno
     character(len=20) :: node1str, node2str
     ! -- formats
     character(len=*), parameter :: fmthfb = "(i10, 2a10, 1(1pg15.6))"
@@ -606,6 +606,9 @@ contains
     call mem_setptr(cellids1, 'CELLID1', this%input_mempath)
     call mem_setptr(cellids2, 'CELLID2', this%input_mempath)
     call mem_setptr(hydchr, 'HYDCHR', this%input_mempath)
+
+    ! initialize hfb number
+    hfbno = 0
 
     ! set nhfb
     this%nhfb = nbound
@@ -659,19 +662,20 @@ contains
         call store_warning(warnmsg)
         this%nhfb = this%nhfb - 1
         cycle
-      else
-        this%noden(n) = noder1
-        this%nodem(n) = noder2
       end if
 
-      this%hydchr(n) = hydchr(n)
+      ! add hfb
+      hfbno = hfbno + 1
+      this%noden(hfbno) = noder1
+      this%nodem(hfbno) = noder2
+      this%hydchr(hfbno) = hydchr(n)
 
       ! print input if requested
       if (this%iprpak /= 0) then
-        call this%dis%noder_to_string(this%noden(n), nodenstr)
-        call this%dis%noder_to_string(this%nodem(n), nodemstr)
-        write (this%iout, fmthfb) n, trim(adjustl(nodenstr)), &
-          trim(adjustl(nodemstr)), this%hydchr(n)
+        call this%dis%noder_to_string(this%noden(hfbno), nodenstr)
+        call this%dis%noder_to_string(this%nodem(hfbno), nodemstr)
+        write (this%iout, fmthfb) hfbno, trim(adjustl(nodenstr)), &
+          trim(adjustl(nodemstr)), this%hydchr(hfbno)
       end if
     end do
 


### PR DESCRIPTION
Currently, if a horizontal flow barrier includes an inactive cell this connection is excluded but not adjusted for in the number of HFB's defined.  This can lead to segmentation faults when HFB connections are defined for inactive cells.   This fix adjusts the accounting but also sets a warning when an HFB connection is excluded.

Note: currently FloPy will not write an HFB package file when a horizontal flow barrier connection has an inactive cell, unless data verification is disabled, i.e.: `sim.simulation_data.verify_data = False`.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Added new test or modified an existing test
- [X] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
