### PR TITLE
ci(release): add gfortran intel mac build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,9 @@ jobs:
           # arm mac, debug mode
           - os: macos-14
             debug: true
+          # intel mac, release mode
+          - os: macos-15-intel
+            debug: false
           # ubuntu, release mode
           - os: ubuntu-22.04
             debug: false

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -27,6 +27,7 @@ jobs:
           - {os: macos-14, compiler: gcc, version: 12}
           - {os: macos-14, compiler: gcc, version: 13}
           - {os: macos-14, compiler: gcc, version: 14}
+          - {os: macos-15-intel, compiler: gcc, version: 13}
           - {os: windows-2022, compiler: gcc, version: 11}
           - {os: windows-2022, compiler: gcc, version: 12}
           - {os: windows-2022, compiler: gcc, version: 13}
@@ -91,6 +92,19 @@ jobs:
       - name: Custom pixi install
         working-directory: modflow6
         run: pixi run install
+
+      - name: Set GCC_LIBPATH
+        if: runner.os == 'macOS'
+        run: |
+          echo "GCC_LIBPATH=$(brew --prefix)" >> $GITHUB_ENV
+
+      - name: Hide dylibs on macOS
+        if: runner.os == 'macOS'
+        run: |
+          version=${{ matrix.version }}
+          libpath="${{ env.GCC_LIBPATH }}/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
+          mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak
 
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,11 @@ jobs:
             version: 13
             optimization: 1
             extended: false
+          - os: macos-15-intel
+            compiler: gcc
+            version: 13
+            optimization: 1
+            extended: false
           - os: windows-2022
             compiler: ${{ inputs.compiler_toolchain }}
             version: ${{ inputs.compiler_version }}
@@ -213,13 +218,18 @@ jobs:
           fi
           echo "filters=$filters" >> $GITHUB_OUTPUT
 
-      # for statically linked gfortran ARM mac build
+      - name: Set GCC_LIBPATH
+        if: runner.os == 'macOS'
+        run: |
+          echo "GCC_LIBPATH=$(brew --prefix)" >> $GITHUB_ENV
+
+      # for statically linked gfortran mac build
       - name: Hide dylibs (macOS)
-        if: matrix.os == 'macos-14'
+        if: runner.os == 'macOS'
         run: |
           version="${{ matrix.version }}"
-          libpath="/opt/homebrew/opt/gcc@$version/lib/gcc/$version"
-          mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak 
+          libpath="${{ env.GCC_LIBPATH }}/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
       - name: Set LDFLAGS (macOS)
@@ -563,6 +573,7 @@ jobs:
         include:
           - os: ubuntu-22.04
           - os: macos-14
+          - os: macos-15-intel
           - os: windows-2022
             extended: false
           - os: windows-2022


### PR DESCRIPTION
We recently removed the intel fortran intel mac build in #2628 due to concerns about ongoing availability of compatible versions of intel compilers. Add a gfortran build for intel macs.