### PR TITLE
fix(prt): add warning for high exit_solve_tolerance

### DIFF
--- a/autotest/test_prt_exit_solve_tolerance.py
+++ b/autotest/test_prt_exit_solve_tolerance.py
@@ -1,0 +1,199 @@
+"""
+Test exit_solve_tolerance validation and warning behavior.
+
+Tests four scenarios:
+1. High tolerance (> 0.01): Should issue a warning showing the actual value
+2. Normal tolerance (<= 0.01): Should run without warning
+3. Negative tolerance (< 0): Should error and fail
+4. Zero tolerance (= 0): Should error and fail
+"""
+
+import os
+
+import flopy
+import pytest
+from framework import TestFramework
+from prt_test_utils import FlopyReadmeCase, get_model_name
+
+simname = "prtex"
+cases = [
+    f"{simname}_high",  # 0.1, should warn
+    f"{simname}_ok",  # 0.005, should not warn
+    f"{simname}_neg",  # -0.1, should error
+    f"{simname}_zero",  # 0.0, should error
+]
+
+
+def get_tolerance(name):
+    """Get the exit_solve_tolerance value for the test case."""
+    if "high" in name:
+        return 0.1
+    elif "ok" in name:
+        return 0.005
+    elif "neg" in name:
+        return -0.1
+    elif "zero" in name:
+        return 0.0
+    raise ValueError(f"Unknown test case: {name}")
+
+
+def build_prt_sim(name, gwf_ws, prt_ws, mf6):
+    # create simulation
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name,
+        exe_name=mf6,
+        version="mf6",
+        sim_ws=prt_ws,
+    )
+
+    # create tdis package
+    flopy.mf6.modflow.mftdis.ModflowTdis(
+        sim,
+        pname="tdis",
+        time_units="DAYS",
+        nper=FlopyReadmeCase.nper,
+        perioddata=[
+            (
+                FlopyReadmeCase.perlen,
+                FlopyReadmeCase.nstp,
+                FlopyReadmeCase.tsmult,
+            )
+        ],
+    )
+
+    # create prt model
+    prt_name = get_model_name(name, "prt")
+    prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name)
+
+    # create prt discretization
+    flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
+        prt,
+        pname="dis",
+        nlay=FlopyReadmeCase.nlay,
+        nrow=FlopyReadmeCase.nrow,
+        ncol=FlopyReadmeCase.ncol,
+    )
+
+    # create mip package
+    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=FlopyReadmeCase.porosity)
+
+    # create a single release point
+    releasepts = [[0, 0, 0, 0, 0.5, 0.5, 0.5]]
+
+    # create prp package with the specified exit_solve_tolerance
+    prp_track_file = f"{prt_name}.prp.trk"
+    prp_track_csv_file = f"{prt_name}.prp.trk.csv"
+
+    tolerance = get_tolerance(name)
+
+    flopy.mf6.ModflowPrtprp(
+        prt,
+        pname="prp1",
+        filename=f"{prt_name}_1.prp",
+        nreleasepts=len(releasepts),
+        packagedata=releasepts,
+        perioddata={0: [("FIRST",)]},
+        track_filerecord=[prp_track_file],
+        trackcsv_filerecord=[prp_track_csv_file],
+        exit_solve_tolerance=tolerance,
+        coordinate_check_method="none",  # Disable coordinate checking for this test
+        print_input=True,
+        extend_tracking=True,
+    )
+
+    # create output control package
+    prt_track_file = f"{prt_name}.trk"
+    prt_track_csv_file = f"{prt_name}.trk.csv"
+    flopy.mf6.ModflowPrtoc(
+        prt,
+        pname="oc",
+        track_filerecord=[prt_track_file],
+        trackcsv_filerecord=[prt_track_csv_file],
+    )
+
+    # create the flow model interface
+    gwf_name = get_model_name(name, "gwf")
+    rel_gwf_folder = os.path.relpath(gwf_ws, start=prt_ws)
+    gwf_budget_file = f"{rel_gwf_folder}/{gwf_name}.bud"
+    gwf_head_file = f"{rel_gwf_folder}/{gwf_name}.hds"
+    flopy.mf6.ModflowPrtfmi(
+        prt,
+        packagedata=[
+            ("GWFHEAD", gwf_head_file),
+            ("GWFBUDGET", gwf_budget_file),
+        ],
+    )
+
+    # add explicit model solution
+    ems = flopy.mf6.ModflowEms(
+        sim,
+        pname="ems",
+        filename=f"{prt_name}.ems",
+    )
+    sim.register_solution_package(ems, [prt.name])
+
+    return sim
+
+
+def build_models(test):
+    gwf_sim = FlopyReadmeCase.get_gwf_sim(
+        test.name, test.workspace / "gwf", test.targets["mf6"]
+    )
+    prt_sim = build_prt_sim(
+        test.name,
+        test.workspace / "gwf",
+        test.workspace / "prt",
+        test.targets["mf6"],
+    )
+    return gwf_sim, prt_sim
+
+
+def check_output(test):
+    name = test.name
+    tolerance = get_tolerance(name)
+
+    # For the PRT simulation (second simulation), check output buffer
+    # test.buffs[0] is GWF, test.buffs[1] is PRT
+    buff = test.buffs[1]
+
+    if "high" in name:
+        # Should have warning message for high tolerance (> 0.01)
+        assert any("WARNING: EXIT_SOLVE_TOLERANCE is set to" in l for l in buff), (
+            "Expected warning for high exit_solve_tolerance not found"
+        )
+
+        # Check that the warning shows the actual tolerance value
+        buff_text = " ".join(buff)
+        assert "0.100" in buff_text or "0.1" in buff_text or "1.00E-01" in buff_text, (
+            "Warning should show tolerance value 0.1 in the output"
+        )
+
+        # Check that it mentions the default value
+        assert "default value" in buff_text, "Warning should mention the default value"
+
+    elif "ok" in name:
+        # Should NOT have warning message for tolerance <= 0.01
+        assert not any("WARNING: EXIT_SOLVE_TOLERANCE is set to" in l for l in buff), (
+            "Unexpected warning for acceptable exit_solve_tolerance"
+        )
+
+    elif "neg" in name or "zero" in name:
+        # Should have error message for negative or zero tolerance
+        assert any("EXIT_SOLVE_TOLERANCE MUST BE POSITIVE" in l for l in buff), (
+            "Expected error for non-positive exit_solve_tolerance not found"
+        )
+
+
+@pytest.mark.parametrize("name", cases)
+def test_mf6model(name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=build_models,
+        check=check_output,
+        targets=targets,
+        compare=None,
+        # For non-positive tolerance cases: GWF should succeed, PRT should fail
+        xfail=[False, True] if ("neg" in name or "zero" in name) else False,
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -72,3 +72,8 @@ description = "The OPTIONS block in the Energy Source Loading (ESL) Package acce
 section = "fixes"
 subsection = "stress packages"
 description = "The OPTIONS block in the Mass Source Loading (SRC) Package accepted the AUXILIARY and AUXMULTNAME keywords; however, they had no effect on the GWT solution.  The SRC package was fixed such that when the AUXMULTCOL keyword is invoked, the user-specified amount of energy added or removed from cells will be multiplied by the value supplied by the user in the corresponding AUXILIARY column." 
+
+[[items]]
+section = "fixes"
+subsection = "model"
+description = "Setting the PRT model's Particle Release Point (PRP) package option EXIT\\_SOLVE\\_TOLERANCE too high can cause the generalized (DISV) tracking method to produce invalid/meaningless results, as the algorithm considers every lateral subcell exit solution equally valid. Add a warning for tolerances above 0.01. The variable being solved varies from 0 to 1, so in most cases the tolerance should be much less than 1, but appropriate values will vary by model and desired performance (models run faster with higher tolerance)."

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -35,7 +35,7 @@ reader urword
 optional true
 mf6internal extol
 longname exit solve tolerance
-description the convergence tolerance for iterative solution of particle exit location and time in the generalized Pollock's method.  A value of 0.00001 works well for many problems, but the value that strikes the best balance between accuracy and runtime is problem-dependent.
+description the convergence tolerance for iterative solution of particle exit location and time in the generalized Pollock's method.  The variable being solved for varies from 0 to 1.  A tolerance of 0.00001 works well for many problems, but the value that strikes the best balance between accuracy and runtime is problem-dependent.
 default_value 1e-5
 
 block options

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -2,7 +2,7 @@ module PrtPrpModule
   use KindModule, only: DP, I4B, LGP
   use ConstantsModule, only: DZERO, DEM1, DEM5, DONE, LENFTYPE, LINELENGTH, &
                              LENBOUNDNAME, LENPAKLOC, TABLEFT, TABCENTER, &
-                             MNORMAL, DSAME, DEP3, DEP9
+                             MNORMAL, DSAME, DEP3, DEP9, DEM2
   use BndModule, only: BndType
   use BndExtModule, only: BndExtType
   use ObsModule, only: DefaultObsIdProcessor
@@ -683,6 +683,13 @@ contains
       &[character(len=LENVARNAME) :: 'NONE', 'EAGER']
     character(len=LINELENGTH) :: trackfile, trackcsvfile, fname
     type(PrtPrpParamFoundType) :: found
+    character(len=*), parameter :: fmtextolwrn = &
+      "('WARNING: EXIT_SOLVE_TOLERANCE is set to ',g10.3,' &
+      &which is much greater than the default value of 0.00001. &
+      &The tolerance that strikes the best balance between accuracy &
+      &and runtime is problem-dependent. Since the variable being solved &
+      &solved varies from 0 to 1, tolerance values much less than 1 &
+      &typically give the best results.')"
 
     ! -- source base class options
     call this%BndExtType%source_options()
@@ -737,6 +744,10 @@ contains
     if (found%extol) then
       if (this%extol <= DZERO) &
         call store_error('EXIT_SOLVE_TOLERANCE MUST BE POSITIVE')
+      if (this%extol > DEM2) then
+        write (warnmsg, fmt=fmtextolwrn) this%extol
+        call store_warning(warnmsg)
+      end if
     end if
 
     if (found%rttol) then

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -33,6 +33,7 @@ module PrtPrpModule
 
   character(len=LENFTYPE) :: ftype = 'PRP'
   character(len=16) :: text = '             PRP'
+  real(DP), parameter :: DEFAULT_EXIT_SOLVE_TOLERANCE = DEM5
 
   !> @brief Particle release point (PRP) package
   type, extends(BndExtType) :: PrtPrpType
@@ -290,7 +291,7 @@ contains
     this%iexmeth = 0
     this%ichkmeth = 1
     this%icycwin = 0
-    this%extol = DEM5
+    this%extol = DEFAULT_EXIT_SOLVE_TOLERANCE
     this%rttol = DSAME * DEP9
     this%rtfreq = DZERO
 
@@ -685,9 +686,9 @@ contains
     type(PrtPrpParamFoundType) :: found
     character(len=*), parameter :: fmtextolwrn = &
       "('WARNING: EXIT_SOLVE_TOLERANCE is set to ',g10.3,' &
-      &which is much greater than the default value of 0.00001. &
+      &which is much greater than the default value of ',g10.3,'. &
       &The tolerance that strikes the best balance between accuracy &
-      &and runtime is problem-dependent. Since the variable being solved &
+      &and runtime is problem-dependent. Since the variable being &
       &solved varies from 0 to 1, tolerance values much less than 1 &
       &typically give the best results.')"
 
@@ -745,7 +746,8 @@ contains
       if (this%extol <= DZERO) &
         call store_error('EXIT_SOLVE_TOLERANCE MUST BE POSITIVE')
       if (this%extol > DEM2) then
-        write (warnmsg, fmt=fmtextolwrn) this%extol
+        write (warnmsg, fmt=fmtextolwrn) &
+          this%extol, DEFAULT_EXIT_SOLVE_TOLERANCE
         call store_warning(warnmsg)
       end if
     end if


### PR DESCRIPTION
Setting PRP option `EXIT_SOLVE_TOLERANCE` too high can produce invalid/meaningless results with the generalized DISV tracking method, as the algorithm then considers every lateral exit solution from every subcell equally valid.

Add a warning for tolerances above 0.01. The variable being solved varies from 0 to 1, so in most cases the tolerance should be much less than 1, though appropriate values will vary by model and desired performance (higher tolerance = faster).

Also update the DFN parameter description. 

___

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request