### PR TITLE
fix(gwe-esl): aux multiplier has hooks but no functionality

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -62,3 +62,8 @@ description = "Setting PRECONDITIONER\\_DROP\\_TOLERANCE in the IMS Linear block
 section = "fixes"
 subsection = "model"
 description = "Balanced the PRT model mass budget with a new term to accumulate mass of terminated particles. Previously particle mass remained in storage regardless of particle status, leaving the particle mass budget unbalanced at the end of the simulation. Also, report cell-by-cell mass storage in the binary budget file; only cumulative mass storage was reported in the list file previously."
+
+[[items]]
+section = "fixes"
+subsection = "stress packages"
+description = "The OPTIONS block in the Energy Source Loading (ESL) Package accepted the AUXILIARY and AUXMULTNAME keywords; however, they had no effect on the GWE solution.  The ESL code was fixed such that when the AUXMULTCOL keyword is invoked, the user-specified amount of energy added or removed from cells will be multiplied by whatever value the user supplies in the corresponding AUXILIARY column." 

--- a/src/Model/GroundWaterEnergy/gwe-esl.f90
+++ b/src/Model/GroundWaterEnergy/gwe-esl.f90
@@ -32,7 +32,6 @@ module GweEslModule
     procedure :: bnd_da => esl_da
     procedure :: define_listlabel
     procedure :: bound_value => esl_bound_value
-    procedure :: ener_mult
     ! -- methods for observations
     procedure, public :: bnd_obs_supported => esl_obs_supported
     procedure, public :: bnd_df_obs => esl_df_obs

--- a/src/Model/GroundWaterEnergy/gwe-esl.f90
+++ b/src/Model/GroundWaterEnergy/gwe-esl.f90
@@ -150,7 +150,7 @@ contains
     integer(I4B) :: node
     ! -- formats
     character(len=*), parameter :: fmtenermulterr = &
-      "('DRN BOUNDARY (',i0,') ESL MULTIPLIER (',g10.3,') IS &
+      "('ESL BOUNDARY (',i0,') ESL MULTIPLIER (',g10.3,') IS &
       &LESS THAN ZERO')"
     !
     ! -- check stress period data

--- a/src/Model/GroundWaterEnergy/gwe-esl.f90
+++ b/src/Model/GroundWaterEnergy/gwe-esl.f90
@@ -2,6 +2,8 @@ module GweEslModule
   !
   use KindModule, only: DP, I4B
   use ConstantsModule, only: DZERO, DEM1, DONE, LENFTYPE
+  use SimVariablesModule, only: errmsg
+  use SimModule, only: count_errors, store_error, store_error_filename
   use BndExtModule, only: BndExtType
   use ObsModule, only: DefaultObsIdProcessor
   use GweInputDataModule, only: GweInputDataType
@@ -25,10 +27,12 @@ module GweEslModule
     procedure :: allocate_scalars => esl_allocate_scalars
     procedure :: allocate_arrays => esl_allocate_arrays
     procedure :: bnd_cf => esl_cf
+    procedure :: bnd_ck => esl_ck
     procedure :: bnd_fc => esl_fc
     procedure :: bnd_da => esl_da
     procedure :: define_listlabel
     procedure :: bound_value => esl_bound_value
+    procedure :: ener_mult
     ! -- methods for observations
     procedure, public :: bnd_obs_supported => esl_obs_supported
     procedure, public :: bnd_df_obs => esl_df_obs
@@ -136,6 +140,42 @@ contains
                      'SENERRATE', this%input_mempath)
   end subroutine esl_allocate_arrays
 
+  !> @brief Check drain boundary condition data
+  !<
+  subroutine esl_ck(this)
+    ! -- dummy
+    class(GweEslType), intent(inout) :: this
+    ! -- local
+    integer(I4B) :: i
+    integer(I4B) :: node
+    real(DP) :: drndepth
+    real(DP) :: drntop
+    real(DP) :: drnbot
+    ! -- formats
+    character(len=*), parameter :: fmtenermulterr = &
+      "('DRN BOUNDARY (',i0,') ESL MULTIPLIER (',g10.3,') IS &
+      &LESS THAN ZERO')"
+    !
+    ! -- check stress period data
+    do i = 1, this%nbound
+      node = this%nodelist(i)
+      !
+      ! -- accumulate errors
+      if (this%iauxmultcol > 0) then
+        if (this%auxvar(this%iauxmultcol, i) < DZERO) then
+          write (errmsg, fmt=fmtenermulterr) &
+            i, this%auxvar(this%iauxmultcol, i)
+          call store_error(errmsg)
+        end if
+      end if
+    end do
+    !
+    ! -- write summary of energy source loading package error messages
+    if (count_errors() > 0) then
+      call store_error_filename(this%input_fname)
+    end if
+  end subroutine esl_ck
+  
   !> @brief Formulate the HCOF and RHS terms
   !!
   !! This subroutine:
@@ -148,6 +188,7 @@ contains
     ! -- local
     integer(I4B) :: i, node
     real(DP) :: q
+    real(DP) :: ener_esl
     !
     ! -- Return if no sources
     if (this%nbound == 0) return
@@ -160,6 +201,10 @@ contains
         this%rhs(i) = DZERO
         cycle
       end if
+      !
+      ! -- set energy loading rate accounting for multiplier
+      ener_esl = this%ener_mult(i)
+      
       q = this%bound_value(1, i)
       this%rhs(i) = -q
     end do
@@ -285,5 +330,26 @@ contains
     case default
     end select
   end function esl_bound_value
