### PR TITLE
fix(csub, prp): set error for configured inactive cell

### DIFF
--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -1209,6 +1209,7 @@ contains
     real(DP), dimension(:), pointer, contiguous :: ssv_cc, sse_cr, theta, kv, h0
     character(len=LINELENGTH) :: cdelaystr
     character(len=LENBOUNDNAME) :: bndname
+    character(len=20) :: cellidstr
     real(DP) :: top, botm, baq, q, thick, rval
     integer(I4B) :: idelay, ndelaybeds, csubno
     integer(I4B) :: ib, n, nodeu, noder
@@ -1265,6 +1266,11 @@ contains
       ! -- set node reduced
       noder = this%dis%get_nodenumber(nodeu, 1)
       if (noder <= 0) then
+        call this%dis%nodeu_to_string(nodeu, cellidstr)
+        write (errmsg, '(a)') &
+          'CSUB configured for inactive cell: '// &
+          trim(adjustl(cellidstr))//'.'
+        call store_error(errmsg)
         cycle
       end if
 
@@ -1534,6 +1540,10 @@ contains
       call this%csub_print_packagedata()
     end if
 
+    ! -- terminate if errors encountered
+    if (count_errors() > 0) then
+      call store_error_filename(this%input_fname)
+    end if
   end subroutine csub_source_packagedata
 
   !> @ brief Print packagedata

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -889,6 +889,7 @@ contains
       contiguous :: boundnames
     character(len=LENBOUNDNAME) :: bndName, bndNameTemp
     character(len=9) :: cno
+    character(len=20) :: cellidstr
     integer(I4B), dimension(:), allocatable :: nboundchk
     integer(I4B), dimension(:), pointer :: cellid
     integer(I4B) :: n, noder, nodeu, rptno
@@ -945,6 +946,11 @@ contains
       ! set noder
       noder = this%dis%get_nodenumber(nodeu, 1)
       if (noder <= 0) then
+        call this%dis%nodeu_to_string(nodeu, cellidstr)
+        write (errmsg, '(a)') &
+          'Particle release point configured for inactive cell: '// &
+          trim(adjustl(cellidstr))//'.'
+        call store_error(errmsg)
         cycle
       else
         this%rptnode(rptno) = noder


### PR DESCRIPTION
Set an error and terminate:
  - when CSUB is configured for inactive cell
  - when a particle release point is configured for an inactive cell

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
