### PR TITLE
fix(sfr): avoid courant number remaining uninitialized when depth equals zero

### DIFF
--- a/src/Model/GroundWaterFlow/submodules/gwf-sfr-transient.f90
+++ b/src/Model/GroundWaterFlow/submodules/gwf-sfr-transient.f90
@@ -106,9 +106,10 @@ contains
     call this%sfr_calc_reach_depth(n, q2, d2)
     a2 = this%calc_area_wet(n, d2)
     celerity = (q2 - q) / (a2 - a)
-    courant = celerity * delt / this%length(n)
-    ! write(*,*) this%length(n), courant * delt
+  else
+    celerity = DZERO
   end if
+  courant = celerity * delt / this%length(n)
 
   qlat = qlat / this%length(n)
 


### PR DESCRIPTION
giving floating point exceptions, at least in debug mode. Since the problem does not appear to be present in release mode, we can leave it out of the release notes.


```
Program received signal SIGFPE: Floating-point exception - erroneous arithmetic operation.

Backtrace for this error:
#0  0x7f9696790e59 in ???
#1  0x7f969678fe75 in ???
#2  0x7f969648932f in ???
        at ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
#3  0x5600641f9caf in kinematic_residual_
        at ../src/Model/ModelUtilities/GwfSfrCommon.f90:34
#4  0x560064141df0 in __sfrmodule_MOD_sfr_calc_transient
        at ../src/Model/GroundWaterFlow/submodules/gwf-sfr-transient.f90:142
#5  0x5600640edc3c in __sfrmodule_MOD_sfr_solve
        at ../src/Model/GroundWaterFlow/gwf-sfr.f90:3605
#6  0x5600640f7edb in __sfrmodule_MOD_sfr_fc
        at ../src/Model/GroundWaterFlow/gwf-sfr.f90:2227
...
```

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Removed checklist items not relevant to this pull request
