### PR TITLE
feat(wel): add flow_reduction_length option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ modflow6.code-workspace
 # unittests
 unittests/
 autotest/.failed
+autotest/.keep
 autotest/.temp/
 autotest/temp/
 autotest/tempbin/

--- a/autotest/test_gwf_wel02.py
+++ b/autotest/test_gwf_wel02.py
@@ -1,5 +1,5 @@
 """
-Variation of test_gwf_wel01 that compares head and flow results for a MODFLOW 6
+Variation of test_gwf_wel01 that compares head and flow results for MODFLOW 6
 simulations with and without the FLOW_REDUCTION_LENGTH option.
 """
 

--- a/autotest/test_gwf_wel02.py
+++ b/autotest/test_gwf_wel02.py
@@ -1,0 +1,158 @@
+"""
+Variation of test_gwf_wel01 that compares head and flow results for a MODFLOW 6
+simulations with and without the FLOW_REDUCTION_LENGTH option.
+"""
+
+import flopy
+import pytest
+from framework import TestFramework
+
+cases = ["wel02"]
+
+# set static data
+nper = 1
+tdis_rc = [
+    (50.0, 50, 1.05),
+]
+
+nlay, nrow, ncol = 2, 1, 1
+delr = delc = 10.0
+top, botm = 10.0, [9.0, 8.0]
+strt = top
+hk = 1.0
+sy = 0.1
+wellq = 0.25
+
+nouter, ninner = 100, 300
+hclose, rclose, relax = 1e-9, 1e-6, 1.0
+
+
+def build_model(ws, idx, reduce_length=None):
+    name = cases[idx]
+
+    # build MODFLOW 6 files
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name,
+        version="mf6",
+        exe_name="mf6",
+        sim_ws=ws,
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(
+        sim,
+        time_units="DAYS",
+        nper=nper,
+        perioddata=tdis_rc,
+    )
+
+    # create iterative model solution and register the gwf model with it
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+    )
+
+    # create gwf model
+    gwf = flopy.mf6.ModflowGwf(
+        sim,
+        modelname=name,
+        newtonoptions="NEWTON UNDER_RELAXATION",
+        save_flows=True,
+    )
+
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
+
+    # node property flow
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf,
+        save_flows=True,
+        icelltype=1,
+        k=hk,
+        k33=hk,
+    )
+    # storage
+    sto = flopy.mf6.ModflowGwfsto(
+        gwf,
+        save_flows=True,
+        iconvert=1,
+        ss=0.0,
+        sy=sy,
+        steady_state={0: False},
+        transient={0: False},
+    )
+
+    wel_spd = {0: [[0, 0, 0, -wellq]]}
+    wel = flopy.mf6.ModflowGwfwel(
+        gwf,
+        print_input=True,
+        print_flows=True,
+        auto_flow_reduce="auto_flow_reduce 0.5",
+        flow_reduction_length=reduce_length,
+        stress_period_data=wel_spd,
+        afrcsv_filerecord=f"{name}.afr.csv",
+    )
+
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=f"{name}.hds",
+        budget_filerecord=f"{name}.cbc",
+        printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
+    return sim
+
+
+def build_models(idx, test):
+    ws = test.workspace
+    sim = build_model(ws, idx, reduce_length=True)
+    mc = build_model(ws / "mf6", idx)
+    return sim, mc
+
+
+def check_output(idx, test):
+    fpth0 = test.workspace / f"{test.name}.cbc"
+    fpth1 = test.workspace / "mf6" / f"{test.name}.cbc"
+    outfile = test.workspace / f"{test.name}.cbc.cmp.out"
+    success = flopy.utils.compare.compare_cell_budget(
+        fpth0,
+        fpth1,
+        outfile=outfile,
+        rclose=rclose,
+    )
+    assert success, f"budgets do not match for {test.name}"
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        compare="mf6",
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -106,4 +106,4 @@ description = "The storage term for SFE, like SFT, was not consistent with the s
 [[items]]
 section = "features"
 subsection = "stress"