+
+  !> @brief Return a multiplier value
+  !!
+  !! Apply multiplier to specified energy load depending on user-selected
+  !! option
+  !<
+  function ener_mult(this, row) result(ener)
+    ! -- modules
+    use ConstantsModule, only: DZERO
+    ! -- dummy variables
+    class(GweEslType), intent(inout) :: this !< BndExtType object
+    integer(I4B), intent(in) :: row
+    ! -- result
+    real(DP) :: ener
+    !
+    if (this%iauxmultcol > 0) then
+      ener = this%senerrate(row) * this%auxvar(this%iauxmultcol, row)
+    else
+      ener = this%senerrate(row)
+    end if
+  end function ener_mult
 
 end module GweEslModule

--- a/src/Model/GroundWaterEnergy/gwe-esl.f90
+++ b/src/Model/GroundWaterEnergy/gwe-esl.f90
@@ -2,8 +2,8 @@ module GweEslModule
   !
   use KindModule, only: DP, I4B
   use ConstantsModule, only: DZERO, DEM1, DONE, LENFTYPE
-  use SimVariablesModule, only: errmsg
-  use SimModule, only: count_errors, store_error, store_error_filename
+  use SimVariablesModule, only: warnmsg
+  use SimModule, only: store_warning
   use BndExtModule, only: BndExtType
   use ObsModule, only: DefaultObsIdProcessor
   use GweInputDataModule, only: GweInputDataType
@@ -151,26 +151,23 @@ contains
     ! -- formats
     character(len=*), parameter :: fmtenermulterr = &
       "('ESL BOUNDARY (',i0,') ESL MULTIPLIER (',g10.3,') IS &
-      &LESS THAN ZERO')"
+      &LESS THAN ZERO THEREBY REVERSING THE ORIGINAL SIGN ON THE &
+      &AMOUNT OF ENERGY ENTERING OR EXITING THE MODEL.')"
     !
     ! -- check stress period data
     do i = 1, this%nbound
       node = this%nodelist(i)
       !
-      ! -- accumulate errors
+      ! -- accumulate warnings
       if (this%iauxmultcol > 0) then
         if (this%auxvar(this%iauxmultcol, i) < DZERO) then
-          write (errmsg, fmt=fmtenermulterr) &
+          write (warnmsg, fmt=fmtenermulterr) &
             i, this%auxvar(this%iauxmultcol, i)
-          call store_error(errmsg)
+          call store_warning(warnmsg)
+          write (this%iout, '(/1x,a)') 'WARNING: '//trim(warnmsg)
         end if
       end if
     end do
-    !
-    ! -- write summary of energy source loading package error messages
-    if (count_errors() > 0) then
-      call store_error_filename(this%input_fname)
-    end if
   end subroutine esl_ck
 
   !> @brief Formulate the HCOF and RHS terms

--- a/src/Model/GroundWaterEnergy/gwe-esl.f90
+++ b/src/Model/GroundWaterEnergy/gwe-esl.f90
@@ -32,6 +32,7 @@ module GweEslModule
     procedure :: bnd_da => esl_da
     procedure :: define_listlabel
     procedure :: bound_value => esl_bound_value
+    procedure :: ener_mult
     ! -- methods for observations
     procedure, public :: bnd_obs_supported => esl_obs_supported
     procedure, public :: bnd_df_obs => esl_df_obs
@@ -147,9 +148,6 @@ contains
     ! -- local
     integer(I4B) :: i
     integer(I4B) :: node
-    real(DP) :: drndepth
-    real(DP) :: drntop
-    real(DP) :: drnbot
     ! -- formats
     character(len=*), parameter :: fmtenermulterr = &
       "('DRN BOUNDARY (',i0,') ESL MULTIPLIER (',g10.3,') IS &

--- a/src/Model/GroundWaterEnergy/gwe-esl.f90
+++ b/src/Model/GroundWaterEnergy/gwe-esl.f90
@@ -139,7 +139,7 @@ contains
                      'SENERRATE', this%input_mempath)
   end subroutine esl_allocate_arrays
 
-  !> @brief Check drain boundary condition data
+  !> @brief Check energy source loading boundary condition data
   !<
   subroutine esl_ck(this)
     ! -- dummy

--- a/src/Model/GroundWaterEnergy/gwe-esl.f90
+++ b/src/Model/GroundWaterEnergy/gwe-esl.f90
@@ -175,7 +175,7 @@ contains
       call store_error_filename(this%input_fname)
     end if
   end subroutine esl_ck
-  
+
   !> @brief Formulate the HCOF and RHS terms
   !!
   !! This subroutine:
@@ -188,7 +188,6 @@ contains
     ! -- local
     integer(I4B) :: i, node
     real(DP) :: q
-    real(DP) :: ener_esl
     !
     ! -- Return if no sources
     if (this%nbound == 0) return
@@ -203,9 +202,8 @@ contains
       end if
       !
       ! -- set energy loading rate accounting for multiplier
-      ener_esl = this%ener_mult(i)
-      
-      q = this%bound_value(1, i)
+      q = this%ener_mult(i)
+      !
       this%rhs(i) = -q
     end do
   end subroutine esl_cf

--- a/src/Model/GroundWaterEnergy/gwe-esl.f90
+++ b/src/Model/GroundWaterEnergy/gwe-esl.f90
@@ -326,7 +326,7 @@ contains
     end select
   end function esl_bound_value
 
-  !> @brief Return a multiplier value
+  !> @brief Return a value that applies a multiplier
   !!
   !! Apply multiplier to specified energy load depending on user-selected
   !! option


### PR DESCRIPTION
Even though AUXILIARY and AUXMULTNAME keywords could be specified in the OPTIONS block of the ESL input file, the source code didn't do anything with them.  

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Addresses issue #2577 
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
