### PR TITLE
ci: fall back to ifort 2021.6 on macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       FC: intel-classic
-      FC_V: "2021.7"
+      FC_V: "2021.6"
     strategy:
       fail-fast: false
       matrix:
@@ -629,7 +629,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
     defaults:
       run:
         shell: bash
@@ -662,7 +662,7 @@ jobs:
         run: pixi run pip install xugrid xarray netcdf4
 
       - name: Set LDFLAGS (macOS)
-        if: matrix.os == 'macos-13'
+        if: runner.os == 'macOS'
         run: |
           os_ver=$(sw_vers -productVersion | cut -d'.' -f1)
           if (( "$os_ver" > 12 )); then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,7 +629,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-2022]
+        os: [ubuntu-22.04, macos-13, windows-2022]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/large.yml
+++ b/.github/workflows/large.yml
@@ -19,8 +19,8 @@ jobs:
         include:
           # this combo is for windows parallel oneapi components (compilers + mkl/mpi) and petsc
           - {os: windows-2022, compiler: intel, version: 2024.0}
-          # ifort 2021.7 currently used for all other CI testing
-          - {os: windows-2022, compiler: intel-classic, version: 2021.7}
+          # ifort 2021.6 currently used for all other CI testing
+          - {os: windows-2022, compiler: intel-classic, version: 2021.6}
     steps:
       - name: Setup ${{ matrix.compiler }} ${{ matrix.version }}
         if: (!(matrix.compiler == 'intel' && matrix.version == '2024.0'))
@@ -46,7 +46,7 @@ jobs:
       matrix:
         include:
           - {compiler: gcc, version: 13}
-          - {compiler: intel-classic, version: 2021.7}
+          - {compiler: intel-classic, version: 2021.6}
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
         description: 'Compiler version to use. For supported options see https://github.com/MODFLOW-ORG/modflow6/blob/develop/DEVELOPER.md#compiler-compatibility.'
         required: false
         type: string
-        default: '2021.7'
+        default: '2021.6'
       releasemode:
         description: 'Build a full distribution containing sources, examples, and all documentation. If false, the distribution contains only binaries, mf6io, release notes, and code.json, with binaries built in develop mode, and disclaimers & version strings indicating preliminary/provisional status. If true, a full distribution is created, with binaries built in release mode, and disclaimer language indicating review and approval.'
         required: false
@@ -81,7 +81,7 @@ jobs:
             extended: false
           - os: windows-2022
             compiler: intel-classic
-            version: "2021.7"
+            version: "2021.6"
             optimization: 2
             extended: true
     defaults:

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -33,7 +33,7 @@ on:
         description: 'Compiler version to use. For supported options see https://github.com/MODFLOW-ORG/modflow6/blob/develop/DEVELOPER.md#compiler-compatibility.'
         required: false
         type: string
-        default: '2021.7'
+        default: '2021.6'
       developmode:
         description: 'Build binaries in develop mode. If false, IDEVELOPMODE is set to 0.'
         required: false
@@ -111,7 +111,7 @@ jobs:
           elif [[ ("${{ github.event_name }}" == "push") && ("${{ github.ref_name }}" != "master") ]]; then
             # if release was triggered by pushing a release branch, use the default toolchain and version
             compiler_toolchain="intel-classic"
-            compiler_version="2021.7"
+            compiler_version="2021.6"
             echo "using default compiler toolchain $compiler_toolchain version $compiler_version"
           else
             # otherwise exit with an error


### PR DESCRIPTION
As mentioned in #2575 we [lost ifort 2021.7 on macOS](https://github.com/fortran-lang/setup-fortran/pull/165/files#diff-55e31fb1b15d71f329723e36a03a839c3b3700d5a07fafe4294a049144c94d79R17), this is a temporary stopgap til we move to ifx.

Now is the time to drop the macos-13 (intel mac) distribution entirely though. To keep it after the move to ifx we'd have to convert it to gfortran like the apple silicon distribution, and in any case [github will retire macos-13 soon anyway](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/).