-description = "Added the FLOW\\_REDUCTION\\_LENGTH option to WEL package that indicates the AUTO\\_FLOW\\_REDUCE value is a length instead of a fraction of the cell thickness. A warning will be issued if the FLOW\\_REDUCTION\\_LENGTH option is specified but the AUTO\\_FLOW\\_REDUCE option is not specified in the options block. The program will terminate with an error if FLOW\\_REDUCTION\\_LENGTH is specified and the AUTO\\_FLOW\\_REDUCE value specified in the options block is less than or equal to zero."
+description = "Added the FLOW\\_REDUCTION\\_LENGTH option to WEL package that indicates the AUTO\\_FLOW\\_REDUCE value is a length instead of a fraction of the cell thickness. A warning will be issued if the FLOW\\_REDUCTION\\_LENGTH option is specified but the AUTO\\_FLOW\\_REDUCE option is not specified in the options block. The program will terminate with an error if the FLOW\\_REDUCTION\\_LENGTH option is specified and the AUTO\\_FLOW\\_REDUCE value specified in the options block is less than or equal to zero."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -106,4 +106,4 @@ description = "The storage term for SFE, like SFT, was not consistent with the s
 [[items]]
 section = "features"
 subsection = "stress"
-description = "Add FLOW\\_REDUCTION\\_LENGTH option to WEL package that indicates the AUTO\\_FLOW\\_REDUCE value is a length instead of a fraction of cell thickness. A warning will be issued if FLOW\\_REDUCTION\\_LENGTH is specified but AUTO\\_FLOW\\_REDUCE is not specified in the option block."
+description = "Added the FLOW\\_REDUCTION\\_LENGTH option to WEL package that indicates the AUTO\\_FLOW\\_REDUCE value is a length instead of a fraction of the cell thickness. A warning will be issued if the FLOW\\_REDUCTION\\_LENGTH option is specified but the AUTO\\_FLOW\\_REDUCE option is not specified in the options block. The program will terminate with an error if FLOW\\_REDUCTION\\_LENGTH is specified and the AUTO\\_FLOW\\_REDUCE value specified in the options block is less than or equal to zero."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -102,3 +102,8 @@ description = "The storage term for SFT was not consistent with the standard SFR
 section = "fixes"
 subsection = "advanced"
 description = "The storage term for SFE, like SFT, was not consistent with the standard SFR flow approach (steady-state). Prior to this change, the reach volume for the previous timestep was calculated using the current storage flow rate, which is zero for SFR even though there can be a calculated change in stage. The SFE storage term is now calculated using the current and previous reach water volumes. This change may affect SFE results for existing models."
+
+[[items]]
+section = "features"
+subsection = "stress"
+description = "Add FLOW\\_REDUCTION\\_LENGTH option to WEL package that indicates the AUTO\\_FLOW\\_REDUCE value is a length instead of a fraction of cell thickness. A warning will be issued if FLOW\\_REDUCTION\\_LENGTH is specified but AUTO\\_FLOW\\_REDUCE is not specified in the option block."

--- a/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
@@ -112,6 +112,15 @@ longname file keyword
 description name of the comma-separated value (CSV) output file to write information about well extraction rates that have been reduced by the program.  Entries are only written if the extraction rates are reduced.
 
 block options
+name flow_reduction_length
+type keyword
+reader urword
+optional true
+longname flow reduction length keyword
+description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length instead of a fraction of cell thickness. A warning will be issued if FLOW\_REDUCTION\_LENGTH is specified but AUTO\_FLOW\_REDUCE is not specified in the option block.
+mf6internal iflowredlen
+
+block options
 name ts_filerecord
 type record ts6 filein ts6_filename
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
@@ -117,7 +117,7 @@ type keyword
 reader urword
 optional true
 longname flow reduction length keyword
