### PR TITLE
fix(gwt-src): aux multiplier has hooks but no functionality

### DIFF
--- a/autotest/test_gwt_src01.py
+++ b/autotest/test_gwt_src01.py
@@ -18,6 +18,7 @@ xt3d = [False, False]
 
 mass_mult = 2.0
 
+
 def build_models(idx, test):
     nlay, nrow, ncol = 1, 1, 100
     nper = 1
@@ -214,7 +215,7 @@ def build_models(idx, test):
             stress_period_data=srcs,
             save_flows=False,
             pname="SRC-1",
-        )        
+        )
 
     # mobile storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
@@ -256,7 +257,7 @@ def check_output(idx, test):
     # steady state and calculated from F = D * (c1 - c2) / L
     cres = np.linspace(9.9, 0, 100).reshape(conc.shape)
     if idx > 0:
-    	cres *= mass_mult
+        cres *= mass_mult
     assert np.allclose(cres, conc), (
         "simulated concentrations do not match with known solution."
     )

--- a/autotest/test_gwt_src01.py
+++ b/autotest/test_gwt_src01.py
@@ -13,9 +13,10 @@ import numpy as np
 import pytest
 from framework import TestFramework
 
-cases = ["src01a"]
-xt3d = [False]
+cases = ["src01a", "srcmult"]
+xt3d = [False, False]
 
+mass_mult = 2.0
 
 def build_models(idx, test):
     nlay, nrow, ncol = 1, 1, 100
@@ -194,14 +195,26 @@ def build_models(idx, test):
     )
 
     # mass loading source
-    srcs = {0: [[(0, 0, 0), 1.0]]}
-    src = flopy.mf6.ModflowGwtsrc(
-        gwt,
-        maxbound=len(srcs),
-        stress_period_data=srcs,
-        save_flows=False,
-        pname="SRC-1",
-    )
+    if idx == 0:
+        srcs = {0: [[(0, 0, 0), 1.0]]}
+        src = flopy.mf6.ModflowGwtsrc(
+            gwt,
+            maxbound=len(srcs),
+            stress_period_data=srcs,
+            save_flows=False,
+            pname="SRC-1",
+        )
+    elif idx > 0:
+        srcs = {0: [[(0, 0, 0), 1.0, mass_mult]]}
+        src = flopy.mf6.ModflowGwtsrc(
+            gwt,
+            auxiliary=["multiplier"],
+            auxmultname="multiplier",
+            maxbound=len(srcs),
+            stress_period_data=srcs,
+            save_flows=False,
+            pname="SRC-1",
+        )        
 
     # mobile storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
@@ -242,6 +255,8 @@ def check_output(idx, test):
     # This is the answer to this problem.  These concentrations are for
     # steady state and calculated from F = D * (c1 - c2) / L
     cres = np.linspace(9.9, 0, 100).reshape(conc.shape)
+    if idx > 0:
+    	cres *= mass_mult
     assert np.allclose(cres, conc), (
         "simulated concentrations do not match with known solution."
     )

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -67,3 +67,8 @@ description = "Balanced the PRT model mass budget with a new term to accumulate 
 section = "fixes"
 subsection = "stress packages"
 description = "The OPTIONS block in the Energy Source Loading (ESL) Package accepted the AUXILIARY and AUXMULTNAME keywords; however, they had no effect on the GWE solution.  The ESL code was fixed such that when the AUXMULTCOL keyword is invoked, the user-specified amount of energy added or removed from cells will be multiplied by whatever value the user supplies in the corresponding AUXILIARY column." 
+
+[[items]]
+section = "fixes"
+subsection = "stress packages"
+description = "The OPTIONS block in the Mass Source Loading (SRC) Package accepted the AUXILIARY and AUXMULTNAME keywords; however, they had no effect on the GWT solution.  The SRC package was fixed such that when the AUXMULTCOL keyword is invoked, the user-specified amount of energy added or removed from cells will be multiplied by the value supplied by the user in the corresponding AUXILIARY column." 

--- a/src/Model/GroundWaterTransport/gwt-src.f90
+++ b/src/Model/GroundWaterTransport/gwt-src.f90
@@ -2,6 +2,8 @@ module GwtSrcModule
   !
   use KindModule, only: DP, I4B, LGP
   use ConstantsModule, only: DZERO, DEM1, DONE, LENFTYPE, LENVARNAME
+  use SimVariablesModule, only: errmsg
+  use SimModule, only: count_errors, store_error, store_error_filename
   use TspFmiModule, only: TspFmiType
   use BndExtModule, only: BndExtType
   use ObsModule, only: DefaultObsIdProcessor
@@ -30,11 +32,13 @@ module GwtSrcModule
     procedure :: source_options => src_options
     procedure :: bnd_rp => src_rp
     procedure :: bnd_cf => src_cf
+    procedure :: bnd_ck => src_ck
     procedure :: bnd_fc => src_fc
     procedure :: bnd_da => src_da
     procedure :: define_listlabel
     procedure :: set_nodesontop
     procedure :: bound_value => src_bound_value
