### PR TITLE
fix(npf): fix newton under_relaxation in confined cells

### DIFF
--- a/autotest/test_gwf_nur02.py
+++ b/autotest/test_gwf_nur02.py
@@ -1,0 +1,119 @@
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = ["nur-pr2606"]
+nper = 1
+nlay = 2
+nrow = 1
+ncol = 11
+xlen = 1000.0
+ylen = 1000.0
+top = 25.0
+k11 = 1.0
+H1 = 7.5
+H2 = 7.5
+delr = xlen / float(ncol)
+delc = ylen / float(nrow)
+extents = (0, xlen, 0, ylen)
+shape2d = (nrow, ncol)
+shape3d = (nlay, nrow, ncol)
+nouter = 75
+ninner = 100
+hclose = 1e-9
+hclose_outer = hclose * 10.0
+rclose = 1e-3
+botm = [0, -25]
+chd_spd = [[0, i, 0, H1] for i in range(nrow)]
+chd_spd += [[0, i, ncol - 1, H2] for i in range(nrow)]
+wel_spd = [(1, 0, 5, -5000.0)]
+icelltype = [1]
+arr = np.ones(shape2d)
+arr[:, 4:7] = 0
+icelltype.append(arr)
+
+
+def build_models(idx, test):
+    name = cases[idx]
+    sim_ws = test.workspace
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name,
+        sim_ws=str(sim_ws),
+        exe_name="mf6",
+    )
+    flopy.mf6.ModflowTdis(sim, nper=nper)
+    linear_acceleration = "bicgstab"
+    newtonoptions = "newton under_relaxation"
+
+    flopy.mf6.ModflowIms(
+        sim,
+        print_option="ALL",
+        no_ptcrecord="ALL",
+        linear_acceleration=linear_acceleration,
+        outer_maximum=nouter,
+        outer_dvclose=hclose_outer,
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+    )
+    gwf = flopy.mf6.ModflowGwf(
+        sim,
+        modelname=name,
+        newtonoptions=newtonoptions,
+    )
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        idomain=1,
+    )
+    flopy.mf6.ModflowGwfnpf(
+        gwf,
+        icelltype=icelltype,
+        k=k11,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=H1)
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd_spd)
+    flopy.mf6.ModflowGwfwel(gwf, maxbound=1, stress_period_data=wel_spd)
+
+    head_filerecord = f"{name}.hds"
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=head_filerecord,
+        saverecord=[("HEAD", "ALL")],
+        printrecord=[("HEAD", "ALL")],
+    )
+
+    return sim, None
+
+
+def check_output(idx, test):
+    mf6sim = flopy.mf6.MFSimulation.load(sim_ws=test.workspace)
+    heads = mf6sim.get_model().output.head().get_data()
+    for k in range(nlay):
+        b = botm[k]
+        arr = heads[k]
+        for j in (4, 5, 6):
+            assert arr[:, j] < b, f"head > botm in columns in ({k + 1},{1},{j + 1})"
+    b = botm[-1]
+    arr = heads[nlay - 1]
+    for j in (0, 1, 2, 3, 7, 8, 9, 10):
+        assert arr[:, j] >= b, f"head < botm in columns in ({k + 1},{1},{j + 1})"
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -174,3 +174,8 @@ description = "An example was added to demonstrate the new UTVD capability in th
 section = "fixes"
 subsection = "model"
 description = "PRT maintains a transformation for each particle between the model coordinate system and coordinates local to the particle's current tracking domain. When a submethod hands control of a particle back to a delegating method, its corresponding transform is inverted to restore the delegating method's coordinate system. Up to now, this inverse operation unconditionally applied a rotation, whether or not the corresponding forward transform included a rotation. On rotated DISV grid cells, this could produce invalid particle coordinates, without substantially disturbing the remainder of the affected particle's pathline. The inverse coordinate transform has been corrected such that particle positions are reported correctly for rotated DISV grid cells."