-description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length instead of a fraction of the cell thickness. A warning will be issued if the FLOW\_REDUCTION\_LENGTH option is specified but the AUTO\_FLOW\_REDUCE option is not specified in the options block. The program will terminate with an error if FLOW\_REDUCTION\_LENGTH is specified and the AUTO\_FLOW\_REDUCE value specified in the options block is less than or equal to zero.
+description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length instead of a fraction of the cell thickness. A warning will be issued if the FLOW\_REDUCTION\_LENGTH option is specified but the AUTO\_FLOW\_REDUCE option is not specified in the options block. The program will terminate with an error if the FLOW\_REDUCTION\_LENGTH option is specified and the AUTO\_FLOW\_REDUCE value specified in the options block is less than or equal to zero.
 mf6internal iflowredlen
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
@@ -117,7 +117,7 @@ type keyword
 reader urword
 optional true
 longname flow reduction length keyword
-description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length instead of a fraction of cell thickness. A warning will be issued if FLOW\_REDUCTION\_LENGTH is specified but AUTO\_FLOW\_REDUCE is not specified in the option block.
+description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length instead of a fraction of the cell thickness. A warning will be issued if the FLOW\_REDUCTION\_LENGTH option is specified but the AUTO\_FLOW\_REDUCE option is not specified in the options block. The program will terminate with an error if FLOW\_REDUCTION\_LENGTH is specified and the AUTO\_FLOW\_REDUCE value specified in the options block is less than or equal to zero.
 mf6internal iflowredlen
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
@@ -113,6 +113,15 @@ longname file keyword
 description name of the comma-separated value (CSV) output file to write information about well extraction rates that have been reduced by the program.  Entries are only written if the extraction rates are reduced.
 
 block options
+name flow_reduction_length
+type keyword
+reader urword
+optional true
+longname flow reduction length keyword
+description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length instead of a fraction of cell thickness. A warning will be issued if FLOW\_REDUCTION\_LENGTH is specified but AUTO\_FLOW\_REDUCE is not specified in the option block.
+mf6internal iflowredlen
+
+block options
 name obs_filerecord
 type record obs6 filein obs6_filename
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
@@ -118,7 +118,7 @@ type keyword
 reader urword
 optional true
 longname flow reduction length keyword
-description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length instead of a fraction of the cell thickness. A warning will be issued if the FLOW\_REDUCTION\_LENGTH option is specified but the AUTO\_FLOW\_REDUCE option is not specified in the options block. The program will terminate with an error if FLOW\_REDUCTION\_LENGTH is specified and the AUTO\_FLOW\_REDUCE value specified in the options block is less than or equal to zero.
+description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length instead of a fraction of the cell thickness. A warning will be issued if the FLOW\_REDUCTION\_LENGTH option is specified but the AUTO\_FLOW\_REDUCE option is not specified in the options block. The program will terminate with an error if the FLOW\_REDUCTION\_LENGTH option is specified and the AUTO\_FLOW\_REDUCE value specified in the options block is less than or equal to zero.
 mf6internal iflowredlen
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
@@ -118,7 +118,7 @@ type keyword
 reader urword
 optional true
 longname flow reduction length keyword
-description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length instead of a fraction of cell thickness. A warning will be issued if FLOW\_REDUCTION\_LENGTH is specified but AUTO\_FLOW\_REDUCE is not specified in the option block.
+description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length instead of a fraction of the cell thickness. A warning will be issued if the FLOW\_REDUCTION\_LENGTH option is specified but the AUTO\_FLOW\_REDUCE option is not specified in the options block. The program will terminate with an error if FLOW\_REDUCTION\_LENGTH is specified and the AUTO\_FLOW\_REDUCE value specified in the options block is less than or equal to zero.
 mf6internal iflowredlen
 
 block options

--- a/src/Idm/gwf-welgidm.f90
+++ b/src/Idm/gwf-welgidm.f90
@@ -23,6 +23,7 @@ module GwfWelgInputModule
     logical :: afrcsv = .false.
     logical :: fileout = .false.
     logical :: afrcsvfile = .false.
+    logical :: iflowredlen = .false.
     logical :: obs_filerecord = .false.
     logical :: filein = .false.
     logical :: obs6 = .false.