+    procedure :: mass_mult
     ! -- methods for observations
     procedure, public :: bnd_obs_supported => src_obs_supported
     procedure, public :: bnd_df_obs => src_df_obs
@@ -197,8 +201,40 @@ contains
         this%nodesontop(n) = 0
       end do
     end if
-
   end subroutine src_allocate_arrays
+  
+  !> @brief Check mass source loading boundary condition data
+  !<
+  subroutine src_ck(this)
+    ! -- dummy
+    class(GwtSrcType), intent(inout) :: this
+    ! -- local
+    integer(I4B) :: i
+    integer(I4B) :: node
+    ! -- formats
+    character(len=*), parameter :: fmtenermulterr = &
+      "('SRC BOUNDARY (',i0,') SRC MULTIPLIER (',g10.3,') IS &
+      &LESS THAN ZERO')"
+    !
+    ! -- check stress period data
+    do i = 1, this%nbound
+      node = this%nodelist(i)
+      !
+      ! -- accumulate errors
+      if (this%iauxmultcol > 0) then
+        if (this%auxvar(this%iauxmultcol, i) < DZERO) then
+          write (errmsg, fmt=fmtenermulterr) &
+            i, this%auxvar(this%iauxmultcol, i)
+          call store_error(errmsg)
+        end if
+      end if
+    end do
+    !
+    ! -- write summary of energy source loading package error messages
+    if (count_errors() > 0) then
+      call store_error_filename(this%input_fname)
+    end if
+  end subroutine src_ck
 
   subroutine src_rp(this)
     ! -- modules
@@ -268,7 +304,10 @@ contains
         this%rhs(i) = DZERO
         cycle
       end if
-      q = this%bound_value(1, i)
+      !
+      ! -- set energy loading rate accounting for multiplier
+      q = this%mass_mult(i)
+      !
       this%rhs(i) = -q
     end do
   end subroutine src_cf
@@ -394,4 +433,24 @@ contains
     end select
   end function src_bound_value
 
+  !> @brief Return a value that applies a multiplier
+  !!
+  !! Apply multiplier to specified mass-source load depending on user-selected
+  !! option
+  !<
+  function mass_mult(this, row) result(ener)
+    ! -- modules
+    use ConstantsModule, only: DZERO
+    ! -- dummy variables
+    class(GwtSrcType), intent(inout) :: this !< BndExtType object
+    integer(I4B), intent(in) :: row
+    ! -- result
+    real(DP) :: ener
+    !
+    if (this%iauxmultcol > 0) then
+      ener = this%smassrate(row) * this%auxvar(this%iauxmultcol, row)
+    else
+      ener = this%smassrate(row)
+    end if
+  end function mass_mult
 end module GwtSrcModule

--- a/src/Model/GroundWaterTransport/gwt-src.f90
+++ b/src/Model/GroundWaterTransport/gwt-src.f90
@@ -202,7 +202,7 @@ contains
       end do
     end if
   end subroutine src_allocate_arrays
-  
+
   !> @brief Check mass source loading boundary condition data
   !<
   subroutine src_ck(this)

--- a/src/Model/GroundWaterTransport/gwt-src.f90
+++ b/src/Model/GroundWaterTransport/gwt-src.f90
@@ -32,7 +32,6 @@ module GwtSrcModule
     procedure :: source_options => src_options
     procedure :: bnd_rp => src_rp
     procedure :: bnd_cf => src_cf
-    procedure :: bnd_ck => src_ck
     procedure :: bnd_fc => src_fc
     procedure :: bnd_da => src_da
     procedure :: define_listlabel
@@ -202,39 +201,6 @@ contains
       end do
     end if
   end subroutine src_allocate_arrays
-
-  !> @brief Check mass source loading boundary condition data
-  !<
-  subroutine src_ck(this)
-    ! -- dummy
-    class(GwtSrcType), intent(inout) :: this
-    ! -- local
-    integer(I4B) :: i
-    integer(I4B) :: node
-    ! -- formats
-    character(len=*), parameter :: fmtenermulterr = &
-      "('SRC BOUNDARY (',i0,') SRC MULTIPLIER (',g10.3,') IS &
-      &LESS THAN ZERO')"
-    !
-    ! -- check stress period data
-    do i = 1, this%nbound
-      node = this%nodelist(i)
-      !
-      ! -- accumulate errors
-      if (this%iauxmultcol > 0) then
-        if (this%auxvar(this%iauxmultcol, i) < DZERO) then
-          write (errmsg, fmt=fmtenermulterr) &
-            i, this%auxvar(this%iauxmultcol, i)
-          call store_error(errmsg)
-        end if
-      end if
-    end do
-    !
-    ! -- write summary of energy source loading package error messages
-    if (count_errors() > 0) then
-      call store_error_filename(this%input_fname)
-    end if
-  end subroutine src_ck
 
   subroutine src_rp(this)
     ! -- modules


### PR DESCRIPTION
Even though AUXILIARY and AUXMULTNAME keywords could be specified in the OPTIONS block of the SRC input file, the source code didn't do anything with them.

- [x] Replaced section above with description of pull request
- [x] Similar to #2597 
- [x] Motivated by issue #2577 
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
