### PR TITLE
fix(input): set errors for non-valid option strings

### DIFF
--- a/autotest/test_gwe_lke_conduction.py
+++ b/autotest/test_gwe_lke_conduction.py
@@ -89,7 +89,7 @@ strt_lk_stg = [33.75, 33.75, 33.75]
 lkbdthkcnd = [0.0001, 0.0001, 0.0001]  # Thickness to consider for feature/gw conduction
 
 # Model units
-length_units = "m"
+length_units = "meters"
 time_units = "days"
 
 # model domain and grid definition

--- a/autotest/test_gwe_sfe_strmbedcond.py
+++ b/autotest/test_gwe_sfe_strmbedcond.py
@@ -50,7 +50,7 @@ def get_xy_pts(x, y, rwid):
 
 
 # Model units
-length_units = "m"
+length_units = "meters"
 time_units = "days"
 
 # model domain and grid definition

--- a/autotest/test_gwf_sfr_evap.py
+++ b/autotest/test_gwf_sfr_evap.py
@@ -13,7 +13,7 @@ cases = ["sfr-evap"]
 
 
 # Model units
-length_units = "m"
+length_units = "meters"
 time_units = "days"
 
 # model domain and grid definition

--- a/autotest/test_gwf_sfr_gwdischarge.py
+++ b/autotest/test_gwf_sfr_gwdischarge.py
@@ -15,8 +15,8 @@ def build_models(idx, test):
     ws = test.workspace
     name = cases[idx]
 
-    length_units = "m"
-    time_units = "sec"
+    length_units = "meters"
+    time_units = "seconds"
 
     nrow = 1
     ncol = 1

--- a/autotest/test_gwf_sfr_inactive02.py
+++ b/autotest/test_gwf_sfr_inactive02.py
@@ -15,8 +15,8 @@ cases = ["sfr-inactive02"]
 def get_model(ws, name, array_input=False):
     # Base simulation and model name and workspace
 
-    length_units = "m"
-    time_units = "sec"
+    length_units = "meters"
+    time_units = "seconds"
 
     nrow = 1
     ncol = 1

--- a/autotest/test_gwf_sfr_tbedk.py
+++ b/autotest/test_gwf_sfr_tbedk.py
@@ -18,8 +18,8 @@ def build_models(idx, test):
     ws = test.workspace
     name = cases[idx]
 
-    length_units = "m"
-    time_units = "sec"
+    length_units = "meters"
+    time_units = "seconds"
 
     nrow = 1
     ncol = 1

--- a/autotest/test_gwf_sfr_wetstrmbedarea.py
+++ b/autotest/test_gwf_sfr_wetstrmbedarea.py
@@ -23,7 +23,7 @@ def get_xy_pts(x, y, rwid):
 
 
 # Model units
-length_units = "m"
+length_units = "meters"
 time_units = "days"
 
 # model domain and grid definition

--- a/autotest/test_gwf_vsc01.py
+++ b/autotest/test_gwf_vsc01.py
@@ -21,7 +21,7 @@ hydraulic_conductivity = [hyd_cond[0], hyd_cond[1], hyd_cond[1]]
 
 # Model units
 
-length_units = "cm"
+length_units = "centimeters"
 time_units = "seconds"
 
 # Table of model parameters

--- a/autotest/test_gwf_vsc02.py
+++ b/autotest/test_gwf_vsc02.py
@@ -23,7 +23,7 @@ hydraulic_conductivity = [hyd_cond[0], hyd_cond[1], hyd_cond[1]]
 
 # Model units
 
-length_units = "cm"
+length_units = "centimeters"
 time_units = "seconds"
 
 # Table of model parameters

--- a/autotest/test_gwf_vsc03_sfr.py
+++ b/autotest/test_gwf_vsc03_sfr.py
@@ -28,7 +28,7 @@ def topElev_sfrCentered(x, y):
 
 
 # Model units
-length_units = "m"
+length_units = "meters"
 time_units = "days"
 
 # model domain and grid definition

--- a/autotest/test_gwf_vsc04_lak.py
+++ b/autotest/test_gwf_vsc04_lak.py
@@ -25,7 +25,7 @@ cases = ["no-vsc04-lak", "vsc04-lak"]
 viscosity_on = [False, True]
 
 # Model units
-length_units = "m"
+length_units = "meters"
 time_units = "days"
 
 # model domain and grid definition

--- a/autotest/test_gwf_vsc05_hfb.py
+++ b/autotest/test_gwf_vsc05_hfb.py
@@ -32,7 +32,7 @@ icell_inactive = 3
 
 # Model units
 
-length_units = "cm"
+length_units = "centimeters"
 time_units = "seconds"
 
 # Table of model parameters

--- a/src/Exchange/exg-gwegwe.f90
+++ b/src/Exchange/exg-gwegwe.f90
@@ -715,11 +715,16 @@ contains
     end if
     !
     if (found%adv_scheme) then
-      ! -- count from 0
-      this%iAdvScheme = this%iAdvScheme - 1
-      write (iout, '(4x,a,a)') &
-        'ADVECTION SCHEME METHOD HAS BEEN SET TO: ', &
-        trim(adv_scheme(this%iAdvScheme + 1))
+      if (this%iAdvScheme == 0) then
+        call store_error('Unrecognized input value for ADV_SCHEME option.')
+        call store_error_filename(this%filename)
+      else
+        ! -- count from 0
+        this%iAdvScheme = this%iAdvScheme - 1
+        write (iout, '(4x,a,a)') &
+          'ADVECTION SCHEME METHOD HAS BEEN SET TO: ', &
+          trim(adv_scheme(this%iAdvScheme + 1))
+      end if
     end if
     !
     if (found%cnd_xt3d_off .and. found%cnd_xt3d_rhs) then