@@ -252,6 +253,25 @@ module GwfWelgInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
+    gwfwelg_iflowredlen = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'WELG', & ! subcomponent
+    'OPTIONS', & ! block
+    'FLOW_REDUCTION_LENGTH', & ! tag name
+    'IFLOWREDLEN', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'flow reduction length keyword', & ! longname
+    .false., & ! required
+    .false., & ! developmode
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
     gwfwelg_obs_filerecord = InputParamDefinitionType &
     ( &
     'GWF', & ! component
@@ -436,6 +456,7 @@ module GwfWelgInputModule
     gwfwelg_afrcsv, &
     gwfwelg_fileout, &
     gwfwelg_afrcsvfile, &
+    gwfwelg_iflowredlen, &
     gwfwelg_obs_filerecord, &
     gwfwelg_filein, &
     gwfwelg_obs6, &

--- a/src/Idm/gwf-welidm.f90
+++ b/src/Idm/gwf-welidm.f90
@@ -23,6 +23,7 @@ module GwfWelInputModule
     logical :: afrcsv = .false.
     logical :: fileout = .false.
     logical :: afrcsvfile = .false.
+    logical :: iflowredlen = .false.
     logical :: ts_filerecord = .false.
     logical :: ts6 = .false.
     logical :: filein = .false.
@@ -251,6 +252,25 @@ module GwfWelInputModule
     .false., & ! developmode
     .true., & ! multi-record
     .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfwel_iflowredlen = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'WEL', & ! subcomponent
+    'OPTIONS', & ! block
+    'FLOW_REDUCTION_LENGTH', & ! tag name
+    'IFLOWREDLEN', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'flow reduction length keyword', & ! longname
+    .false., & ! required
+    .false., & ! developmode
+    .false., & ! multi-record
+    .false., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -516,6 +536,7 @@ module GwfWelInputModule
     gwfwel_afrcsv, &
     gwfwel_fileout, &
     gwfwel_afrcsvfile, &
+    gwfwel_iflowredlen, &
     gwfwel_ts_filerecord, &
     gwfwel_ts6, &
     gwfwel_filein, &

--- a/src/Model/GroundWaterFlow/gwf-wel.f90
+++ b/src/Model/GroundWaterFlow/gwf-wel.f90
@@ -213,12 +213,13 @@ contains
                        found%iflowredlen)
 
     if (found%iflowredlen) then
-      this%iflowredlen = 1
       if (found%flowred .eqv. .FALSE.) then
         write (warnmsg, '(a)') &
           'FLOW_REDUCTION_LENGTH option specified but a AUTO_FLOW_REDUCTION value &
           &is not specified. The FLOW_REDUCTION_LENGTH option will be ignored.'
         call store_warning(warnmsg)
+      else
+        this%iflowredlen = 1
       end if
     end if
 
@@ -233,7 +234,7 @@ contains
         else
           this%flowred = DEM1
         end if
-      else if (this%flowred > DONE .and. found%iflowredlen .eqv. .FALSE.) then
+      else if (this%flowred > DONE .and. this%iflowredlen == 0) then
         this%flowred = DONE
       end if
     end if
@@ -264,26 +265,31 @@ contains
       &"(4x, 'AUTOMATIC FLOW REDUCTION OF WELLS IMPLEMENTED.')"
     character(len=*), parameter :: fmtflowredv = &
       &"(4x, 'AUTOMATIC FLOW REDUCTION FRACTION (',g15.7,').')"
+    character(len=*), parameter :: fmtflowredl = &
+      &"(4x, 'AUTOMATIC FLOW REDUCTION LENGTH (',g15.7,').')"
     !
     ! -- log found options
     write (this%iout, '(/1x,a)') 'PROCESSING '//trim(adjustl(this%text)) &
       //' OPTIONS'
-    !
+
+    if (found%iflowredlen) then
+      write (this%iout, fmtflowred)
+      write (this%iout, '(4x,A)') &
+        'AUTOMATIC FLOW REDUCTION FRACTION INTERPRETED AS A LENGTH'
+    end if
+
     if (found%flowred) then
