### PR TITLE
refactor(netcdf): write input arrays only in validate mode

### DIFF
--- a/autotest/framework.py
+++ b/autotest/framework.py
@@ -5,7 +5,7 @@ from itertools import repeat
 from pathlib import Path
 from subprocess import PIPE, STDOUT, Popen
 from traceback import format_exc
-from typing import Callable, Union
+from typing import Callable, Optional, Union
 from warnings import warn
 
 import flopy
@@ -245,6 +245,7 @@ class TestFramework:
         overwrite: bool = True,
         verbose: bool = False,
         xfail: bool | list[bool] = False,
+        cargs: Optional[list] = None,
     ):
         # make sure workspace exists
         workspace = Path(workspace).expanduser().absolute()
@@ -268,6 +269,7 @@ class TestFramework:
         self.overwrite = overwrite
         self.verbose = verbose
         self.xfail = [xfail] if isinstance(xfail, bool) else xfail
+        self.cargs = cargs
 
     def __repr__(self):
         return self.name
@@ -467,6 +469,7 @@ class TestFramework:
         workspace: Union[str, os.PathLike],
         target: Union[str, os.PathLike],
         xfail: bool = False,
+        cargs: Optional[str] = None,
         ncpus: int = 1,
     ) -> tuple[bool, list[str]]:
         """
@@ -533,6 +536,7 @@ class TestFramework:
                             workspace / "mfsim.nam",
                             model_ws=workspace,
                             report=True,
+                            cargs=cargs,
                         )
                     except Exception:
                         warn(
@@ -617,8 +621,9 @@ class TestFramework:
                 else tgts.get(exe_path.stem, tgts["mf6"])
             )
             xfail = self.xfail[i]
+            cargs = self.cargs[i] if self.cargs is not None else None
             ncpus = self.ncpus[i]
-            success, buff = self._run(workspace, target, xfail, ncpus)
+            success, buff = self._run(workspace, target, xfail, cargs, ncpus)
             self.buffs[i] = buff  # store model output for assertions later
             assert success, (
                 f"{'Simulation' if 'mf6' in str(target) else 'Model'} "

--- a/autotest/test_netcdf_gwe_cnd.py
+++ b/autotest/test_netcdf_gwe_cnd.py
@@ -178,6 +178,11 @@ def check_output(idx, test, export, gridded_input):
                 ), f"NetCDF-temperature comparison failure in timestep {kstp + 1}"
                 kstp += 1
 
+    for v in xds.data_vars.keys():
+        assert not v.startswith("dis")
+        assert not v.startswith("ic")
+        assert not v.startswith("cnd")
+
     xds.close()
 
     if gridded_input == "ascii":

--- a/autotest/test_netcdf_gwe_cnd.py
+++ b/autotest/test_netcdf_gwe_cnd.py
@@ -39,10 +39,11 @@ def build_models(idx, test, export, gridded_input):
 
     name = "gwe-" + cases[idx]
 
+    fname = f"{name}.{export}.nc" if gridded_input == "netcdf" else f"{name}.nc"
     if export == "ugrid":
-        gwe.name_file.nc_mesh2d_filerecord = f"{name}.nc"
+        gwe.name_file.nc_mesh2d_filerecord = fname
     elif export == "structured":
-        gwe.name_file.nc_structured_filerecord = f"{name}.nc"
+        gwe.name_file.nc_structured_filerecord = fname
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -59,15 +60,12 @@ def check_output(idx, test, export, gridded_input):
     name = "gwe-" + test.name
 
     # verify format of generated netcdf file
-    with nc.Dataset(test.workspace / f"{name}.nc") as ds:
+    fname = f"{name}.{export}.nc" if gridded_input == "netcdf" else f"{name}.nc"
+    with nc.Dataset(test.workspace / fname) as ds:
         assert ds.data_model == "NETCDF4"
 
     if gridded_input == "netcdf":
         # re-run the simulation with model netcdf input
-        input_fname = f"{name}.nc"
-        nc_fname = f"{name}.{export}.nc"
-        os.rename(test.workspace / input_fname, test.workspace / nc_fname)
-
         if export == "ugrid":
             fileout_tag = "NETCDF_MESH2D"
         elif export == "structured":
@@ -93,7 +91,6 @@ def check_output(idx, test, export, gridded_input):
         with open(test.workspace / f"{name}.dis", "w") as f:
             f.write("BEGIN options\n")
             f.write("  NOGRB\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write(f"  NCF6  FILEIN  {name}.dis.ncf\n")
             f.write("END options\n\n")
             f.write("BEGIN dimensions\n")
@@ -111,7 +108,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{name}.ic", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  strt NETCDF\n")
@@ -120,7 +116,6 @@ def check_output(idx, test, export, gridded_input):
         with open(test.workspace / f"{name}.cnd", "w") as f:
             f.write("BEGIN options\n")
             f.write("  XT3D_OFF\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  alh  NETCDF\n")
@@ -141,11 +136,7 @@ def check_output(idx, test, export, gridded_input):
 
     check(idx, test)
 
-    # read transport results from GWE model
-    name = cases[idx]
-    gwename = "gwe-" + name
-
-    fpth = os.path.join(test.workspace, f"{gwename}.ucn")
+    fpth = os.path.join(test.workspace, f"{name}.ucn")
     try:
         # load temperatures
         cobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
@@ -154,7 +145,7 @@ def check_output(idx, test, export, gridded_input):
         assert False, f'could not load concentration data from "{fpth}"'
 
     # Check NetCDF output
-    nc_fpth = os.path.join(test.workspace, f"{gwename}.nc")
+    nc_fpth = os.path.join(test.workspace, f"{name}.nc")
     if export == "ugrid":
         ds = xu.open_dataset(nc_fpth)
         xds = ds.ugrid.to_dataset()
@@ -186,6 +177,19 @@ def check_output(idx, test, export, gridded_input):
                     xds["temperature"][kstp, :].data,
                 ), f"NetCDF-temperature comparison failure in timestep {kstp + 1}"
                 kstp += 1
+
+    xds.close()
+
+    if gridded_input == "ascii":
+        return
+
+    # Check NetCDF input
+    nc_fpth = os.path.join(test.workspace, f"{name}.{export}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
 
     vlist = [
         "dis_delr",
@@ -241,5 +245,6 @@ def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
         build=lambda t: build_models(idx, t, export, gridded_input),
         check=lambda t: check_output(idx, t, export, gridded_input),
         targets=targets,
+        cargs=["--mode=validate"] if gridded_input == "netcdf" else None,
     )
     test.run()

--- a/autotest/test_netcdf_gwf_disv.py
+++ b/autotest/test_netcdf_gwf_disv.py
@@ -51,7 +51,9 @@ def build_models(idx, test, gridded_input):
 
     name = cases[idx]
 
-    gwf.name_file.nc_mesh2d_filerecord = f"{name}.nc"
+    gwf.name_file.nc_mesh2d_filerecord = (
+        f"{name}.ugrid.nc" if gridded_input == "netcdf" else f"{name}.nc"
+    )
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -87,27 +89,11 @@ def check_output(idx, test, gridded_input):
     crs = grbobj._datadict["CRS"]
     assert crs == wkt
 
-    # verify format of generated netcdf file
-    with nc.Dataset(test.workspace / f"{name}.nc") as ds:
-        assert ds.data_model == "NETCDF4"
-        cmpr = ds.variables["head_l1"].filters()
-        chnk = ds.variables["head_l1"].chunking()
-        assert cmpr["shuffle"]
-        assert cmpr["complevel"] == 9
-        assert chnk == [1, 3]
-        assert ds.variables["projection"].getncattr("wkt").lower() == wkt.lower()
-
     if gridded_input == "netcdf":
         # re-run the simulation with model netcdf input
-        input_fname = f"{name}.nc"
-        nc_fname = f"{name}.ugrid.nc"
-        os.rename(test.workspace / input_fname, test.workspace / nc_fname)
-
-        fileout_tag = "NETCDF_MESH2D"
-
         with open(test.workspace / f"{name}.nam", "w") as f:
             f.write("BEGIN options\n")
-            f.write(f"  {fileout_tag}  FILEOUT  {name}.nc\n")
+            f.write(f"  NETCDF_MESH2D  FILEOUT  {name}.nc\n")
             f.write(f"  NETCDF  FILEIN {name}.ugrid.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")
@@ -120,7 +106,6 @@ def check_output(idx, test, gridded_input):
 
         with open(test.workspace / f"{name}.disv", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write(f"  NCF6  FILEIN  {name}.disv.ncf\n")
             f.write("END options\n\n")
             f.write("BEGIN dimensions\n")
@@ -166,7 +151,6 @@ def check_output(idx, test, gridded_input):
 
         with open(test.workspace / f"{name}.ic", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  strt NETCDF\n")
@@ -174,7 +158,6 @@ def check_output(idx, test, gridded_input):
 
         with open(test.workspace / f"{name}.npf", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  icelltype  NETCDF\n")
@@ -192,6 +175,16 @@ def check_output(idx, test, gridded_input):
         test.success = success
 
     check(idx, test)
+
+    # verify format of generated netcdf file
+    with nc.Dataset(test.workspace / f"{name}.nc") as ds:
+        assert ds.data_model == "NETCDF4"
+        cmpr = ds.variables["head_l1"].filters()
+        chnk = ds.variables["head_l1"].chunking()
+        assert cmpr["shuffle"]
+        assert cmpr["complevel"] == 9
+        assert chnk == [1, 3]
+        assert ds.variables["projection"].getncattr("wkt").lower() == wkt.lower()
 
     # Check NetCDF output
     nc_fpth = os.path.join(test.workspace, name + ".nc")
@@ -218,6 +211,16 @@ def check_output(idx, test, gridded_input):
                     xds[f"head_l{l + 1}"][timestep, :].fillna(1.00000000e30).data,
                 ), f"NetCDF-Headfile comparison failure in timestep {timestep + 1}"
             timestep += 1
+
+    xds.close()
+
+    if gridded_input == "ascii":
+        return
+
+    # Check NetCDF input
+    nc_fpth = os.path.join(test.workspace, f"{name}.ugrid.nc")
+    ds = xu.open_dataset(nc_fpth)
+    xds = ds.ugrid.to_dataset()
 
     # NetCDF variables, layered variables end with "_l"
     vlist = ["disv_top", "disv_botm_l", "npf_icelltype_l", "npf_k_l", "ic_strt_l"]
@@ -251,6 +254,7 @@ def test_mf6model(idx, name, function_tmpdir, targets, gridded_input):
         targets=targets,
         build=lambda t: build_models(idx, t, gridded_input),
         check=lambda t: check_output(idx, t, gridded_input),
+        cargs=["--mode=validate"] if gridded_input == "netcdf" else None,
         compare=None,
     )
     test.run()

--- a/autotest/test_netcdf_gwf_disv.py
+++ b/autotest/test_netcdf_gwf_disv.py
@@ -212,6 +212,11 @@ def check_output(idx, test, gridded_input):
                 ), f"NetCDF-Headfile comparison failure in timestep {timestep + 1}"
             timestep += 1
 
+    for v in xds.data_vars.keys():
+        assert not v.startswith("disv")
+        assert not v.startswith("ic")
+        assert not v.startswith("npf")
+
     xds.close()
 
     if gridded_input == "ascii":

--- a/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
+++ b/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
@@ -202,6 +202,11 @@ def check_output(idx, test, export, gridded_input):
                 ), f"NetCDF-head comparison failure in timestep {kstp + 1}"
                 kstp += 1
 
+    for v in xds.data_vars.keys():
+        assert not v.startswith("dis")
+        assert not v.startswith("ic")
+        assert not v.startswith("npf")
+
     xds.close()
 
     if gridded_input == "ascii":

--- a/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
+++ b/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
@@ -39,18 +39,18 @@ def build_models(idx, test, export, gridded_input):
     gwf.rch.export_array_netcdf = True
     gwf.evt.export_array_netcdf = True
 
-    name = cases[idx]
-    gwfname = "gwf-" + name
+    name = "gwf-" + cases[idx]
 
+    fname = f"{name}.{export}.nc" if gridded_input == "netcdf" else f"{name}.nc"
     if export == "ugrid":
-        gwf.name_file.nc_mesh2d_filerecord = f"{gwfname}.nc"
+        gwf.name_file.nc_mesh2d_filerecord = fname
     elif export == "structured":
-        gwf.name_file.nc_structured_filerecord = f"{gwfname}.nc"
+        gwf.name_file.nc_structured_filerecord = fname
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
         gwf.dis,
-        filename=f"{gwfname}.dis.ncf",
+        filename=f"{name}.dis.ncf",
     )
 
     return sim, dummy
@@ -59,48 +59,44 @@ def build_models(idx, test, export, gridded_input):
 def check_output(idx, test, export, gridded_input):
     from test_gwf_lak_wetlakbedarea02 import check_output as check
 
-    name = cases[idx]
-    gwfname = "gwf-" + name
+    name = "gwf-" + cases[idx]
 
     # verify format of generated netcdf file
-    with nc.Dataset(test.workspace / f"{gwfname}.nc") as ds:
+    fname = f"{name}.{export}.nc" if gridded_input == "netcdf" else f"{name}.nc"
+    with nc.Dataset(test.workspace / fname) as ds:
         assert ds.data_model == "NETCDF4"
 
     if gridded_input == "netcdf":
         # re-run the simulation with model netcdf input
-        input_fname = f"{gwfname}.nc"
-        nc_fname = f"{gwfname}.{export}.nc"
-        os.rename(test.workspace / input_fname, test.workspace / nc_fname)
 
         if export == "ugrid":
             fileout_tag = "NETCDF_MESH2D"
         elif export == "structured":
             fileout_tag = "NETCDF_STRUCTURED"
 
-        with open(test.workspace / f"{gwfname}.nam", "w") as f:
+        with open(test.workspace / f"{name}.nam", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_FLOWS\n")
             f.write("  NEWTON\n")
-            f.write(f"  {fileout_tag}  FILEOUT  {gwfname}.nc\n")
-            f.write(f"  NETCDF  FILEIN {gwfname}.{export}.nc\n")
+            f.write(f"  {fileout_tag}  FILEOUT  {name}.nc\n")
+            f.write(f"  NETCDF  FILEIN {name}.{export}.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")
-            f.write(f"  DIS6  {gwfname}.dis  dis\n")
-            f.write(f"  NPF6  {gwfname}.npf  npf\n")
-            f.write(f"  STO6  {gwfname}.sto  sto\n")
-            f.write(f"  IC6  {gwfname}.ic  ic\n")
-            f.write(f"  CHD6  {gwfname}.chd  chd_0\n")
-            f.write(f"  RCH6  {gwfname}.rcha  rcha_0\n")
-            f.write(f"  EVT6  {gwfname}.evta  evta_0\n")
-            f.write(f"  LAK6  {gwfname}.lak  lak-1\n")
-            f.write(f"  OC6  {gwfname}.oc  oc\n")
+            f.write(f"  DIS6  {name}.dis  dis\n")
+            f.write(f"  NPF6  {name}.npf  npf\n")
+            f.write(f"  STO6  {name}.sto  sto\n")
+            f.write(f"  IC6  {name}.ic  ic\n")
+            f.write(f"  CHD6  {name}.chd  chd_0\n")
+            f.write(f"  RCH6  {name}.rcha  rcha_0\n")
+            f.write(f"  EVT6  {name}.evta  evta_0\n")
+            f.write(f"  LAK6  {name}.lak  lak-1\n")
+            f.write(f"  OC6  {name}.oc  oc\n")
             f.write("END packages\n")
 
-        with open(test.workspace / f"{gwfname}.dis", "w") as f:
+        with open(test.workspace / f"{name}.dis", "w") as f:
             f.write("BEGIN options\n")
             f.write("  LENGTH_UNITS feet\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
-            f.write(f"  NCF6  FILEIN  {gwfname}.dis.ncf\n")
+            f.write(f"  NCF6  FILEIN  {name}.dis.ncf\n")
             f.write("END options\n\n")
             f.write("BEGIN dimensions\n")
             f.write("  NLAY  6\n")
@@ -115,18 +111,16 @@ def check_output(idx, test, export, gridded_input):
             f.write("  idomain NETCDF\n")
             f.write("END griddata\n\n")
 
-        with open(test.workspace / f"{gwfname}.ic", "w") as f:
+        with open(test.workspace / f"{name}.ic", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  strt NETCDF\n")
             f.write("END griddata\n")
 
-        with open(test.workspace / f"{gwfname}.npf", "w") as f:
+        with open(test.workspace / f"{name}.npf", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_SPECIFIC_DISCHARGE\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  icelltype  NETCDF\n")
@@ -134,19 +128,17 @@ def check_output(idx, test, export, gridded_input):
             f.write("  k33  NETCDF\n")
             f.write("END griddata\n")
 
-        with open(test.workspace / f"{gwfname}.rcha", "w") as f:
+        with open(test.workspace / f"{name}.rcha", "w") as f:
             f.write("BEGIN options\n")
             f.write("  READASARRAYS\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN period 1\n")
             f.write("  recharge NETCDF\n")
             f.write("END period 1\n")
 
-        with open(test.workspace / f"{gwfname}.evta", "w") as f:
+        with open(test.workspace / f"{name}.evta", "w") as f:
             f.write("BEGIN options\n")
             f.write("  READASARRAYS\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN period 1\n")
             f.write("  surface NETCDF\n")
@@ -166,13 +158,9 @@ def check_output(idx, test, export, gridded_input):
 
     check(idx, test)
 
-    # read transport results from GWF model
-    name = cases[idx]
-    gwfname = "gwf-" + name
-
     try:
         # load heads
-        fname = gwfname + ".hds"
+        fname = name + ".hds"
         fpth = os.path.join(test.workspace, fname)
         hobj = flopy.utils.HeadFile(fpth, precision="double")
         heads = hobj.get_alldata()
@@ -180,7 +168,7 @@ def check_output(idx, test, export, gridded_input):
         assert False, f'could not load headfile data from "{fpth}"'
 
     # Check NetCDF output
-    nc_fpth = os.path.join(test.workspace, f"{gwfname}.nc")
+    nc_fpth = os.path.join(test.workspace, f"{name}.nc")
     if export == "ugrid":
         ds = xu.open_dataset(nc_fpth)
         xds = ds.ugrid.to_dataset()
@@ -213,6 +201,19 @@ def check_output(idx, test, export, gridded_input):
                     xds["head"][kstp, :].fillna(1.00000000e30).data,
                 ), f"NetCDF-head comparison failure in timestep {kstp + 1}"
                 kstp += 1
+
+    xds.close()
+
+    if gridded_input == "ascii":
+        return
+
+    # Check NetCDF input
+    nc_fpth = os.path.join(test.workspace, f"{name}.{export}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
 
     vlist = [
         "dis_delr",
@@ -266,5 +267,6 @@ def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
         build=lambda t: build_models(idx, t, export, gridded_input),
         check=lambda t: check_output(idx, t, export, gridded_input),
         targets=targets,
+        cargs=["--mode=validate"] if gridded_input == "netcdf" else None,
     )
     test.run()

--- a/autotest/test_netcdf_gwf_rch01.py
+++ b/autotest/test_netcdf_gwf_rch01.py
@@ -40,10 +40,11 @@ def build_models(idx, test, export, gridded_input):
 
     name = "rch"
 
+    fname = f"{name}.{export}.nc" if gridded_input == "netcdf" else f"{name}.nc"
     if export == "ugrid":
-        gwf.name_file.nc_mesh2d_filerecord = f"{name}.nc"
+        gwf.name_file.nc_mesh2d_filerecord = fname
     elif export == "structured":
-        gwf.name_file.nc_structured_filerecord = f"{name}.nc"
+        gwf.name_file.nc_structured_filerecord = fname
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -60,15 +61,12 @@ def check_output(idx, test, export, gridded_input):
     name = "rch"
 
     # verify format of generated netcdf file
-    with nc.Dataset(test.workspace / f"{name}.nc") as ds:
+    fname = f"{name}.{export}.nc" if gridded_input == "netcdf" else f"{name}.nc"
+    with nc.Dataset(test.workspace / fname) as ds:
         assert ds.data_model == "NETCDF4"
 
     if gridded_input == "netcdf":
         # re-run the simulation with model netcdf input
-        input_fname = f"{name}.nc"
-        nc_fname = f"{name}.{export}.nc"
-        os.rename(test.workspace / input_fname, test.workspace / nc_fname)
-
         if export == "ugrid":
             fileout_tag = "NETCDF_MESH2D"
         elif export == "structured":
@@ -92,7 +90,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{name}.dis", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write(f"  NCF6  FILEIN  {name}.dis.ncf\n")
             f.write("END options\n\n")
             f.write("BEGIN dimensions\n")
@@ -109,7 +106,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{name}.ic", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  strt NETCDF\n")
@@ -118,7 +114,6 @@ def check_output(idx, test, export, gridded_input):
         with open(test.workspace / f"{name}.npf", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_FLOWS\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  icelltype  NETCDF\n")
@@ -128,7 +123,6 @@ def check_output(idx, test, export, gridded_input):
         with open(test.workspace / f"{name}.rcha", "w") as f:
             f.write("BEGIN options\n")
             f.write("  READASARRAYS\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN period 1\n")
             if idx > 0:
@@ -192,6 +186,19 @@ def check_output(idx, test, export, gridded_input):
                     xds["head"][kstp, :].data,
                 ), f"NetCDF-head comparison failure in timestep {kstp + 1}"
                 kstp += 1
+
+    xds.close()
+
+    if gridded_input == "ascii":
+        return
+
+    # Check NetCDF input
+    nc_fpth = os.path.join(test.workspace, f"{name}.{export}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
 
     # compare recharge arrays
     rch = getattr(gwf, "rcha_0")
@@ -262,5 +269,6 @@ def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
         build=lambda t: build_models(idx, t, export, gridded_input),
         check=lambda t: check_output(idx, t, export, gridded_input),
         targets=targets,
+        cargs=["--mode=validate"] if gridded_input == "netcdf" else None,
     )
     test.run()

--- a/autotest/test_netcdf_gwf_rch01.py
+++ b/autotest/test_netcdf_gwf_rch01.py
@@ -187,6 +187,12 @@ def check_output(idx, test, export, gridded_input):
                 ), f"NetCDF-head comparison failure in timestep {kstp + 1}"
                 kstp += 1
 
+    for v in xds.data_vars.keys():
+        assert not v.startswith("rcha")
+        assert not v.startswith("dis")
+        assert not v.startswith("ic")
+        assert not v.startswith("npf")
+
     xds.close()
 
     if gridded_input == "ascii":

--- a/autotest/test_netcdf_gwf_rch03.py
+++ b/autotest/test_netcdf_gwf_rch03.py
@@ -185,6 +185,12 @@ def check_output(idx, test, export, gridded_input):
                 ), f"NetCDF-head comparison failure in timestep {kstp + 1}"
                 kstp += 1
 
+    for v in xds.data_vars.keys():
+        assert not v.startswith("rcha")
+        assert not v.startswith("dis")
+        assert not v.startswith("ic")
+        assert not v.startswith("npf")
+
     xds.close()
 
     if gridded_input == "ascii":

--- a/autotest/test_netcdf_gwf_rch03.py
+++ b/autotest/test_netcdf_gwf_rch03.py
@@ -38,13 +38,13 @@ def build_models(idx, test, export, gridded_input):
     gwf.npf.export_array_netcdf = True
     gwf.rch.export_array_netcdf = True
 
-    # name = "gwf-" + cases[idx]
     name = "rch"
 
+    fname = f"{name}.{export}.nc" if gridded_input == "netcdf" else f"{name}.nc"
     if export == "ugrid":
-        gwf.name_file.nc_mesh2d_filerecord = f"{name}.nc"
+        gwf.name_file.nc_mesh2d_filerecord = fname
     elif export == "structured":
-        gwf.name_file.nc_structured_filerecord = f"{name}.nc"
+        gwf.name_file.nc_structured_filerecord = fname
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -61,15 +61,12 @@ def check_output(idx, test, export, gridded_input):
     name = "rch"
 
     # verify format of generated netcdf file
-    with nc.Dataset(test.workspace / f"{name}.nc") as ds:
+    fname = f"{name}.{export}.nc" if gridded_input == "netcdf" else f"{name}.nc"
+    with nc.Dataset(test.workspace / fname) as ds:
         assert ds.data_model == "NETCDF4"
 
     if gridded_input == "netcdf":
         # re-run the simulation with model netcdf input
-        input_fname = f"{name}.nc"
-        nc_fname = f"{name}.{export}.nc"
-        os.rename(test.workspace / input_fname, test.workspace / nc_fname)
-
         if export == "ugrid":
             fileout_tag = "NETCDF_MESH2D"
         elif export == "structured":
@@ -92,7 +89,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{name}.dis", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write(f"  NCF6  FILEIN  {name}.dis.ncf\n")
             f.write("END options\n\n")
             f.write("BEGIN dimensions\n")
@@ -110,7 +106,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{name}.ic", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  strt NETCDF\n")
@@ -119,7 +114,6 @@ def check_output(idx, test, export, gridded_input):
         with open(test.workspace / f"{name}.npf", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_FLOWS\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  icelltype  NETCDF\n")
@@ -130,7 +124,6 @@ def check_output(idx, test, export, gridded_input):
             f.write("BEGIN options\n")
             f.write("  READASARRAYS\n")
             f.write("  PRINT_FLOWS\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN period 1\n")
             f.write("  irch NETCDF\n")
@@ -148,9 +141,6 @@ def check_output(idx, test, export, gridded_input):
         test.success = success
 
     check(idx, test)
-
-    # read transport results from GWF model
-    name = "rch"
 
     try:
         # load heads
@@ -194,6 +184,19 @@ def check_output(idx, test, export, gridded_input):
                     xds["head"][kstp, :].fillna(1.00000000e30).data,
                 ), f"NetCDF-head comparison failure in timestep {kstp + 1}"
                 kstp += 1
+
+    xds.close()
+
+    if gridded_input == "ascii":
+        return
+
+    # Check NetCDF input
+    nc_fpth = os.path.join(test.workspace, f"{name}.{export}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
 
     # compare recharge arrays
     rch = getattr(gwf, "rcha_0")
@@ -264,5 +267,6 @@ def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
         build=lambda t: build_models(idx, t, export, gridded_input),
         check=lambda t: check_output(idx, t, export, gridded_input),
         targets=targets,
+        cargs=["--mode=validate"] if gridded_input == "netcdf" else None,
     )
     test.run()

--- a/autotest/test_netcdf_gwf_sto01.py
+++ b/autotest/test_netcdf_gwf_sto01.py
@@ -44,11 +44,7 @@ def build_models(idx, test, export, gridded_input):
     sim, dummy = build(idx, test)
     sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwf = sim.gwf[0]
-    gwf.dis.export_array_netcdf = True
     gwf.dis.crs = wkt
-    gwf.ic.export_array_netcdf = True
-    gwf.npf.export_array_netcdf = True
-    gwf.sto.export_array_netcdf = True
 
     name = cases[idx]
 
@@ -90,7 +86,7 @@ def check_output(idx, test, export, gridded_input):
     assert crs == wkt
 
     # verify format of generated netcdf file
-    with nc.Dataset(test.workspace / "gwf_sto01.nc") as ds:
+    with nc.Dataset(test.workspace / f"{test.name}.nc") as ds:
         assert ds.data_model == "NETCDF4"
         if export == "structured":
             cmpr = ds.variables["head"].filters()
@@ -108,11 +104,30 @@ def check_output(idx, test, export, gridded_input):
         assert cmpr["complevel"] == 5
 
     if gridded_input == "netcdf":
-        # re-run the simulation with model netcdf input
-        input_fname = "gwf_sto01.nc"
-        nc_fname = f"gwf_sto01.{export}.nc"
-        os.rename(test.workspace / input_fname, test.workspace / nc_fname)
+        # re-run the simulation in validate mode to generate netcdf input
+        test.sims[0].gwf[0].get_package("DIS").export_array_netcdf = True
+        test.sims[0].gwf[0].get_package("IC").export_array_netcdf = True
+        test.sims[0].gwf[0].get_package("NPF").export_array_netcdf = True
+        test.sims[0].gwf[0].get_package("STO").export_array_netcdf = True
+        if export == "ugrid":
+            test.sims[0].gwf[
+                0
+            ].name_file.nc_mesh2d_filerecord = f"{test.name}.{export}.nc"
+        elif export == "structured":
+            test.sims[0].gwf[
+                0
+            ].name_file.nc_structured_filerecord = f"{test.name}.{export}.nc"
+        test.sims[0].write_simulation()
+        success, buff = flopy.run_model(
+            test.targets["mf6"],
+            test.workspace / "mfsim.nam",
+            model_ws=test.workspace,
+            report=True,
+            cargs=["--mode=validate"],
+        )
+        assert success
 
+        # re-run the simulation with model netcdf input
         if export == "ugrid":
             fileout_tag = "NETCDF_MESH2D"
         elif export == "structured":
@@ -138,7 +153,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / "gwf_sto01.dis", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("  NCF6  FILEIN  gwf_sto01.dis.ncf\n")
             f.write("END options\n\n")
             f.write("BEGIN dimensions\n")
@@ -155,7 +169,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / "gwf_sto01.ic", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  strt NETCDF\n")
@@ -163,7 +176,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / "gwf_sto01.npf", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  icelltype  NETCDF\n")
@@ -173,7 +185,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / "gwf_sto01.sto", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  iconvert  NETCDF\n")
@@ -237,6 +248,19 @@ def check_output(idx, test, export, gridded_input):
                     xds["head"][timestep, :].data,
                 ), f"NetCDF-Headfile comparison failure in timestep {timestep + 1}"
                 timestep += 1
+
+    xds.close()
+
+    if gridded_input == "ascii":
+        return
+
+    # Check NetCDF input
+    nc_fpth = os.path.join(test.workspace, f"{test.name}.{export}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
 
     vlist = [
         "dis_delr",

--- a/autotest/test_netcdf_gwf_vsc03_sfr.py
+++ b/autotest/test_netcdf_gwf_vsc03_sfr.py
@@ -43,10 +43,11 @@ def build_models(idx, test, export, gridded_input):
 
     name = "gwf-" + cases[idx]
 
+    fname = f"{name}.{export}.nc" if gridded_input == "netcdf" else f"{name}.nc"
     if export == "ugrid":
-        gwf.name_file.nc_mesh2d_filerecord = f"{name}.nc"
+        gwf.name_file.nc_mesh2d_filerecord = fname
     elif export == "structured":
-        gwf.name_file.nc_structured_filerecord = f"{name}.nc"
+        gwf.name_file.nc_structured_filerecord = fname
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -63,15 +64,12 @@ def check_output(idx, test, export, gridded_input):
     name = "gwf-" + test.name
 
     # verify format of generated netcdf file
-    with nc.Dataset(test.workspace / f"{name}.nc") as ds:
+    fname = f"{name}.{export}.nc" if gridded_input == "netcdf" else f"{name}.nc"
+    with nc.Dataset(test.workspace / fname) as ds:
         assert ds.data_model == "NETCDF4"
 
     if gridded_input == "netcdf":
         # re-run the simulation with model netcdf input
-        input_fname = f"{name}.nc"
-        nc_fname = f"{name}.{export}.nc"
-        os.rename(test.workspace / input_fname, test.workspace / nc_fname)
-
         if export == "ugrid":
             fileout_tag = "NETCDF_MESH2D"
         elif export == "structured":
@@ -100,7 +98,6 @@ def check_output(idx, test, export, gridded_input):
         with open(test.workspace / f"{name}.dis", "w") as f:
             f.write("BEGIN options\n")
             f.write("  LENGTH_UNITS m\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write(f"  NCF6  FILEIN  {name}.dis.ncf\n")
             f.write("END options\n\n")
             f.write("BEGIN dimensions\n")
@@ -117,7 +114,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{name}.ic", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  strt NETCDF\n")
@@ -126,7 +122,6 @@ def check_output(idx, test, export, gridded_input):
         with open(test.workspace / f"{name}.npf", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_SPECIFIC_DISCHARGE\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  icelltype  NETCDF\n")
@@ -135,7 +130,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{name}.sto", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  iconvert  NETCDF\n")
@@ -154,7 +148,6 @@ def check_output(idx, test, export, gridded_input):
             f.write("  READASARRAYS\n")
             f.write("  auxiliary  TEMPERATURE\n")
             f.write("  PRINT_FLOWS\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN period 1\n")
             f.write("  irch NETCDF\n")
@@ -219,6 +212,19 @@ def check_output(idx, test, export, gridded_input):
                     xds["head"][kstp, :].fillna(1.00000000e30).data,
                 ), f"NetCDF-head comparison failure in timestep {kstp + 1}"
                 kstp += 1
+
+    xds.close()
+
+    if gridded_input == "ascii":
+        return
+
+    # Check NetCDF input
+    nc_fpth = os.path.join(test.workspace, f"{name}.{export}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
 
     # compare recharge arrays
     rch = getattr(gwf, "rcha-1")
@@ -294,5 +300,6 @@ def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
         build=lambda t: build_models(idx, t, export, gridded_input),
         check=lambda t: check_output(idx, t, export, gridded_input),
         targets=targets,
+        cargs=["--mode=validate"] if gridded_input == "netcdf" else None,
     )
     test.run()

--- a/autotest/test_netcdf_gwf_vsc03_sfr.py
+++ b/autotest/test_netcdf_gwf_vsc03_sfr.py
@@ -213,6 +213,13 @@ def check_output(idx, test, export, gridded_input):
                 ), f"NetCDF-head comparison failure in timestep {kstp + 1}"
                 kstp += 1
 
+    for v in xds.data_vars.keys():
+        assert not v.startswith("rcha")
+        assert not v.startswith("dis")
+        assert not v.startswith("ic")
+        assert not v.startswith("npf")
+        assert not v.startswith("sto")
+
     xds.close()
 
     if gridded_input == "ascii":

--- a/autotest/test_netcdf_gwt_dsp01.py
+++ b/autotest/test_netcdf_gwt_dsp01.py
@@ -28,8 +28,9 @@ def build_models(idx, test, export, gridded_input):
     # output control
     gwtname = "gwt_" + cases[idx]
 
+    fname = f"{gwtname}.{export}.nc" if gridded_input == "netcdf" else f"{gwtname}.nc"
     if export == "ugrid":
-        gwt.name_file.nc_mesh2d_filerecord = f"{gwtname}.nc"
+        gwt.name_file.nc_mesh2d_filerecord = fname
         ncf = flopy.mf6.ModflowUtlncf(
             gwt.dis,
             deflate=3,
@@ -39,7 +40,7 @@ def build_models(idx, test, export, gridded_input):
             filename=f"{gwtname}.dis.ncf",
         )
     elif export == "structured":
-        gwt.name_file.nc_structured_filerecord = f"{gwtname}.nc"
+        gwt.name_file.nc_structured_filerecord = fname
         ncf = flopy.mf6.ModflowUtlncf(
             gwt.dis,
             deflate=3,
@@ -69,26 +70,8 @@ def check_output(idx, test, export, gridded_input):
     name = cases[idx]
     gwtname = "gwt_" + name
 
-    # verify format of generated netcdf file
-    with nc.Dataset(test.workspace / f"{gwtname}.nc") as ds:
-        assert ds.data_model == "NETCDF4"
-        if export == "structured":
-            cmpr = ds.variables["concentration"].filters()
-            chnk = ds.variables["concentration"].chunking()
-            assert chnk == [1, 1, 1, 20]
-        elif export == "ugrid":
-            cmpr = ds.variables["concentration_l1"].filters()
-            chnk = ds.variables["concentration_l1"].chunking()
-            assert chnk == [1, 5]
-        assert not cmpr["shuffle"]
-        assert cmpr["complevel"] == 3
-
     if gridded_input == "netcdf":
         # re-run the simulation with model netcdf input
-        input_fname = f"{gwtname}.nc"
-        nc_fname = f"{gwtname}.{export}.nc"
-        os.rename(test.workspace / input_fname, test.workspace / nc_fname)
-
         if export == "ugrid":
             fileout_tag = "NETCDF_MESH2D"
         elif export == "structured":
@@ -114,7 +97,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{gwtname}.dis", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write(f"  NCF6  FILEIN  {gwtname}.dis.ncf\n")
             f.write("END options\n\n")
             f.write("BEGIN dimensions\n")
@@ -132,7 +114,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{gwtname}.ic", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  strt NETCDF\n")
@@ -142,7 +123,6 @@ def check_output(idx, test, export, gridded_input):
             f.write("BEGIN options\n")
             if not xt3d[idx]:
                 f.write("  XT3D_OFF\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  diffc  NETCDF\n")
@@ -163,6 +143,20 @@ def check_output(idx, test, export, gridded_input):
         test.success = success
 
     check(idx, test)
+
+    # verify format of generated netcdf file
+    with nc.Dataset(test.workspace / f"{gwtname}.nc") as ds:
+        assert ds.data_model == "NETCDF4"
+        if export == "structured":
+            cmpr = ds.variables["concentration"].filters()
+            chnk = ds.variables["concentration"].chunking()
+            assert chnk == [1, 1, 1, 20]
+        elif export == "ugrid":
+            cmpr = ds.variables["concentration_l1"].filters()
+            chnk = ds.variables["concentration_l1"].chunking()
+            assert chnk == [1, 5]
+        assert not cmpr["shuffle"]
+        assert cmpr["complevel"] == 3
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
@@ -207,6 +201,19 @@ def check_output(idx, test, export, gridded_input):
                     xds["concentration"][timestep, :].data,
                 ), f"NetCDF-concentration comparison failure in timestep {timestep + 1}"
                 timestep += 1
+
+    xds.close()
+
+    if gridded_input == "ascii":
+        return
+
+    # Check NetCDF input
+    nc_fpth = os.path.join(test.workspace, f"{gwtname}.{export}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
 
     vlist = [
         "dis_delr",
@@ -260,5 +267,6 @@ def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
         targets=targets,
         build=lambda t: build_models(idx, t, export, gridded_input),
         check=lambda t: check_output(idx, t, export, gridded_input),
+        cargs=["--mode=validate"] if gridded_input == "netcdf" else None,
     )
     test.run()

--- a/autotest/test_netcdf_gwt_dsp01.py
+++ b/autotest/test_netcdf_gwt_dsp01.py
@@ -202,6 +202,11 @@ def check_output(idx, test, export, gridded_input):
                 ), f"NetCDF-concentration comparison failure in timestep {timestep + 1}"
                 timestep += 1
 
+    for v in xds.data_vars.keys():
+        assert not v.startswith("dis")
+        assert not v.startswith("ic")
+        assert not v.startswith("dsp")
+
     xds.close()
 
     if gridded_input == "ascii":

--- a/autotest/test_netcdf_gwt_prudic2004t2.py
+++ b/autotest/test_netcdf_gwt_prudic2004t2.py
@@ -28,10 +28,11 @@ def build_models(idx, test, export, gridded_input):
     name = cases[idx]
     gwtname = "gwt_" + name
 
+    fname = f"{gwtname}.{export}.nc" if gridded_input == "netcdf" else f"{gwtname}.nc"
     if export == "ugrid":
-        gwt.name_file.nc_mesh2d_filerecord = f"{gwtname}.nc"
+        gwt.name_file.nc_mesh2d_filerecord = fname
     elif export == "structured":
-        gwt.name_file.nc_structured_filerecord = f"{gwtname}.nc"
+        gwt.name_file.nc_structured_filerecord = fname
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -49,15 +50,12 @@ def check_output(idx, test, export, gridded_input):
     gwtname = "gwt_" + name
 
     # verify format of generated netcdf file
-    with nc.Dataset(test.workspace / f"{gwtname}.nc") as ds:
+    fname = f"{gwtname}.{export}.nc" if gridded_input == "netcdf" else f"{gwtname}.nc"
+    with nc.Dataset(test.workspace / fname) as ds:
         assert ds.data_model == "NETCDF4"
 
     if gridded_input == "netcdf":
         # re-run the simulation with model netcdf input
-        input_fname = f"{gwtname}.nc"
-        nc_fname = f"{gwtname}.{export}.nc"
-        os.rename(test.workspace / input_fname, test.workspace / nc_fname)
-
         if export == "ugrid":
             fileout_tag = "NETCDF_MESH2D"
         elif export == "structured":
@@ -84,7 +82,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{gwtname}.dis", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write(f"  NCF6  FILEIN  {gwtname}.dis.ncf\n")
             f.write("END options\n\n")
             f.write("BEGIN dimensions\n")
@@ -102,7 +99,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{gwtname}.ic", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  strt NETCDF\n")
@@ -110,7 +106,6 @@ def check_output(idx, test, export, gridded_input):
 
         with open(test.workspace / f"{gwtname}.dsp", "w") as f:
             f.write("BEGIN options\n")
-            f.write("  EXPORT_ARRAY_NETCDF\n")
             f.write("END options\n\n")
             f.write("BEGIN griddata\n")
             f.write("  alh  NETCDF\n")
@@ -174,6 +169,19 @@ def check_output(idx, test, export, gridded_input):
                 ), f"NetCDF-concentration comparison failure in timestep {timestep + 1}"
                 timestep += 1
 
+    xds.close()
+
+    if gridded_input == "ascii":
+        return
+
+    # Check NetCDF input
+    nc_fpth = os.path.join(test.workspace, f"{gwtname}.{export}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
+
     vlist = [
         "dis_delr",
         "dis_delc",
@@ -223,5 +231,6 @@ def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
         targets=targets,
         build=lambda t: build_models(idx, t, export, gridded_input),
         check=lambda t: check_output(idx, t, export, gridded_input),
+        cargs=["--mode=validate"] if gridded_input == "netcdf" else None,
     )
     test.run()

--- a/autotest/test_netcdf_gwt_prudic2004t2.py
+++ b/autotest/test_netcdf_gwt_prudic2004t2.py
@@ -169,6 +169,11 @@ def check_output(idx, test, export, gridded_input):
                 ), f"NetCDF-concentration comparison failure in timestep {timestep + 1}"
                 timestep += 1
 
+    for v in xds.data_vars.keys():
+        assert not v.startswith("dis")
+        assert not v.startswith("ic")
+        assert not v.startswith("dsp")
+
     xds.close()
 
     if gridded_input == "ascii":

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -12,6 +12,7 @@ advanced = "ADVANCED STRESS PACKAGES"
 solution = "SOLUTION"
 exchanges = "EXCHANGES"
 parallel = "PARALLEL"
+netcdf = "NETCDF"
 
 [[items]]
 section = "features"
@@ -137,3 +138,9 @@ description = "Added support for vertical hydraulic barriers in the HFB package.
 section = "fixes"
 subsection = "exchanges"
 description = "Fixed a bug that crashed the program during initialization when GWT or GWE models were connected through an Exchange and at least one model has grid type DISU and does not have the (currently optional) CELL2D information specified in its input. It could have happened for GWF models in a similar manner, though only when running in parallel mode."
+
+
+[[items]]
+section = "fixes"
+subsection = "netcdf"
+description = "Previously, gridded parameters read from ascii input files could be written to configured NetCDF files with the package EXPORT\\_ARRAY\\_NETCDF option in both regular and validate simulation mode. This capability will now only be supported in validate mode and is primarily intended to support generating NetCDF files that can serve as model inputs in subsequent simulation runs. Furthermore, the time dimension in these generated NetCDF input files, when defined, has been updated from NSTP to NPER, and the MODFLOW 6 NetCDF input load interfaces have been updated to reflect that change."

--- a/doc/mf6io/extended_modflow.tex
+++ b/doc/mf6io/extended_modflow.tex
@@ -8,12 +8,12 @@ This sections describes input files that are only available with Extended \mf.  
 \subsection{NetCDF in Extended \mf}
 Extended \mf can read and write version 4 NetCDF (Network Common Data Form) files. Two different formats are supported for each (input and output) file type: a structured format and a UGRID (Unstructured Grid) based Layered Mesh format. Each format aims to be cf-conventions compliant.
 
-All MODFLOW 6 NetCDF files correspond to a model. Output files typically contain arrays for the model dependent variable. Input files can contain package arrays that are supported as inputs from NetCDF files. These variables are indicated with red highlighting in package description chapters of this guide. Refer to the \mf Wiki (linked above) for additional documentation and details related to using NetCDF files as \mf inputs.
+All \mf NetCDF files correspond to a model. Output files contain model dependent variable array(s). Input files can contain package gridded arrays that are supported as inputs from NetCDF files. These variables are indicated with red highlighting in package description chapters of this guide. Refer to the \mf Wiki (linked above) for additional documentation and details related to using NetCDF files as \mf inputs.
 
-\mf structured NetCDF files support GWF, GWT and GWE models based on DIS package grids. To configure a model structured NetCDF output file that includes a dependent timeseries variable, add the NETCDF\_STRUCTURED option to the model name file:
+\mf structured NetCDF files support GWF, GWT and GWE models based on DIS package grids. To configure a structured NetCDF output file that includes the model dependent timeseries variable, add the NETCDF\_STRUCTURED option to the model name file:
 \lstinputlisting[style=inputfile]{./mf6ivar/examples/ext-netcdf-gwf-structured.dat}
 
-\mf UGRID Layered Mesh NetCDF files support GWF, GWT and GWE models based on DIS and DISV package grids. Each grid based array variable in these file types is split into a set of layer variables, including model dependent variable output. To configure a model NetCDF mesh output file that includes layered dependent timeseries variables, add the NETCDF\_MESH2D output file option to the model name file:
+\mf UGRID Layered Mesh NetCDF files support GWF, GWT and GWE models based on DIS and DISV package grids. Each grid based array variable in these file types is split into a set of layer variables, including model dependent variable output. To configure a layered mesh NetCDF output file that includes model dependent timeseries variables, add the NETCDF\_MESH2D output file option to the model name file:
 \lstinputlisting[style=inputfile]{./mf6ivar/examples/ext-netcdf-gwf-mesh.dat}
 
 \newpage

--- a/doc/mf6io/mf6ivar/dfn/gwe-cnd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-cnd.dfn
@@ -34,7 +34,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwe cnd griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-dis.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-disv.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwe-ic.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-ic.dfn
@@ -16,7 +16,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwe ic griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-chdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-chdg.dfn
@@ -107,7 +107,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # dev options

--- a/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-dis.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
@@ -125,7 +125,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # dev options

--- a/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
@@ -173,6 +173,7 @@ shape (ncol*nrow; ncpl)
 reader readarray
 numeric_index true
 optional true
+netcdf true
 longname layer number for evapotranspiration
 description IEVT is the layer number that defines the layer in each vertical column where evapotranspiration is applied. If IEVT is omitted, evapotranspiration by default is applied to cells in layer 1.  If IEVT is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error.
 
@@ -181,6 +182,7 @@ name surface
 type double precision
 shape (ncol*nrow; ncpl)
 reader readarray
+netcdf true
 longname evapotranspiration surface
 description is the elevation of the ET surface ($L$).
 default_value 0.
@@ -191,6 +193,7 @@ type double precision
 shape (ncol*nrow; ncpl)
 reader readarray
 time_series true
+netcdf true
 longname evapotranspiration surface
 description is the maximum ET flux rate ($LT^{-1}$).
 default_value 1.e-3
@@ -200,6 +203,7 @@ name depth
 type double precision
 shape (ncol*nrow; ncpl)
 reader readarray
+netcdf true
 longname extinction depth
 description is the ET extinction depth ($L$).
 default_value 1.0
@@ -210,6 +214,7 @@ type double precision
 shape (ncol*nrow; ncpl)
 reader readarray
 time_series true
+netcdf true
 longname evapotranspiration auxiliary variable iaux
 description is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.
 mf6internal auxvar

--- a/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
@@ -148,7 +148,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwf evta period ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
@@ -116,7 +116,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwf ghbg dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-ic.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-ic.dfn
@@ -16,7 +16,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwf ic griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-npf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-npf.dfn
@@ -250,7 +250,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # dev options

--- a/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
@@ -173,6 +173,7 @@ shape (ncol*nrow; ncpl)
 reader readarray
 numeric_index true
 optional true
+netcdf true
 longname layer number for recharge
 description IRCH is the layer number that defines the layer in each vertical column where recharge is applied. If IRCH is omitted, recharge by default is applied to cells in layer 1.  IRCH can only be used if READASARRAYS is specified in the OPTIONS block.  If IRCH is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error.
 
@@ -182,6 +183,7 @@ type double precision
 shape (ncol*nrow; ncpl)
 reader readarray
 time_series true
+netcdf true
 longname recharge rate
 description is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the ``Using Time-Array Series in a Package'' section).
 default_value 1.e-3
@@ -193,6 +195,7 @@ shape (ncol*nrow; ncpl)
 reader readarray
 time_series true
 optional true
+netcdf true
 longname recharge auxiliary variable iaux
 description is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array.
 mf6internal auxvar

--- a/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
@@ -148,7 +148,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwf rcha period ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-rivg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rivg.dfn
@@ -116,7 +116,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwf rivg dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-sto.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sto.dfn
@@ -85,7 +85,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # dev options

--- a/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
@@ -180,7 +180,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwf wel dimensions ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-dis.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
@@ -97,7 +97,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwt-dsp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-dsp.dfn
@@ -34,7 +34,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwt dsp griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-ic.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-ic.dfn
@@ -16,7 +16,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwt ic griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-ist.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-ist.dfn
@@ -275,7 +275,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwt ist griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwt-mst.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-mst.dfn
@@ -96,7 +96,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 extended true
 
 # --------------------- gwt mst griddata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-dis.dfn
@@ -96,7 +96,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 
 block options
 name crs

--- a/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-disv.dfn
@@ -96,7 +96,7 @@ reader urword
 optional true
 mf6internal export_nc
 longname export array variables to netcdf output files.
-description keyword that specifies input griddata arrays should be written to the model output NetCDF file.
+description keyword that specifies input gridded arrays should be written to the model output NetCDF file with attributes that support using the generated file as a MODFLOW 6 simulation input.  This option only has an effect when an output model NetCDF file is configured and the simulation is run in VALIDATE mode, otherwise it is ignored.
 
 block options
 name crs

--- a/src/Utilities/Export/DisNCMesh.f90
+++ b/src/Utilities/Export/DisNCMesh.f90
@@ -93,18 +93,21 @@ contains
     call this%define_dim()
     ! define mesh variables
     call this%create_mesh()
-    if (isim_mode /= MVALIDATE) then
+    if (isim_mode == MVALIDATE) then
+      ! define period input arrays
+      call this%df_export()
+    else
       ! define the dependent variable
       call this%define_dependent()
     end if
-    ! define period input arrays
-    call this%df_export()
     ! exit define mode
     call nf_verify(nf90_enddef(this%ncid), this%nc_fname)
     ! create mesh
     call this%add_mesh_data()
-    ! define and set package input griddata
-    call this%add_pkg_data()
+    if (isim_mode == MVALIDATE) then
+      ! define and set package input griddata
+      call this%add_pkg_data()
+    end if
     ! define and set gridmap variable
     call this%define_gridmap()
     ! synchronize file
@@ -181,7 +184,7 @@ contains
   !> @brief netcdf export package dynamic input
   !<
   subroutine package_step(this, export_pkg)
-    use TdisModule, only: kper
+    use TdisModule, only: totim, kper
     use DefinitionSelectModule, only: get_param_definition_type
     use NCModelExportModule, only: ExportPackageType
     class(Mesh2dDisExportType), intent(inout) :: this
@@ -306,6 +309,11 @@ contains
       end select
     end do
 
+    ! write to time coordinate variable
+    call nf_verify(nf90_put_var(this%ncid, this%var_ids%time, &
+                                totim, start=(/kper/)), &
+                   this%nc_fname)
+
     ! synchronize file
     call nf_verify(nf90_sync(this%ncid), this%nc_fname)
   end subroutine package_step
@@ -379,24 +387,28 @@ contains
   !> @brief netcdf export define dimensions
   !<
   subroutine define_dim(this)
+    use ConstantsModule, only: MVALIDATE
+    use SimVariablesModule, only: isim_mode
     class(Mesh2dDisExportType), intent(inout) :: this
 
-    ! time
-    call nf_verify(nf90_def_dim(this%ncid, 'time', this%totnstp, &
-                                this%dim_ids%time), this%nc_fname)
-    call nf_verify(nf90_def_var(this%ncid, 'time', NF90_DOUBLE, &
-                                this%dim_ids%time, this%var_ids%time), &
-                   this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'calendar', &
-                                'standard'), this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'units', &
-                                this%datetime), this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'axis', 'T'), &
-                   this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'standard_name', &
-                                'time'), this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'long_name', &
-                                'time'), this%nc_fname)
+    if (isim_mode /= MVALIDATE .or. this%pkglist%Count() > 0) then
+      ! time
+      call nf_verify(nf90_def_dim(this%ncid, 'time', this%totnstp, &
+                                  this%dim_ids%time), this%nc_fname)
+      call nf_verify(nf90_def_var(this%ncid, 'time', NF90_DOUBLE, &
+                                  this%dim_ids%time, this%var_ids%time), &
+                     this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'calendar', &
+                                  'standard'), this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'units', &
+                                  this%datetime), this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'axis', 'T'), &
+                     this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'standard_name', &
+                                  'time'), this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'long_name', &
+                                  'time'), this%nc_fname)
+    end if
 
     ! mesh
     call nf_verify(nf90_def_dim(this%ncid, 'nmesh_node', &
@@ -560,7 +572,7 @@ contains
   subroutine nc_export_int1d(p_mem, ncid, dim_ids, x_dim, y_dim, var_ids, dis, &
                              idt, mempath, nc_tag, pkgname, gridmap_name, &
                              deflate, shuffle, chunk_face, iper, nc_fname)
-    use NetCDFCommonModule, only: ixstp
+    use TdisModule, only: kper
     integer(I4B), dimension(:), pointer, contiguous, intent(in) :: p_mem
     integer(I4B), intent(in) :: ncid
     type(MeshNCDimIdType), intent(inout) :: dim_ids
@@ -580,7 +592,7 @@ contains
     character(len=*), intent(in) :: nc_fname
     integer(I4B), dimension(:, :, :), pointer, contiguous :: int3d
     integer(I4B), dimension(:), pointer, contiguous :: int1d
-    integer(I4B) :: axis_dim, nvals, k, istp
+    integer(I4B) :: axis_dim, nvals, k
     integer(I4B), dimension(:), allocatable :: var_id
     character(len=LINELENGTH) :: longname, varname
 
@@ -629,11 +641,10 @@ contains
         call nf_verify(nf90_put_var(ncid, var_id(1), p_mem), &
                        nc_fname)
       else
-        istp = ixstp()
         nvals = dis%nrow * dis%ncol
         call nf_verify(nf90_put_var(ncid, &
                                     var_ids%export(1), p_mem, &
-                                    start=(/1, istp/), &
+                                    start=(/1, kper/), &
                                     count=(/nvals, 1/)), nc_fname)
       end if
 
@@ -688,12 +699,11 @@ contains
         deallocate (var_id)
       else
         ! timeseries, add period data
-        istp = ixstp()
         do k = 1, dis%nlay
           int1d(1:nvals) => int3d(:, :, k)
           call nf_verify(nf90_put_var(ncid, &
                                       var_ids%export(k), int1d, &
-                                      start=(/1, istp/), &
+                                      start=(/1, kper/), &
                                       count=(/nvals, 1/)), nc_fname)
         end do
       end if
@@ -826,7 +836,7 @@ contains
   subroutine nc_export_dbl1d(p_mem, ncid, dim_ids, x_dim, y_dim, var_ids, dis, &
                              idt, mempath, nc_tag, pkgname, gridmap_name, &
                              deflate, shuffle, chunk_face, iper, iaux, nc_fname)
-    use NetCDFCommonModule, only: ixstp
+    use TdisModule, only: kper
     real(DP), dimension(:), pointer, contiguous, intent(in) :: p_mem
     integer(I4B), intent(in) :: ncid
     type(MeshNCDimIdType), intent(inout) :: dim_ids
@@ -847,7 +857,7 @@ contains
     character(len=*), intent(in) :: nc_fname
     real(DP), dimension(:, :, :), pointer, contiguous :: dbl3d
     real(DP), dimension(:), pointer, contiguous :: dbl1d
-    integer(I4B) :: axis_dim, nvals, k, istp
+    integer(I4B) :: axis_dim, nvals, k
     integer(NF90_INT), dimension(:), allocatable :: var_id
     character(len=LINELENGTH) :: longname, varname
 
@@ -897,11 +907,10 @@ contains
         call nf_verify(nf90_put_var(ncid, var_id(1), p_mem), &
                        nc_fname)
       else
-        istp = ixstp()
         nvals = dis%nrow * dis%ncol
         call nf_verify(nf90_put_var(ncid, &
                                     var_ids%export(1), p_mem, &
-                                    start=(/1, istp/), &
+                                    start=(/1, kper/), &
                                     count=(/nvals, 1/)), nc_fname)
       end if
 
@@ -961,12 +970,11 @@ contains
         deallocate (var_id)
       else
         ! timeseries, add period data
-        istp = ixstp()
         do k = 1, dis%nlay
           dbl1d(1:nvals) => dbl3d(:, :, k)
           call nf_verify(nf90_put_var(ncid, &
                                       var_ids%export(k), dbl1d, &
-                                      start=(/1, istp/), &
+                                      start=(/1, kper/), &
                                       count=(/nvals, 1/)), nc_fname)
         end do
       end if

--- a/src/Utilities/Export/DisNCMesh.f90
+++ b/src/Utilities/Export/DisNCMesh.f90
@@ -119,7 +119,6 @@ contains
   subroutine step(this)
     use ConstantsModule, only: DHNOFLO
     use TdisModule, only: totim
-    use NetCDFCommonModule, only: ixstp
     class(Mesh2dDisExportType), intent(inout) :: this
     real(DP), dimension(:), pointer, contiguous :: dbl1d
     integer(I4B) :: n, k, nvals, istp
@@ -131,7 +130,7 @@ contains
     nullify (dbl2d)
 
     ! set global step index
-    istp = ixstp()
+    istp = this%istp()
 
     dis_shape(1) = this%dis%ncol * this%dis%nrow
     dis_shape(2) = this%dis%nlay

--- a/src/Utilities/Export/DisNCStructured.f90
+++ b/src/Utilities/Export/DisNCStructured.f90
@@ -218,20 +218,23 @@ contains
     call this%define_dim()
     ! define grid projection variables
     call this%define_geocoords()
-    if (isim_mode /= MVALIDATE) then
+    if (isim_mode == MVALIDATE) then
+      ! define period input arrays
+      call this%df_export()
+    else
       ! define the dependent variable
       call this%define_dependent()
     end if
-    ! define period input arrays
-    call this%df_export()
     ! exit define mode
     call nf_verify(nf90_enddef(this%ncid), this%nc_fname)
     ! add data locations
     call this%add_grid_data()
     ! add projection data
     call this%add_proj_data()
-    ! define and set package input griddata
-    call this%add_pkg_data()
+    if (isim_mode == MVALIDATE) then
+      ! define and set package input griddata
+      call this%add_pkg_data()
+    end if
     ! define and set gridmap variable
     call this%define_gridmap()
     ! synchronize file
@@ -535,7 +538,7 @@ contains
   !> @brief netcdf export package dynamic input
   !<
   subroutine package_step(this, export_pkg)
-    use TdisModule, only: kper
+    use TdisModule, only: totim, kper
     use DefinitionSelectModule, only: get_param_definition_type
     use NCModelExportModule, only: ExportPackageType
     class(DisNCStructuredType), intent(inout) :: this
@@ -553,6 +556,7 @@ contains
 
     ! export defined period input
     do iparam = 1, export_pkg%nparam
+      if (export_pkg%iper /= kper) cycle
       ! check if variable was read this period
       if (export_pkg%param_reads(iparam)%invar < 1) cycle
 
@@ -654,6 +658,11 @@ contains
       end select
     end do
 
+    ! write to time coordinate variable
+    call nf_verify(nf90_put_var(this%ncid, this%var_ids%time, &
+                                totim, start=(/kper/)), &
+                   this%nc_fname)
+
     ! synchronize file
     call nf_verify(nf90_sync(this%ncid), this%nc_fname)
   end subroutine package_step
@@ -742,29 +751,33 @@ contains
   !> @brief netcdf export define dimensions
   !<
   subroutine define_dim(this)
+    use ConstantsModule, only: MVALIDATE
+    use SimVariablesModule, only: isim_mode
     class(DisNCStructuredType), intent(inout) :: this
 
     ! bound dim
     call nf_verify(nf90_def_dim(this%ncid, 'bnd', 2, this%dim_ids%bnd), &
                    this%nc_fname)
 
-    ! Time
-    call nf_verify(nf90_def_dim(this%ncid, 'time', this%totnstp, &
-                                this%dim_ids%time), this%nc_fname)
-    call nf_verify(nf90_def_var(this%ncid, 'time', NF90_DOUBLE, &
-                                this%dim_ids%time, this%var_ids%time), &
-                   this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'calendar', &
-                                'standard'), this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'units', &
-                                this%datetime), this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'axis', 'T'), &
-                   this%nc_fname)
-    !call nf_verify(nf90_put_att(ncid, var_ids%time, 'bounds', 'time_bnds'), this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'standard_name', &
-                                'time'), this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'long_name', &
-                                'time'), this%nc_fname)
+    if (isim_mode /= MVALIDATE .or. this%pkglist%Count() > 0) then
+      ! Time
+      call nf_verify(nf90_def_dim(this%ncid, 'time', this%totnstp, &
+                                  this%dim_ids%time), this%nc_fname)
+      call nf_verify(nf90_def_var(this%ncid, 'time', NF90_DOUBLE, &
+                                  this%dim_ids%time, this%var_ids%time), &
+                     this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'calendar', &
+                                  'standard'), this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'units', &
+                                  this%datetime), this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'axis', 'T'), &
+                     this%nc_fname)
+      !call nf_verify(nf90_put_att(ncid, var_ids%time, 'bounds', 'time_bnds'), this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'standard_name', &
+                                  'time'), this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'long_name', &
+                                  'time'), this%nc_fname)
+    end if
 
     ! Z dimension
     call nf_verify(nf90_def_dim(this%ncid, 'z', this%dis%nlay, this%dim_ids%z), &
@@ -1100,7 +1113,7 @@ contains
   subroutine nc_export_int1d(p_mem, ncid, dim_ids, var_ids, dis, idt, mempath, &
                              nc_tag, pkgname, gridmap_name, latlon, deflate, &
                              shuffle, chunk_z, chunk_y, chunk_x, iper, nc_fname)
-    use NetCDFCommonModule, only: ixstp
+    use TdisModule, only: kper
     integer(I4B), dimension(:), pointer, contiguous, intent(in) :: p_mem
     integer(I4B), intent(in) :: ncid
     type(StructuredNCDimIdType), intent(inout) :: dim_ids
@@ -1119,7 +1132,7 @@ contains
     integer(I4B), intent(in) :: chunk_x
     integer(I4B), intent(in) :: iper
     character(len=*), intent(in) :: nc_fname
-    integer(I4B) :: var_id, axis_sz, istp
+    integer(I4B) :: var_id, axis_sz
     character(len=LINELENGTH) :: varname, longname
 
     varname = export_varname(pkgname, idt%tagname, mempath)
@@ -1163,10 +1176,9 @@ contains
                        nc_fname)
       else
         ! timeseries
-        istp = ixstp()
         call nf_verify(nf90_put_var(ncid, &
                                     var_ids%export, p_mem, &
-                                    start=(/1, istp/), &
+                                    start=(/1, kper/), &
                                     count=(/dis%ncol, dis%nrow, 1/)), nc_fname)
       end if
 
@@ -1201,10 +1213,9 @@ contains
                        nc_fname)
       else
         ! timeseries
-        istp = ixstp()
         call nf_verify(nf90_put_var(ncid, &
                                     var_ids%export, p_mem, &
-                                    start=(/1, 1, 1, istp/), &
+                                    start=(/1, 1, 1, kper/), &
                                     count=(/dis%ncol, dis%nrow, dis%nlay, 1/)), &
                        nc_fname)
       end if
@@ -1327,7 +1338,7 @@ contains
                              nc_tag, pkgname, gridmap_name, latlon, deflate, &
                              shuffle, chunk_z, chunk_y, chunk_x, iper, iaux, &
                              nc_fname)
-    use NetCDFCommonModule, only: ixstp
+    use TdisModule, only: kper
     real(DP), dimension(:), pointer, contiguous, intent(in) :: p_mem
     integer(I4B), intent(in) :: ncid
     type(StructuredNCDimIdType), intent(inout) :: dim_ids
@@ -1347,7 +1358,7 @@ contains
     integer(I4B), intent(in) :: iper
     integer(I4B), intent(in) :: iaux
     character(len=*), intent(in) :: nc_fname
-    integer(I4B) :: var_id, axis_sz, istp
+    integer(I4B) :: var_id, axis_sz
     character(len=LINELENGTH) :: varname, longname
 
     if (idt%shape == 'NROW' .or. &
@@ -1391,10 +1402,9 @@ contains
                        nc_fname)
       else
         ! timeseries
-        istp = ixstp()
         call nf_verify(nf90_put_var(ncid, &
                                     var_ids%export, p_mem, &
-                                    start=(/1, istp/), &
+                                    start=(/1, kper/), &
                                     count=(/dis%ncol, dis%nrow, 1/)), nc_fname)
       end if
 
@@ -1433,10 +1443,9 @@ contains
                        nc_fname)
       else
         ! timeseries
-        istp = ixstp()
         call nf_verify(nf90_put_var(ncid, &
                                     var_ids%export, p_mem, &
-                                    start=(/1, 1, 1, istp/), &
+                                    start=(/1, 1, 1, kper/), &
                                     count=(/dis%ncol, dis%nrow, dis%nlay, 1/)), &
                        nc_fname)
       end if

--- a/src/Utilities/Export/DisNCStructured.f90
+++ b/src/Utilities/Export/DisNCStructured.f90
@@ -259,13 +259,12 @@ contains
   subroutine step(this)
     use ConstantsModule, only: DHNOFLO
     use TdisModule, only: totim
-    use NetCDFCommonModule, only: ixstp
     class(DisNCStructuredType), intent(inout) :: this
     real(DP), dimension(:), pointer, contiguous :: dbl1d
     integer(I4B) :: n, istp
 
     ! set global step index
-    istp = ixstp()
+    istp = this%istp()
 
     if (size(this%dis%nodeuser) < &
         size(this%dis%nodereduced)) then

--- a/src/Utilities/Export/DisvNCMesh.f90
+++ b/src/Utilities/Export/DisvNCMesh.f90
@@ -91,18 +91,21 @@ contains
     call this%define_dim()
     ! define mesh variables
     call this%create_mesh()
-    if (isim_mode /= MVALIDATE) then
+    if (isim_mode == MVALIDATE) then
+      ! define period input arrays
+      call this%df_export()
+    else
       ! define the dependent variable
       call this%define_dependent()
     end if
-    ! define period input arrays
-    call this%df_export()
     ! exit define mode
     call nf_verify(nf90_enddef(this%ncid), this%nc_fname)
     ! create mesh
     call this%add_mesh_data()
-    ! define and set package input griddata
-    call this%add_pkg_data()
+    if (isim_mode == MVALIDATE) then
+      ! define and set package input griddata
+      call this%add_pkg_data()
+    end if
     ! define and set gridmap variable
     call this%define_gridmap()
     ! synchronize file
@@ -180,7 +183,7 @@ contains
   !> @brief netcdf export package dynamic input
   !<
   subroutine package_step(this, export_pkg)
-    use TdisModule, only: kper
+    use TdisModule, only: totim, kper
     use DefinitionSelectModule, only: get_param_definition_type
     use NCModelExportModule, only: ExportPackageType
     class(Mesh2dDisvExportType), intent(inout) :: this
@@ -299,6 +302,11 @@ contains
       end select
     end do
 
+    ! write to time coordinate variable
+    call nf_verify(nf90_put_var(this%ncid, this%var_ids%time, &
+                                totim, start=(/kper/)), &
+                   this%nc_fname)
+
     ! synchronize file
     call nf_verify(nf90_sync(this%ncid), this%nc_fname)
   end subroutine package_step
@@ -357,28 +365,32 @@ contains
   !> @brief netcdf export define dimensions
   !<
   subroutine define_dim(this)
+    use ConstantsModule, only: MVALIDATE
+    use SimVariablesModule, only: isim_mode
     class(Mesh2dDisvExportType), intent(inout) :: this
     integer(I4B), dimension(:), contiguous, pointer :: ncvert
 
     ! set pointers to input context
     call mem_setptr(ncvert, 'NCVERT', this%dis_mempath)
 
-    ! time
-    call nf_verify(nf90_def_dim(this%ncid, 'time', this%totnstp, &
-                                this%dim_ids%time), this%nc_fname)
-    call nf_verify(nf90_def_var(this%ncid, 'time', NF90_DOUBLE, &
-                                this%dim_ids%time, this%var_ids%time), &
-                   this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'calendar', &
-                                'standard'), this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'units', &
-                                this%datetime), this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'axis', 'T'), &
-                   this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'standard_name', &
-                                'time'), this%nc_fname)
-    call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'long_name', &
-                                'time'), this%nc_fname)
+    if (isim_mode /= MVALIDATE .or. this%pkglist%Count() > 0) then
+      ! time
+      call nf_verify(nf90_def_dim(this%ncid, 'time', this%totnstp, &
+                                  this%dim_ids%time), this%nc_fname)
+      call nf_verify(nf90_def_var(this%ncid, 'time', NF90_DOUBLE, &
+                                  this%dim_ids%time, this%var_ids%time), &
+                     this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'calendar', &
+                                  'standard'), this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'units', &
+                                  this%datetime), this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'axis', 'T'), &
+                     this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'standard_name', &
+                                  'time'), this%nc_fname)
+      call nf_verify(nf90_put_att(this%ncid, this%var_ids%time, 'long_name', &
+                                  'time'), this%nc_fname)
+    end if
 
     ! mesh
     call nf_verify(nf90_def_dim(this%ncid, 'nmesh_node', this%disv%nvert, &
@@ -533,7 +545,7 @@ contains
   subroutine nc_export_int1d(p_mem, ncid, dim_ids, var_ids, disv, idt, mempath, &
                              nc_tag, pkgname, gridmap_name, deflate, shuffle, &
                              chunk_face, iper, nc_fname)
-    use NetCDFCommonModule, only: ixstp
+    use TdisModule, only: kper
     integer(I4B), dimension(:), pointer, contiguous, intent(in) :: p_mem
     integer(I4B), intent(in) :: ncid
     type(MeshNCDimIdType), intent(inout) :: dim_ids
@@ -551,7 +563,7 @@ contains
     character(len=*), intent(in) :: nc_fname
     integer(I4B), dimension(:), pointer, contiguous :: int1d
     integer(I4B), dimension(:, :), pointer, contiguous :: int2d
-    integer(I4B) :: axis_sz, k, istp
+    integer(I4B) :: axis_sz, k
     integer(I4B), dimension(:), allocatable :: var_id
     character(len=LINELENGTH) :: longname, varname
 
@@ -593,10 +605,9 @@ contains
                        nc_fname)
       else
         ! timeseries
-        istp = ixstp()
         call nf_verify(nf90_put_var(ncid, &
                                     var_ids%export(1), p_mem, &
-                                    start=(/1, istp/), &
+                                    start=(/1, kper/), &
                                     count=(/disv%ncpl, 1/)), nc_fname)
       end if
 
@@ -645,12 +656,11 @@ contains
         deallocate (var_id)
       else
         ! timeseries, add period data
-        istp = ixstp()
         do k = 1, disv%nlay
           int1d(1:disv%ncpl) => int2d(:, k)
           call nf_verify(nf90_put_var(ncid, &
                                       var_ids%export(k), int1d, &
-                                      start=(/1, istp/), &
+                                      start=(/1, kper/), &
                                       count=(/disv%ncpl, 1/)), nc_fname)
         end do
       end if
@@ -724,7 +734,7 @@ contains
   subroutine nc_export_dbl1d(p_mem, ncid, dim_ids, var_ids, disv, idt, mempath, &
                              nc_tag, pkgname, gridmap_name, deflate, shuffle, &
                              chunk_face, iper, iaux, nc_fname)
-    use NetCDFCommonModule, only: ixstp
+    use TdisModule, only: kper
     real(DP), dimension(:), pointer, contiguous, intent(in) :: p_mem
     integer(I4B), intent(in) :: ncid
     type(MeshNCDimIdType), intent(inout) :: dim_ids
@@ -743,7 +753,7 @@ contains
     character(len=*), intent(in) :: nc_fname
     real(DP), dimension(:), pointer, contiguous :: dbl1d
     real(DP), dimension(:, :), pointer, contiguous :: dbl2d
-    integer(I4B) :: axis_sz, k, istp
+    integer(I4B) :: axis_sz, k
     integer(I4B), dimension(:), allocatable :: var_id
     character(len=LINELENGTH) :: longname, varname
 
@@ -787,10 +797,9 @@ contains
                        nc_fname)
       else
         ! timeseries
-        istp = ixstp()
         call nf_verify(nf90_put_var(ncid, &
                                     var_ids%export(1), p_mem, &
-                                    start=(/1, istp/), &
+                                    start=(/1, kper/), &
                                     count=(/disv%ncpl, 1/)), nc_fname)
       end if
 
@@ -840,12 +849,11 @@ contains
         deallocate (var_id)
       else
         ! timeseries, add period data
-        istp = ixstp()
         do k = 1, disv%nlay
           dbl1d(1:disv%ncpl) => dbl2d(:, k)
           call nf_verify(nf90_put_var(ncid, &
                                       var_ids%export(k), dbl1d, &
-                                      start=(/1, istp/), &
+                                      start=(/1, kper/), &
                                       count=(/disv%ncpl, 1/)), nc_fname)
         end do
       end if

--- a/src/Utilities/Export/DisvNCMesh.f90
+++ b/src/Utilities/Export/DisvNCMesh.f90
@@ -117,7 +117,6 @@ contains
   subroutine step(this)
     use ConstantsModule, only: DHNOFLO
     use TdisModule, only: totim
-    use NetCDFCommonModule, only: ixstp
     class(Mesh2dDisvExportType), intent(inout) :: this
     real(DP), dimension(:), pointer, contiguous :: dbl1d
     integer(I4B) :: n, k, nvals, istp
@@ -129,7 +128,7 @@ contains
     nullify (dbl2d)
 
     ! set global step index
-    istp = ixstp()
+    istp = this%istp()
 
     dis_shape(1) = this%disv%ncpl
     dis_shape(2) = this%disv%nlay

--- a/src/Utilities/Export/ModelExport.f90
+++ b/src/Utilities/Export/ModelExport.f90
@@ -9,9 +9,9 @@ module ModelExportModule
 
   use KindModule, only: DP, I4B, LGP
   use SimModule, only: store_error, store_error_filename
-  use SimVariablesModule, only: errmsg
+  use SimVariablesModule, only: errmsg, isim_mode
   use ConstantsModule, only: LINELENGTH, LENMODELNAME, LENCOMPONENTNAME, &
-                             LENMEMPATH
+                             LENMEMPATH, MVALIDATE
   use ListModule, only: ListType
   use NCModelExportModule, only: NCBaseModelExportType
   use InputLoadTypeModule, only: ModelDynamicPkgsType
@@ -221,7 +221,9 @@ contains
   subroutine post_prepare(this)
     class(ExportModelType), intent(inout) :: this
     if (associated(this%nc_export)) then
-      call this%nc_export%export_input()
+      if (isim_mode == MVALIDATE) then
+        call this%nc_export%export_input()
+      end if
     end if
   end subroutine post_prepare
 

--- a/src/Utilities/Export/ModelExport.f90
+++ b/src/Utilities/Export/ModelExport.f90
@@ -9,9 +9,9 @@ module ModelExportModule
 
   use KindModule, only: DP, I4B, LGP
   use SimModule, only: store_error, store_error_filename
-  use SimVariablesModule, only: errmsg, isim_mode
+  use SimVariablesModule, only: errmsg
   use ConstantsModule, only: LINELENGTH, LENMODELNAME, LENCOMPONENTNAME, &
-                             LENMEMPATH, MVALIDATE
+                             LENMEMPATH
   use ListModule, only: ListType
   use NCModelExportModule, only: NCBaseModelExportType
   use InputLoadTypeModule, only: ModelDynamicPkgsType
@@ -221,9 +221,7 @@ contains
   subroutine post_prepare(this)
     class(ExportModelType), intent(inout) :: this
     if (associated(this%nc_export)) then
-      if (isim_mode == MVALIDATE) then
-        call this%nc_export%export_input()
-      end if
+      call this%nc_export%export_input()
     end if
   end subroutine post_prepare
 

--- a/src/Utilities/Export/NCExportCreate.f90
+++ b/src/Utilities/Export/NCExportCreate.f90
@@ -7,8 +7,8 @@
 module NCExportCreateModule
 
   use KindModule, only: DP, I4B, LGP
-  use SimVariablesModule, only: errmsg
-  use ConstantsModule, only: DIS, DISU, DISV
+  use SimVariablesModule, only: errmsg, isim_mode
+  use ConstantsModule, only: DIS, DISU, DISV, MVALIDATE
   use SimModule, only: store_error, store_error_filename
   use NumericalModelModule, only: NumericalModelType
   use BaseDisModule, only: DisBaseType
@@ -157,6 +157,12 @@ contains
     class(*), pointer :: obj
     logical(LGP) :: found, readasarrays
     integer(I4B) :: n
+
+    if (isim_mode /= MVALIDATE) then
+      ! input array export configuration is documented
+      ! as ignored if not in validate mode
+      return
+    end if
 
     ! create list of in scope loaders
     allocate (export_arrays)

--- a/src/Utilities/Export/NCModel.f90
+++ b/src/Utilities/Export/NCModel.f90
@@ -97,6 +97,7 @@ module NCModelExportModule
     procedure :: init => export_init
     procedure :: get => export_get
     procedure :: input_attribute
+    procedure :: istp
     procedure :: destroy => export_destroy
   end type NCModelExportType
 
@@ -432,6 +433,20 @@ contains
     end if
   end function input_attribute
 
+  !> @brief step index for timeseries data
+  !<
+  function istp(this)
+    use TdisModule, only: kstp, kper, nstp
+    class(NCModelExportType), intent(inout) :: this
+    integer(I4B) :: n, istp
+    istp = kstp
+    if (kper > 1) then
+      do n = 1, kper - 1
+        istp = istp + nstp(n)
+      end do
+    end if
+  end function istp
+
   !> @brief build netcdf variable name
   !<
   function export_varname(pkgname, tagname, mempath, layer, iaux) &
@@ -530,10 +545,10 @@ contains
       export_pkg => this%get(idx)
       ! period input already exported
       if (export_pkg%eper >= kper) cycle
-      ! set exported iper
-      export_pkg%eper = kper
       ! update export package
       call this%package_step(export_pkg)
+      ! update exported iper
+      export_pkg%eper = kper
     end do
   end subroutine export_input
 

--- a/src/Utilities/Export/NCModel.f90
+++ b/src/Utilities/Export/NCModel.f90
@@ -42,7 +42,7 @@ module NCModelExportModule
     integer(I4B), dimension(:, :), allocatable :: varids_aux
     integer(I4B), dimension(:), pointer, contiguous :: mshape => null() !< model shape
     integer(I4B), pointer :: iper !< most recent package rp load
-    integer(I4B) :: iper_export !< most recent period of netcdf package export
+    integer(I4B) :: eper !< most recent period of netcdf package export
     integer(I4B) :: nparam !< number of in scope params
     integer(I4B) :: naux !< number of auxiliary variables
   contains
@@ -163,7 +163,7 @@ contains
     this%mshape => mshape
     this%nparam = nparam
     this%naux = naux
-    this%iper_export = 0
+    this%eper = 0
 
     input_mempath = create_mem_path(component=mf6_input%component_name, &
                                     subcomponent=mf6_input%subcomponent_name, &
@@ -272,7 +272,7 @@ contains
   !<
   subroutine export_init(this, modelname, modeltype, modelfname, nc_fname, &
                          disenum, nctype, iout)
-    use TdisModule, only: datetime0, nstp, inats
+    use TdisModule, only: datetime0, nper, nstp, inats
     use MemoryManagerModule, only: mem_setptr
     use MemoryHelperModule, only: create_mem_path
     use MemoryManagerExtModule, only: mem_set_value
@@ -390,7 +390,11 @@ contains
     end if
 
     ! set total nstp
-    this%totnstp = sum(nstp)
+    if (isim_mode == MVALIDATE) then
+      this%totnstp = nper
+    else
+      this%totnstp = sum(nstp)
+    end if
   end subroutine export_init
 
   !> @brief retrieve dynamic export object from package list
@@ -524,12 +528,10 @@ contains
     class(ExportPackageType), pointer :: export_pkg
     do idx = 1, this%pkglist%Count()
       export_pkg => this%get(idx)
-      ! last loaded data is not current period
-      if (export_pkg%iper /= kper) cycle
       ! period input already exported
-      if (export_pkg%iper_export >= export_pkg%iper) cycle
+      if (export_pkg%eper >= kper) cycle
       ! set exported iper
-      export_pkg%iper_export = export_pkg%iper
+      export_pkg%eper = kper
       ! update export package
       call this%package_step(export_pkg)
     end do

--- a/src/Utilities/Export/NCModel.f90
+++ b/src/Utilities/Export/NCModel.f90
@@ -273,7 +273,7 @@ contains
   !<
   subroutine export_init(this, modelname, modeltype, modelfname, nc_fname, &
                          disenum, nctype, iout)
-    use TdisModule, only: datetime0, nper, nstp, inats
+    use TdisModule, only: datetime0, nper, nstp
     use MemoryManagerModule, only: mem_setptr
     use MemoryHelperModule, only: create_mem_path
     use MemoryManagerExtModule, only: mem_set_value
@@ -380,14 +380,6 @@ contains
     else
       ! January 1, 1970 at 00:00:00 UTC
       this%datetime = 'days since 1970-01-01T00:00:00'
-    end if
-
-    ! Set error and exit if ATS is on
-    if (inats > 0) then
-      errmsg = 'Adaptive time stepping not currently supported &
-               &with NetCDF exports.'
-      call store_error(errmsg)
-      call store_error_filename(modelfname)
     end if
 
     ! set total nstp

--- a/src/Utilities/Idm/netcdf/NCArrayReader.f90
+++ b/src/Utilities/Idm/netcdf/NCArrayReader.f90
@@ -281,8 +281,8 @@ contains
   !<
   subroutine load_integer1d_spd(int1d, mf6_input, mshape, idt, nc_vars, &
                                 iper, input_fname)
+    use TdisModule, only: kper
     use ConstantsModule, only: DNODATA
-    use NetCDFCommonModule, only: ixstp
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: int1d
     type(ModflowInputType), intent(in) :: mf6_input
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: mshape
@@ -291,9 +291,7 @@ contains
     integer(I4B), intent(in) :: iper
     character(len=*), intent(in) :: input_fname
     integer(I4B), dimension(:), allocatable :: layer_shape
-    integer(I4B) :: varid, nlay, ncpl, istp
-
-    istp = ixstp()
+    integer(I4B) :: varid, nlay, ncpl
 
     ! set varid
     varid = nc_vars%varid(idt%tagname)
@@ -305,12 +303,12 @@ contains
     case ('NCPL', 'NAUX NCPL')
       if (nc_vars%grid == 'STRUCTURED') then
         call nf_verify(nf90_get_var(nc_vars%ncid, varid, int1d, &
-                                    start=(/1, 1, istp/), &
+                                    start=(/1, 1, kper/), &
                                     count=(/mshape(3), mshape(2), 1/)), &
                        nc_vars%nc_fname)
       else if (nc_vars%grid == 'LAYERED MESH') then
         call nf_verify(nf90_get_var(nc_vars%ncid, varid, int1d, &
-                                    start=(/1, istp/), count=(/ncpl, 1/)), &
+                                    start=(/1, kper/), count=(/ncpl, 1/)), &
                        nc_vars%nc_fname)
       end if
     case ('NODES', 'NAUX NODES')
@@ -359,8 +357,8 @@ contains
   !<
   subroutine load_integer1d_layered_spd(int1d, mf6_input, mshape, idt, nc_vars, &
                                         iper, input_fname)
+    use TdisModule, only: kper
     use ConstantsModule, only: DNODATA
-    use NetCDFCommonModule, only: ixstp
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: int1d
     type(ModflowInputType), intent(in) :: mf6_input
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: mshape
@@ -370,9 +368,7 @@ contains
     character(len=*), intent(in) :: input_fname
     integer(I4B), dimension(:), allocatable :: layer_shape
     integer(I4B) :: nlay, varid
-    integer(I4B) :: ncpl, nvals, istp
-
-    istp = ixstp()
+    integer(I4B) :: ncpl, nvals
 
     call get_layered_shape(mshape, nlay, layer_shape)
     nvals = product(mshape)
@@ -382,11 +378,11 @@ contains
     select case (idt%shape)
     case ('NCPL', 'NAUX NCPL')
       call nf_verify(nf90_get_var(nc_vars%ncid, varid, int1d, &
-                                  start=(/1, istp/), count=(/ncpl, 1/)), &
+                                  start=(/1, kper/), count=(/ncpl, 1/)), &
                      nc_vars%nc_fname)
     case ('NODES', 'NAUX NODES')
       call nf_verify(nf90_get_var(nc_vars%ncid, varid, int1d, &
-                                  start=(/1, istp/), count=(/nvals, 1/)), &
+                                  start=(/1, kper/), count=(/nvals, 1/)), &
                      nc_vars%nc_fname)
     case default
     end select
@@ -547,8 +543,8 @@ contains
   !<
   subroutine load_double1d_spd(dbl1d, mf6_input, mshape, idt, nc_vars, &
                                iper, input_fname, iaux)
+    use TdisModule, only: kper
     use ConstantsModule, only: DNODATA
-    use NetCDFCommonModule, only: ixstp
     real(DP), dimension(:), contiguous, pointer, intent(in) :: dbl1d
     type(ModflowInputType), intent(in) :: mf6_input
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: mshape
@@ -560,11 +556,10 @@ contains
     integer(I4B), dimension(:), allocatable :: layer_shape
     real(DP), dimension(:, :, :), contiguous, pointer :: dbl3d
     integer(I4B) :: varid, nlay, ncpl, nvals
-    integer(I4B) :: n, istp
+    integer(I4B) :: n
 
     ! initialize
     n = 0
-    istp = ixstp()
 
     ! set varid
     if (present(iaux)) then
@@ -581,24 +576,24 @@ contains
     case ('NCPL', 'NAUX NCPL')
       if (nc_vars%grid == 'STRUCTURED') then
         call nf_verify(nf90_get_var(nc_vars%ncid, varid, dbl1d, &
-                                    start=(/1, 1, istp/), &
+                                    start=(/1, 1, kper/), &
                                     count=(/mshape(3), mshape(2), 1/)), &
                        nc_vars%nc_fname)
       else if (nc_vars%grid == 'LAYERED MESH') then
         call nf_verify(nf90_get_var(nc_vars%ncid, varid, dbl1d, &
-                                    start=(/1, istp/), count=(/ncpl, 1/)), &
+                                    start=(/1, kper/), count=(/ncpl, 1/)), &
                        nc_vars%nc_fname)
       end if
     case ('NODES', 'NAUX NODES')
       if (nc_vars%grid == 'STRUCTURED') then
         dbl3d(1:mshape(3), 1:mshape(2), 1:mshape(1)) => dbl1d(1:nvals)
         call nf_verify(nf90_get_var(nc_vars%ncid, varid, dbl3d, &
-                                    start=(/1, 1, 1, istp/), &
+                                    start=(/1, 1, 1, kper/), &
                                     count=(/mshape(3), mshape(2), mshape(1), &
                                             1/)), nc_vars%nc_fname)
       else if (nc_vars%grid == 'LAYERED MESH') then
         call nf_verify(nf90_get_var(nc_vars%ncid, varid, dbl1d, &
-                                    start=(/1, istp/), count=(/nvals, 1/)), &
+                                    start=(/1, kper/), count=(/nvals, 1/)), &
                        nc_vars%nc_fname)
       end if
     case default
@@ -640,8 +635,8 @@ contains
   !<
   subroutine load_double1d_layered_spd(dbl1d, mf6_input, mshape, idt, nc_vars, &
                                        iper, input_fname, iaux)
+    use TdisModule, only: kper
     use ConstantsModule, only: DNODATA
-    use NetCDFCommonModule, only: ixstp
     real(DP), dimension(:), contiguous, pointer, intent(in) :: dbl1d
     type(ModflowInputType), intent(in) :: mf6_input
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: mshape
@@ -652,10 +647,8 @@ contains
     integer(I4B), optional, intent(in) :: iaux
     integer(I4B), dimension(:), allocatable :: layer_shape
     integer(I4B) :: nlay, varid
-    integer(I4B) :: k, n, ncpl, idx, istp
+    integer(I4B) :: k, n, ncpl, idx
     real(DP), dimension(:), contiguous, pointer :: dbl1d_ptr
-
-    istp = ixstp()
 
     call get_layered_shape(mshape, nlay, layer_shape)
     ncpl = product(layer_shape)
@@ -668,7 +661,7 @@ contains
         varid = nc_vars%varid(idt%tagname, layer=k)
       end if
       call nf_verify(nf90_get_var(nc_vars%ncid, varid, dbl1d_ptr, &
-                                  start=(/1, istp/), count=(/ncpl, 1/)), &
+                                  start=(/1, kper/), count=(/ncpl, 1/)), &
                      nc_vars%nc_fname)
       if (idt%shape == 'NODES' .or. idt%shape == 'NAUX NODES') then
         do n = 1, ncpl

--- a/src/Utilities/Idm/netcdf/NetCDFCommon.f90
+++ b/src/Utilities/Idm/netcdf/NetCDFCommon.f90
@@ -17,7 +17,6 @@ module NetCDFCommonModule
   public :: NETCDF_MAX_DIM
   public :: NETCDF_ATTR_STRLEN
   public :: nf_verify
-  public :: ixstp
 
   integer(I4B), parameter :: NETCDF_MAX_DIM = 6
   integer(I4B), parameter :: NETCDF_ATTR_STRLEN = 80
@@ -107,18 +106,5 @@ contains
       call store_error_filename(nc_fname)
     end if
   end subroutine nf_verify
-
-  !> @brief step index for timeseries data
-  !<
-  function ixstp()
-    use TdisModule, only: kstp, kper, nstp
-    integer(I4B) :: n, ixstp
-    ixstp = kstp
-    if (kper > 1) then
-      do n = 1, kper - 1
-        ixstp = ixstp + nstp(n)
-      end do
-    end if
-  end function ixstp
 
 end module NetCDFCommonModule


### PR DESCRIPTION
Restrict writing gridded input arrays to NetCDF in `validate` mode only:
  - documentation reflects package `export_array_netcdf` option is ignored if model output NetCDF is not configured or simulation is not run in `validate` mode
  - NetCDF files generated in `validate` mode will have a time dimension of `NPER`, while those generated during a typical simulation run will have a time dimension of `NSTP`
  - These changes align with `FloPy4` development
  - There is ongoing discussion related to the possibility of deprecating input NetCDF file generation from `MODFLOW 6`
  - The [wiki](https://github.com/MODFLOW-ORG/modflow6/wiki/MODFLOW-NetCDF-Format) will soon be updated to reflect these changes

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Added new test or modified an existing test
- [X] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Added doxygen comments to new and modified procedures
- [X] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [X] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
