### PR TITLE
chore(pixi): update project -> workspace

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "modflow6"
 channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "linux-aarch64", "osx-arm64", "osx-64"]


### PR DESCRIPTION
as of pixi 0.57 the `project` section is deprecated in favor of `workspace` https://pixi.sh/latest/CHANGELOG/#0570-2025-10-20