### PR TITLE
doc(mf6io): clean up package headers for consistency

### DIFF
--- a/doc/mf6io/gwe/gwe.tex
+++ b/doc/mf6io/gwe/gwe.tex
@@ -76,15 +76,15 @@ In \mf time step lengths are controlled by the user and specified in the Tempora
 \input{gwe/namefile.tex}
 
 %\newpage
-%\subsection{Structured Discretization (DIS) Input File}
+%\subsection{Structured Discretization (DIS) Package}
 %\input{gwf/dis}
 
 %\newpage
-%\subsection{Discretization with Vertices (DISV) Input File}
+%\subsection{Discretization with Vertices (DISV) Package}
 %\input{gwf/disv}
 
 %\newpage
-%\subsection{Unstructured Discretization (DISU) Input File}
+%\subsection{Unstructured Discretization (DISU) Package}
 %\input{gwf/disu}
 
 \newpage
@@ -92,7 +92,7 @@ In \mf time step lengths are controlled by the user and specified in the Tempora
 \input{gwe/ic}
 
 \newpage
-\subsection{Output Control (OC) Option}
+\subsection{Output Control (OC) Package}
 \input{gwe/oc}
 
 \newpage

--- a/doc/mf6io/gwf/gwf.tex
+++ b/doc/mf6io/gwf/gwf.tex
@@ -56,15 +56,15 @@ Cell-by-cell stress flows are flow rates into or out of the model, at a particul
 \input{gwf/namefile.tex}
 
 \newpage
-\subsection{Structured Discretization (DIS) Input File}
+\subsection{Structured Discretization (DIS) Package}
 \input{gwf/dis}
 
 \newpage
-\subsection{Discretization by Vertices (DISV) Input File}
+\subsection{Discretization by Vertices (DISV) Package}
 \input{gwf/disv}
 
 \newpage
-\subsection{Unstructured Discretization (DISU) Input File}
+\subsection{Unstructured Discretization (DISU) Package}
 \input{gwf/disu}
 
 \newpage
@@ -72,7 +72,7 @@ Cell-by-cell stress flows are flow rates into or out of the model, at a particul
 \input{gwf/ic}
 
 \newpage
-\subsection{Output Control (OC) Option}
+\subsection{Output Control (OC) Package}
 \input{gwf/oc}
 
 \newpage
@@ -84,7 +84,7 @@ Cell-by-cell stress flows are flow rates into or out of the model, at a particul
 \input{gwf/npf}
 
 \newpage
-\subsection{Time-Varying Hydraulic Conductivity (TVK) Package}
+\subsection{Time-Varying Hydraulic Conductivity (TVK) Utility}
 \input{gwf/tvk}
 
 \newpage
@@ -96,7 +96,7 @@ Cell-by-cell stress flows are flow rates into or out of the model, at a particul
 \input{gwf/sto}
 
 \newpage
-\subsection{Time-Varying Storage (TVS) Package}
+\subsection{Time-Varying Storage (TVS) Utility}
 \input{gwf/tvs}
 
 \newpage

--- a/doc/mf6io/gwt/gwt.tex
+++ b/doc/mf6io/gwt/gwt.tex
@@ -66,15 +66,15 @@ In \mf time step lengths are controlled by the user and specified in the Tempora
 \input{gwt/namefile.tex}
 
 %\newpage
-%\subsection{Structured Discretization (DIS) Input File}
+%\subsection{Structured Discretization (DIS) Package}
 %\input{gwf/dis}
 
 %\newpage
-%\subsection{Discretization with Vertices (DISV) Input File}
+%\subsection{Discretization with Vertices (DISV) Package}
 %\input{gwf/disv}
 
 %\newpage
-%\subsection{Unstructured Discretization (DISU) Input File}
+%\subsection{Unstructured Discretization (DISU) Package}
 %\input{gwf/disu}
 
 \newpage
@@ -82,7 +82,7 @@ In \mf time step lengths are controlled by the user and specified in the Tempora
 \input{gwt/ic}
 
 \newpage
-\subsection{Output Control (OC) Option}
+\subsection{Output Control (OC) Package}
 \input{gwt/oc}
 
 \newpage


### PR DESCRIPTION
Different language was being used for the package section headers: sometimes "input file", sometimes "option", but should generally be "package" or in select instances "utility".

- [x] Replaced section above with description of pull request
- [x] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)