--- a/src/Exchange/exg-gwfgwf.f90
+++ b/src/Exchange/exg-gwfgwf.f90
@@ -1260,11 +1260,16 @@ contains
     call this%DisConnExchangeType%source_options(iout)
     !
     if (found%cell_averaging) then
-      ! -- count from 0
-      this%icellavg = this%icellavg - 1
-      write (iout, '(4x,a,a)') &
-        'CELL AVERAGING METHOD HAS BEEN SET TO: ', &
-        trim(cellavg_method(this%icellavg + 1))
+      if (this%icellavg == 0) then
+        call store_error('Unrecognized input value for CELL_AVERAGING option.')
+        call store_error_filename(this%filename)
+      else
+        ! -- count from 0
+        this%icellavg = this%icellavg - 1
+        write (iout, '(4x,a,a)') &
+          'CELL AVERAGING METHOD HAS BEEN SET TO: ', &
+          trim(cellavg_method(this%icellavg + 1))
+      end if
     end if
     !
     if (found%newton) then

--- a/src/Exchange/exg-gwtgwt.f90
+++ b/src/Exchange/exg-gwtgwt.f90
@@ -711,11 +711,16 @@ contains
     end if
     !
     if (found%adv_scheme) then
-      ! -- count from 0
-      this%iAdvScheme = this%iAdvScheme - 1
-      write (iout, '(4x,a,a)') &
-        'ADVECTION SCHEME METHOD HAS BEEN SET TO: ', &
-        trim(adv_scheme(this%iAdvScheme + 1))
+      if (this%iAdvScheme == 0) then
+        call store_error('Unrecognized input value for ADV_SCHEME option.')
+        call store_error_filename(this%filename)
+      else
+        ! -- count from 0
+        this%iAdvScheme = this%iAdvScheme - 1
+        write (iout, '(4x,a,a)') &
+          'ADVECTION SCHEME METHOD HAS BEEN SET TO: ', &
+          trim(adv_scheme(this%iAdvScheme + 1))
+      end if
     end if
     !
     if (found%dsp_xt3d_off .and. found%dsp_xt3d_rhs) then

--- a/src/Model/GroundWaterFlow/gwf-npf.f90
+++ b/src/Model/GroundWaterFlow/gwf-npf.f90
@@ -1418,6 +1418,15 @@ contains
       call tvk_cr(this%tvk, this%name_model, this%intvk, this%iout)
     end if
     !
+    ! -- verify ALTERNATIVE_CELL_AVERAGING input value is supported
+    if (found%cellavg) then
+      if (this%icellavg == 0) then
+        errmsg = 'Unrecognized input value for ALTERNATIVE_CELL_AVERAGING option.'
+        call store_error(errmsg)
+        call store_error_filename(this%input_fname)
+      end if
+    end if
+    !
     ! -- log options
     if (this%iout > 0) then
       call this%log_options(found)

--- a/src/Model/GroundWaterFlow/gwf-vsc.f90
+++ b/src/Model/GroundWaterFlow/gwf-vsc.f90
@@ -1242,6 +1242,14 @@ contains
                     form, access, 'REPLACE')
     end if
 
+    ! -- verify THERMAL_FORM input value is supported
+    if (found%thermal_form) then
+      if (this%thermivisc == 0) then
+        call store_error('Unrecognized input value for THERMAL_FORM option.')
+        call store_error_filename(this%input_fname)
+      end if
+    end if
+
     ! set warnings and errors
     if (this%thermivisc == 1) then
       if (this%a2 == 0.0) then

--- a/src/Timing/tdis.f90
+++ b/src/Timing/tdis.f90
@@ -385,6 +385,7 @@ contains
     ! -- modules
     use ConstantsModule, only: LINELENGTH
     use InputOutputModule, only: GetUnit, openfile
+    use SimModule, only: store_error, store_error_filename
     use MemoryManagerExtModule, only: mem_set_value
     use SourceCommonModule, only: filein_fname
     use SimTdisInputModule, only: SimTdisParamFoundType
@@ -410,9 +411,14 @@ contains
                        found%start_date_time)
     !
     if (found%time_units) then
-      !
-      ! -- adjust to 0-based indexing for itmuni
-      itmuni = itmuni - 1
+      if (itmuni == 0) then
+        call store_error('Unrecognized input value for TIME_UNITS option.')
+        call store_error_filename(input_fname)
+      else
+        !
+        ! -- adjust to 0-based indexing for itmuni
+        itmuni = itmuni - 1
+      end if
     end if
     !
     ! -- enforce 0 or 1 ATS6_FILENAME entries in option block


### PR DESCRIPTION
Set consistent errors for non-valid string input options:
- #2656
- verify that when an input string with a valid set is read that it matches an expected string and set an error if it does not
- some packages are already validating strings and setting errors: `prt-prp`, `gwt-mst`, `gwt-ist`, `tsp-adv`
- the `DIS` packages are outliers as the documentation states that `FEET`, `METERS` and `CENTIMETERS` are supported as `LENGTH_UNITS` but some tests set the input string as `UNDEFINED`.  Currently any unrecognized `LENGTH_UNITS` input values are assigned as `UNDETERMINED`/`UNDEFINED`/`UNKNOWN`.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Referenced issue or pull request #xxxx
- [X] Added new test or modified an existing test
- [X] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
