### PR TITLE
doc(releaseNotes): add 6.6.3 release notes to appendix A

### DIFF
--- a/doc/ReleaseNotes/appendixA.tex
+++ b/doc/ReleaseNotes/appendixA.tex
@@ -1,5 +1,6 @@
 This appendix describes changes introduced into MODFLOW~6 in previous releases. These changes may substantially affect users.
 
+        \input{./previous/v6.6.3.tex}
         \input{./previous/v6.6.2.tex}
         \input{./previous/v6.6.1.tex}
         \input{./previous/v6.6.0.tex}


### PR DESCRIPTION
Appendix A of the release notes was missing the section for what was included in the 6.6.3 release.  
