### PR TITLE
ci: free disk space on ubuntu gnu fortran job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,18 @@ jobs:
       FC: gfortran
       FC_V: 13
     steps:
+      - name: Free disk space (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout MF6
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Ubuntu GNU fortran test jobs were running out of disk space I think