### PR TITLE
doc(prt-prp): remove developmode attribute from coordinate_check_method

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -290,7 +290,6 @@ type string
 valid none eager
 reader urword
 optional true
-developmode true
 mf6internal ichkmeth
 longname coordinate checking method
 description approach for verifying that release point coordinates are in the cell with the specified ID. Possible values are NONE and EAGER. By default, release point coordinates are checked at release time, i.e. EAGER.

--- a/src/Idm/prt-prpidm.f90
+++ b/src/Idm/prt-prpidm.f90
@@ -612,7 +612,7 @@ module PrtPrpInputModule
     '', & ! shape
     'coordinate checking method', & ! longname
     .false., & ! required
-    .true., & ! developmode
+    .false., & ! developmode
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered


### PR DESCRIPTION
This option will be released with 3.7.0