### PR TITLE
test: mark some extended/netcdf tests developmode

### DIFF
--- a/autotest/test_netcdf_gwf_disv.py
+++ b/autotest/test_netcdf_gwf_disv.py
@@ -241,6 +241,7 @@ def check_output(idx, test, gridded_input):
 
 
 @pytest.mark.netcdf
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.parametrize("gridded_input", ["ascii", "netcdf"])
 def test_mf6model(idx, name, function_tmpdir, targets, gridded_input):

--- a/autotest/test_netcdf_gwf_sto01.py
+++ b/autotest/test_netcdf_gwf_sto01.py
@@ -280,6 +280,7 @@ def check_output(idx, test, export, gridded_input):
 
 
 @pytest.mark.netcdf
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.parametrize("export", ["ugrid", "structured"])
 @pytest.mark.parametrize("gridded_input", ["ascii", "netcdf"])


### PR DESCRIPTION
These use the CRS functionality which is still feature flagged. Fix the [nightly build](https://github.com/MODFLOW-ORG/modflow6-nightly-build/actions/runs/18909769034/job/53979453458#step:23:16855)