-      if (this%iflowred > 0) &
-        write (this%iout, fmtflowred)
-      write (this%iout, fmtflowredv) this%flowred
+      if (this%iflowredlen == 0) then
+        write (this%iout, fmtflowredv) this%flowred
+      else
+        write (this%iout, fmtflowredl) this%flowred
+      end if
     end if
     !
     if (found%afrcsvfile) then
       ! -- currently no-op
     end if
-    !
-    if (found%iflowredlen) then
-      write (this%iout, '(4x,A)') &
-        'AUTOMATIC FLOW REDUCTION FRACTION INTERPRETED AS A LENGTH'
-    end if
-    !
+
     if (found%mover) then
       write (this%iout, '(4x,A)') 'MOVER OPTION ENABLED'
     end if

--- a/src/Model/GroundWaterFlow/gwf-wel.f90
+++ b/src/Model/GroundWaterFlow/gwf-wel.f90
@@ -16,8 +16,8 @@ module WelModule
   ! -- modules used by WelModule methods
   use KindModule, only: DP, I4B
   use ConstantsModule, only: DZERO, DEM1, DONE, LENFTYPE, DNODATA, LINELENGTH
-  use SimVariablesModule, only: errmsg
-  use SimModule, only: store_error, store_error_filename
+  use SimVariablesModule, only: errmsg, warnmsg
+  use SimModule, only: store_error, store_error_filename, store_warning
   use MemoryHelperModule, only: create_mem_path
   use BndModule, only: BndType
   use BndExtModule, only: BndExtType
@@ -41,6 +41,7 @@ module WelModule
     integer(I4B), pointer :: iflowred => null() !< flag indicating if the AUTO_FLOW_REDUCE option is active
     real(DP), pointer :: flowred => null() !< AUTO_FLOW_REDUCE variable
     integer(I4B), pointer :: ioutafrcsv => null() !< unit number for CSV output file containing wells with reduced puping rates
+    integer(I4B), pointer :: iflowredlen => null() !< flag indicating flowred variable is a length value
   contains
     procedure :: allocate_scalars => wel_allocate_scalars
     procedure :: allocate_arrays => wel_allocate_arrays
@@ -123,6 +124,7 @@ contains
     call mem_deallocate(this%iflowred)
     call mem_deallocate(this%flowred)
     call mem_deallocate(this%ioutafrcsv)
+    call mem_deallocate(this%iflowredlen)
     call mem_deallocate(this%q, 'Q', this%memoryPath)
   end subroutine wel_da
 
@@ -145,11 +147,13 @@ contains
     call mem_allocate(this%iflowred, 'IFLOWRED', this%memoryPath)
     call mem_allocate(this%flowred, 'FLOWRED', this%memoryPath)
     call mem_allocate(this%ioutafrcsv, 'IOUTAFRCSV', this%memoryPath)
+    call mem_allocate(this%iflowredlen, 'IFLOWREDLEN', this%memoryPath)
     !
     ! -- Set values
     this%iflowred = 0
     this%ioutafrcsv = 0
     this%flowred = DZERO
+    this%iflowredlen = 0
   end subroutine wel_allocate_scalars
 
   !> @ brief Allocate arrays
@@ -205,6 +209,8 @@ contains
     call mem_set_value(this%flowred, 'FLOWRED', this%input_mempath, found%flowred)
     call mem_set_value(fname, 'AFRCSVFILE', this%input_mempath, found%afrcsvfile)
     call mem_set_value(this%imover, 'MOVER', this%input_mempath, found%mover)
+    call mem_set_value(this%iflowredlen, 'IFLOWREDLEN', this%input_mempath, &
+                       found%iflowredlen)
     !
     if (found%flowred) then
       !
@@ -219,6 +225,10 @@ contains
     !
     if (found%afrcsvfile) then
       call this%wel_afr_csv_init(fname)
+    end if
+    !
+    if (found%iflowredlen) then
+      this%iflowredlen = 1
     end if
     !
     if (found%mover) then
@@ -256,6 +266,17 @@ contains
     !
     if (found%afrcsvfile) then
       ! -- currently no-op
