### PR TITLE
ci(release): free disk space in docs build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,6 +396,16 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
+      - name: Free disk space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Checkout modflow6
         uses: actions/checkout@v6


### PR DESCRIPTION
We are hitting disk space limits https://github.com/MODFLOW-ORG/modflow6-nightly-build/actions/runs/20783475555/job/59696316111#step:20:2487