+
+[[items]]
+section = "fixes"
+subsection = "internal"
+description = "Fixed Newton-Raphson under-relaxation so that it is not applied to cells where the lower-most cell in a vertical stack is not convertible (ICELLTYPE=0). Vertical stacks of cells with non-convertible cells at the bottom of the stack are not evaluated since it is valid for the water-level in a non-convertible cell to be below the bottom of the cell. This approach is consistent with the approach used in previous versions of MODFLOW."

--- a/src/Model/GroundWaterFlow/gwf-npf.f90
+++ b/src/Model/GroundWaterFlow/gwf-npf.f90
@@ -757,6 +757,7 @@ contains
     integer(I4B), intent(inout) :: locmax
     ! -- local
     integer(I4B) :: n
+    integer(I4B) :: ibot
     real(DP) :: botm
     real(DP) :: xx
     real(DP) :: dxx
@@ -764,20 +765,30 @@ contains
     ! -- Newton-Raphson under-relaxation
     do n = 1, this%dis%nodes
       if (this%ibound(n) < 1) cycle
-      if (this%icelltype(n) > 0) then
-        botm = this%dis%bot(this%ibotnode(n))
+      ibot = this%ibotnode(n)
+      ! if (this%icelltype(n) > 0) then
+      if (this%icelltype(n) > 0 .and. this%icelltype(ibot) > 0) then
+        botm = this%dis%bot(ibot)
+        ! if (this%icelltype(ibot) > 0) then
+        !   botm = this%dis%bot(ibot)
+        ! else
+        !   botm = x(ibot)
+        ! endif
         ! -- only apply Newton-Raphson under-relaxation if
         !    solution head is below the bottom of the model
         if (x(n) < botm) then
           inewtonur = 1
           xx = xtemp(n) * (DONE - DP9) + botm * DP9
-          dxx = x(n) - xx
+          ! dxx = x(n) - xx
+          dxx = xx - xtemp(n)
           if (abs(dxx) > abs(dxmax)) then
             locmax = n
             dxmax = dxx
           end if
           x(n) = xx
-          dx(n) = DZERO
+          dx(n) = xtemp(n) - x(n) !DZERO !
+          ! write(*,'(a,i0,6(f10.2))') &
+          !   'nur', n, x(n), xtemp(n), botm, xx, dxx, dx(n)
         end if
       end if
     end do

--- a/src/Model/GroundWaterFlow/gwf-npf.f90
+++ b/src/Model/GroundWaterFlow/gwf-npf.f90
@@ -766,29 +766,22 @@ contains
     do n = 1, this%dis%nodes
       if (this%ibound(n) < 1) cycle
       ibot = this%ibotnode(n)
-      ! if (this%icelltype(n) > 0) then
+      ! Newton-Raphson under-relaxation is only applied to convertible cells where
+      ! the bottom cell in a stack is convertible
       if (this%icelltype(n) > 0 .and. this%icelltype(ibot) > 0) then
         botm = this%dis%bot(ibot)
-        ! if (this%icelltype(ibot) > 0) then
-        !   botm = this%dis%bot(ibot)
-        ! else
-        !   botm = x(ibot)
-        ! endif
-        ! -- only apply Newton-Raphson under-relaxation if
-        !    solution head is below the bottom of the model
+        ! Newton-Raphson under-relaxation applied when solution head is
+        ! below the bottom of the model
         if (x(n) < botm) then
           inewtonur = 1
           xx = xtemp(n) * (DONE - DP9) + botm * DP9
-          ! dxx = x(n) - xx
           dxx = xx - xtemp(n)
           if (abs(dxx) > abs(dxmax)) then
             locmax = n
             dxmax = dxx
           end if
           x(n) = xx
-          dx(n) = xtemp(n) - x(n) !DZERO !
-          ! write(*,'(a,i0,6(f10.2))') &
-          !   'nur', n, x(n), xtemp(n), botm, xx, dxx, dx(n)
+          dx(n) = xtemp(n) - x(n)
         end if
       end if
     end do


### PR DESCRIPTION
Modified gwf npf newton under_relaxation so that it is not applied in vertical columns where the lowest cell in a vertical column is confined.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