+    end if
+    !
+    if (found%iflowredlen) then
+      write (this%iout, '(4x,A)') &
+        'AUTOMATIC FLOW REDUCTION FRACTION INTERPRETED AS A LENGTH'
+      if (found%flowred .eqv. .false.) then
+        write (warnmsg, '(a)') &
+          'FLOW_REDUCTION_LENGTH OPTION SPECIFIED BUT AUTOMATIC FLOW REDUCTION &
+          &IS NOT SPECIFIED. FLOW_REDUCTION_LENGTH WILL BE IGNORED.'
+        call store_warning(warnmsg)
+      end if
     end if
     !
     if (found%mover) then
@@ -319,9 +340,12 @@ contains
       if (this%iflowred /= 0 .and. q < DZERO) then
         ict = this%icelltype(node)
         if (ict /= 0) then
-          tp = this%dis%top(node)
           bt = this%dis%bot(node)
-          thick = tp - bt
+          if (this%iflowredlen == 0) then
+            thick = this%dis%top(node) - bt
+          else
+            thick = DONE
+          end if
           tp = bt + this%flowred * thick
           qmult = sQSaturation(tp, bt, this%xnew(node))
           q = q * qmult

--- a/src/Model/GroundWaterFlow/gwf-wel.f90
+++ b/src/Model/GroundWaterFlow/gwf-wel.f90
@@ -211,30 +211,41 @@ contains
     call mem_set_value(this%imover, 'MOVER', this%input_mempath, found%mover)
     call mem_set_value(this%iflowredlen, 'IFLOWREDLEN', this%input_mempath, &
                        found%iflowredlen)
-    !
+
+    if (found%iflowredlen) then
+      this%iflowredlen = 1
+      if (found%flowred .eqv. .FALSE.) then
+        write (warnmsg, '(a)') &
+          'FLOW_REDUCTION_LENGTH option specified but a AUTO_FLOW_REDUCTION value &
+          &is not specified. The FLOW_REDUCTION_LENGTH option will be ignored.'
+        call store_warning(warnmsg)
+      end if
+    end if
+
     if (found%flowred) then
-      !
       this%iflowred = 1
-      !
       if (this%flowred <= DZERO) then
-        this%flowred = DEM1
-      else if (this%flowred > DONE) then
+        if (found%iflowredlen) then
+          write (errmsg, '(a)') &
+            'An AUTO_FLOW_REDUCTION value less than or equal to zero cannot be &
+            &specified if the FLOW_REDUCTION_LENGTH option is specified.'
+          call store_error(errmsg)
+        else
+          this%flowred = DEM1
+        end if
+      else if (this%flowred > DONE .and. found%iflowredlen .eqv. .FALSE.) then
         this%flowred = DONE
       end if
     end if
-    !
+
     if (found%afrcsvfile) then
       call this%wel_afr_csv_init(fname)
     end if
-    !
-    if (found%iflowredlen) then
-      this%iflowredlen = 1
-    end if
-    !
+
     if (found%mover) then
       this%imover = 1
     end if
-    !
+
     ! -- log WEL specific options
     call this%log_wel_options(found)
   end subroutine wel_options
@@ -271,12 +282,6 @@ contains
     if (found%iflowredlen) then
       write (this%iout, '(4x,A)') &
         'AUTOMATIC FLOW REDUCTION FRACTION INTERPRETED AS A LENGTH'
-      if (found%flowred .eqv. .false.) then
-        write (warnmsg, '(a)') &
-          'FLOW_REDUCTION_LENGTH OPTION SPECIFIED BUT AUTOMATIC FLOW REDUCTION &
-          &IS NOT SPECIFIED. FLOW_REDUCTION_LENGTH WILL BE IGNORED.'
-        call store_warning(warnmsg)
-      end if
     end if
     !
     if (found%mover) then


### PR DESCRIPTION
Add FLOW_REDUCTION_LENGTH option to WEL package that indicates the AUTO_FLOW_REDUCE value is a length instead of a fraction of cell thickness. A warning will be issued if FLOW_REDUCTION_LENGTH is specified but AUTO_FLOW_REDUCE is not specified in the option block.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Closed issue #2608
- [x] Referenced issue or pull request #2608
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
