### PR TITLE
ci: make macos gfortran build logic consistent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,11 +364,11 @@ jobs:
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
-      # use classic xcode linker
+      # use classic xcode linker, static link libgcc
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -Wl,-ld_classic"
+          ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Update version files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,11 +724,8 @@ jobs:
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          os_ver=$(sw_vers -productVersion | cut -d'.' -f1)
-          if (( "$os_ver" > 12 )); then
-            ldflags="$LDFLAGS -Wl,-ld_classic"
-            echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
-          fi
+          ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
+          echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Set markers
         id: set_markers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,11 +364,11 @@ jobs:
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
-      # use classic xcode linker, static link libgcc
+      # static link libgcc
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
+          ldflags="$LDFLAGS -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Update version files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,25 @@ jobs:
           pixi run setup-mf5to6 builddir $MESON_SETUP_ARGS
           pixi run build-mf5to6 builddir
 
+      - name: Show build log
+        if: failure()
+        working-directory: modflow6
+        run: cat builddir/meson-logs/meson-log.txt
+
+      - name: Upload build log
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.os }}-${{ env.FC }}-${{ env.FC_V }}-meson-log.txt
+          path: modflow6/builddir/meson-logs/meson-log.txt
+
+      - name: Check arch/libs (macOS)
+        if: runner.os == 'macOS'
+        working-directory: modflow6/bin
+        run: |
+          otool -L mf6
+          lipo -info mf6
+
       - name: Restore dylibs (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -406,18 +425,6 @@ jobs:
           mv $libpath/libgcc_s.1.1.dylib.bak $libpath/libgcc_s.1.1.dylib
           mv $libpath/libgfortran.5.dylib.bak $libpath/libgfortran.5.dylib
           mv $libpath/libquadmath.0.dylib.bak $libpath/libquadmath.0.dylib
-
-      - name: Check architecture (macOS)
-        working-directory: modflow6/bin
-        if: runner.os == 'macOS'
-        run: |
-          otool -L mf6
-          lipo -info mf6 
-
-      - name: Show build log
-        if: failure()
-        working-directory: modflow6
-        run: cat builddir/meson-logs/meson-log.txt
 
       - name: Unit test MF6
         working-directory: modflow6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,12 +277,15 @@ jobs:
           # arm mac, release mode
           - os: macos-14
             debug: false
+            xcode-version: '15.1.0'
           # arm mac, debug mode
           - os: macos-14
             debug: true
+            xcode-version: '15.1.0'
           # intel mac, release mode
           - os: macos-15-intel
             debug: false
+            xcode-version: '16.1.0'
           # ubuntu, release mode
           - os: ubuntu-22.04
             debug: false
@@ -348,7 +351,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.1.0'
+          xcode-version: ${{ matrix.xcode-version }}
 
       # static link gfortran libs
       - name: Hide dylibs (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 14.5
+          xcode-version: '15.1.0'
 
       # static link gfortran libs
       - name: Hide dylibs (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,16 @@ jobs:
           pixi run setup-mf5to6 builddir $MESON_SETUP_ARGS
           pixi run build-mf5to6 builddir
 
+      - name: Restore dylibs (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          version="${{ env.FC_V }}"
+          brew_prefix="$(brew --prefix)"
+          libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgcc_s.1.1.dylib.bak $libpath/libgcc_s.1.1.dylib
+          mv $libpath/libgfortran.5.dylib.bak $libpath/libgfortran.5.dylib
+          mv $libpath/libquadmath.0.dylib.bak $libpath/libquadmath.0.dylib
+
       - name: Check architecture (macOS)
         working-directory: modflow6/bin
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,8 +375,7 @@ jobs:
         working-directory: modflow6
         run: pixi run update-version
 
-      - name: Build MF6
-        working-directory: modflow6
+      - name: Set setupargs
         run: |
           setupargs=""
           if [[ "${{ matrix.debug }}" == "true" ]]; then
@@ -384,10 +383,26 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
             setupargs="-Doptimization=1"
           fi
-          pixi run setup builddir $setupargs
+          echo "MESON_SETUP_ARGS=$setupargs" >> $GITHUB_ENV
+
+      - name: Build MF6
+        working-directory: modflow6
+        run: |
+          pixi run setup builddir $MESON_SETUP_ARGS
           pixi run build builddir
-          pixi run setup-mf5to6 builddir $setupargs
+
+      - name: Build mf5to6 converter
+        working-directory: modflow6
+        run: |
+          pixi run setup-mf5to6 builddir $MESON_SETUP_ARGS
           pixi run build-mf5to6 builddir
+
+      - name: Check architecture (macOS)
+        working-directory: modflow6/bin
+        if: runner.os == 'macOS'
+        run: |
+          otool -L mf6
+          lipo -info mf6 
 
       - name: Show build log
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,12 +344,11 @@ jobs:
         working-directory: modflow6
         run: pixi run install
 
-      # debugging
-      - name: Check xcode version
+      - name: Set xcode version (macOS)
         if: runner.os == 'macOS'
-        run: |
-          xcode-select -p
-          xcrun --show-sdk-version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 14.5
 
       # static link gfortran libs
       - name: Hide dylibs (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,11 +364,11 @@ jobs:
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
-      # static link libgcc
+      # use classic xcode linker, static link libgcc
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -static-libgcc"
+          ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Update version files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,24 @@ jobs:
         working-directory: modflow6
         run: pixi run install
 
+      # debugging
+      - name: Check xcode version
+        if: runner.os == 'macOS'
+        run: |
+          xcode-select -p
+          xcrun --show-sdk-version
+
+      # static link gfortran libs
+      - name: Hide dylibs (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          version="${{ env.FC_V }}"
+          brew_prefix="$(brew --prefix)"
+          libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
+          mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
+
+      # use classic xcode linker
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,7 @@ jobs:
           version="${{ env.FC_V }}"
           brew_prefix="$(brew --prefix)"
           libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgcc_s.1.1.dylib $libpath/libgcc_s.1.1.dylib.bak
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -129,23 +129,6 @@ jobs:
           pixi run setup-mf5to6 builddir
           pixi run build-mf5to6 builddir
 
-      - name: Restore dylibs (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          version="${{ matrix.version }}"
-          brew_prefix="$(brew --prefix)"
-          libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
-          mv $libpath/libgcc_s.1.1.dylib.bak $libpath/libgcc_s.1.1.dylib
-          mv $libpath/libgfortran.5.dylib.bak $libpath/libgfortran.5.dylib
-          mv $libpath/libquadmath.0.dylib.bak $libpath/libquadmath.0.dylib
-
-      - name: Check architecture (macOS)
-        working-directory: modflow6/bin
-        if: runner.os == 'macOS'
-        run: |
-          otool -L mf6
-          lipo -info mf6 
-
       - name: Show build log
         if: failure()
         working-directory: modflow6
@@ -155,9 +138,26 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: meson-log.txt
+          name: ${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.version }}-meson-log.txt
           path: modflow6/builddir/meson-logs/meson-log.txt
+
+      - name: Check arch/libs (macOS)
+        if: success() && runner.os == 'macOS'
+        working-directory: modflow6/bin
+        run: |
+          otool -L mf6
+          lipo -info mf6 
     
+      - name: Restore dylibs (macOS)
+        if: success() && runner.os == 'macOS'
+        run: |
+          version="${{ matrix.version }}"
+          brew_prefix="$(brew --prefix)"
+          libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgcc_s.1.1.dylib.bak $libpath/libgcc_s.1.1.dylib
+          mv $libpath/libgfortran.5.dylib.bak $libpath/libgfortran.5.dylib
+          mv $libpath/libquadmath.0.dylib.bak $libpath/libquadmath.0.dylib
+
       - name: Unit test programs
         if: success()
         working-directory: modflow6

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -93,19 +93,17 @@ jobs:
         working-directory: modflow6
         run: pixi run install
 
-      - name: Set GCC_LIBPATH
+      # static link gfortran libs
+      - name: Hide dylibs (macOS)
         if: runner.os == 'macOS'
         run: |
-          echo "GCC_LIBPATH=$(brew --prefix)" >> $GITHUB_ENV
-
-      - name: Hide dylibs on macOS
-        if: runner.os == 'macOS'
-        run: |
-          version=${{ matrix.version }}
-          libpath="${{ env.GCC_LIBPATH }}/opt/gcc@$version/lib/gcc/$version"
+          version="${{ matrix.version }}"
+          brew_prefix="$(brew --prefix)"
+          libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
-          mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak
+          mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
+      # use classic xcode linker
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -110,11 +110,11 @@ jobs:
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
-      # static link libgcc
+      # use classic xcode linker, static link libgcc
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -static-libgcc"
+          ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Build MF6

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -117,13 +117,24 @@ jobs:
           ldflags="$LDFLAGS -Wl,-ld_classic"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
-      - name: Build modflow6
+      - name: Build MF6
         working-directory: modflow6
         run: |
           pixi run setup builddir
           pixi run build builddir
+
+      - name: Build mf5to6 converter
+        working-directory: modflow6
+        run: |
           pixi run setup-mf5to6 builddir
           pixi run build-mf5to6 builddir
+
+      - name: Check architecture (macOS)
+        working-directory: modflow6/bin
+        if: runner.os == 'macOS'
+        run: |
+          otool -L mf6
+          lipo -info mf6 
 
       - name: Show build log
         if: failure()

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -Wl,-ld_classic, -static-libgcc"
+          ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Build MF6

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -97,7 +97,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 14.5
+          xcode-version: '15.1.0'
 
       # static link gfortran libs
       - name: Hide dylibs (macOS)

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -110,11 +110,11 @@ jobs:
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
-      # use classic xcode linker, static link libgcc
+      # static link libgcc
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
+          ldflags="$LDFLAGS -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Build MF6

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -23,11 +23,11 @@ jobs:
           - {os: ubuntu-24.04, compiler: gcc, version: 12}
           - {os: ubuntu-24.04, compiler: gcc, version: 13}
           - {os: ubuntu-24.04, compiler: gcc, version: 14}
-          - {os: macos-14, compiler: gcc, version: 11}
-          - {os: macos-14, compiler: gcc, version: 12}
-          - {os: macos-14, compiler: gcc, version: 13}
-          - {os: macos-14, compiler: gcc, version: 14}
-          - {os: macos-15-intel, compiler: gcc, version: 13}
+          - {os: macos-14, compiler: gcc, version: 11, xcode-version: '15.1.0'}
+          - {os: macos-14, compiler: gcc, version: 12, xcode-version: '15.1.0'}
+          - {os: macos-14, compiler: gcc, version: 13, xcode-version: '15.1.0'}
+          - {os: macos-14, compiler: gcc, version: 14, xcode-version: '15.1.0'}
+          - {os: macos-15-intel, compiler: gcc, version: 13, xcode-version: '16.1.0'}
           - {os: windows-2022, compiler: gcc, version: 11}
           - {os: windows-2022, compiler: gcc, version: 12}
           - {os: windows-2022, compiler: gcc, version: 13}
@@ -97,7 +97,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.1.0'
+          xcode-version: ${{ matrix.xcode-version }}
 
       # static link gfortran libs
       - name: Hide dylibs (macOS)

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -93,6 +93,12 @@ jobs:
         working-directory: modflow6
         run: pixi run install
 
+      - name: Set xcode version (macOS)
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 14.5
+
       # static link gfortran libs
       - name: Hide dylibs (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -106,6 +106,7 @@ jobs:
           version="${{ matrix.version }}"
           brew_prefix="$(brew --prefix)"
           libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgcc_s.1.1.dylib $libpath/libgcc_s.1.1.dylib.bak
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -129,6 +129,16 @@ jobs:
           pixi run setup-mf5to6 builddir
           pixi run build-mf5to6 builddir
 
+      - name: Restore dylibs (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          version="${{ matrix.version }}"
+          brew_prefix="$(brew --prefix)"
+          libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgcc_s.1.1.dylib.bak $libpath/libgcc_s.1.1.dylib
+          mv $libpath/libgfortran.5.dylib.bak $libpath/libgfortran.5.dylib
+          mv $libpath/libquadmath.0.dylib.bak $libpath/libquadmath.0.dylib
+
       - name: Check architecture (macOS)
         working-directory: modflow6/bin
         if: runner.os == 'macOS'

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -110,11 +110,11 @@ jobs:
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
-      # use classic xcode linker
+      # use classic xcode linker, static link libgcc
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -Wl,-ld_classic"
+          ldflags="$LDFLAGS -Wl,-ld_classic, -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Build MF6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,11 +237,11 @@ jobs:
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
-      # use classic xcode linker
+      # use classic xcode linker, static link libgcc
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -Wl,-ld_classic"
+          ldflags="$LDFLAGS -Wl,-ld_classic, -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Get executables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
             extended: true
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash
     outputs:
       version: ${{ steps.set_version.outputs.version }}
       distname: ${{ steps.set_version.outputs.distname }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,7 @@ jobs:
           version="${{ matrix.version }}"
           brew_prefix="$(brew --prefix)"
           libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgcc_s.1.1.dylib $libpath/libgcc_s.1.1.dylib.bak
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,12 @@ jobs:
           fi
           echo "filters=$filters" >> $GITHUB_OUTPUT
 
+      - name: Set xcode version (macOS)
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 14.5
+
       # static link gfortran libs
       - name: Hide dylibs (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pixi run get-exes -s
 
-      - name: Build binaries
+      - name: Build MF6
         if: (!(runner.os == 'Windows' && matrix.extended))
         working-directory: modflow6
         run: |
@@ -286,6 +286,11 @@ jobs:
           RELEASEMODE: ${{ inputs.releasemode }}
           MARKERS: ${{ steps.set_markers.outputs.markers }}
           FILTERS: ${{ steps.set_filters.outputs.filters }}
+
+      - name: Show build log
+        if: failure()
+        working-directory: modflow6
+        run: cat builddir/meson-logs/meson-log.txt
 
       - name: Copy deps to bin dir
         if: runner.os == 'Windows' && matrix.extended

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -597,11 +597,21 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
+            compiler: ${{ inputs.compiler_toolchain }}
+            version: ${{ inputs.compiler_version }}
           - os: macos-14
+            compiler: gcc
+            version: 13
           - os: macos-15-intel
+            compiler: gcc
+            version: 13
           - os: windows-2022
+            compiler: ${{ inputs.compiler_toolchain }}
+            version: ${{ inputs.compiler_version }}
             extended: false
           - os: windows-2022
+            compiler: ${{ inputs.compiler_toolchain }}
+            version: ${{ inputs.compiler_version }}
             extended: true
     defaults:
       run:
@@ -620,11 +630,11 @@ jobs:
           repository: MODFLOW-ORG/modflow6-examples
           path: modflow6-examples
 
-      - name: Setup ${{ inputs.compiler_toolchain }} ${{ inputs.compiler_version }}
+      - name: Setup ${{ matrix.compiler }} ${{ matrix.version }}
         uses: fortran-lang/setup-fortran@v1
         with:
-          compiler: ${{ inputs.compiler_toolchain }}
-          version: ${{ inputs.compiler_version }}
+          compiler: ${{ matrix.compiler }}
+          version: ${{ matrix.version }}
 
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.9.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,12 +257,12 @@ jobs:
           pixi run setup builddir -Doptimization=${{ matrix.optimization }}
           pixi run build builddir
           # skip tests on mac, test-drive seems to collect results incorrectly
-          arch=$(uname -m || echo "unknown")
-          if [[ "${{ runner.os }}" == "macOS" ]]; then
-            echo "Skipping unit tests on mac"
-          else
-            pixi run test builddir
-          fi
+          # arch=$(uname -m || echo "unknown")
+          # if [[ "${{ runner.os }}" == "macOS" ]]; then
+          #   echo "Skipping unit tests on mac"
+          # else
+          #   pixi run test builddir
+          # fi
 
       - name: Build mf5to6 converter
         if: (!(runner.os == 'Windows' && matrix.extended))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,7 @@ jobs:
           pixi run build-mf5to6 builddir
 
       - name: Unit test MF6
+        if: (!(runner.os == 'Windows' && matrix.extended))
         working-directory: modflow6
         run: pixi run test builddir
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,11 +237,11 @@ jobs:
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
-      # use classic xcode linker, static link libgcc
+      # static link libgcc
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
+          ldflags="$LDFLAGS -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Get executables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -Wl,-ld_classic, -static-libgcc"
+          ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Get executables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
         run: pixi run install
 
       - name: Install additional netcdf testing packages
+        if: matrix.extended
         working-directory: modflow6
         run: pixi run pip install xarray netcdf4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,8 @@ jobs:
           mv $libpath/libquadmath.0.dylib.bak $libpath/libquadmath.0.dylib
 
       - name: Unit test MF6
-        if: (!(runner.os == 'Windows' && matrix.extended))
+        # temporarily skip macOS.. why don't these fail in the normal CI?
+        if: (!(runner.os == 'Windows' && matrix.extended) && !(runner.os == 'macOS'))
         working-directory: modflow6
         run: pixi run test builddir
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
           pixi run build-mf5to6 builddir
 
       - name: Unit test MF6
-        if: (!(runner.os == 'Windows' && matrix.extended))
+        if: (!(runner.os == 'Windows' && matrix.extended) && !(runner.os == 'macOS'))
         working-directory: modflow6
         run: pixi run test builddir
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,8 +208,8 @@ jobs:
             # run only parallel/extended tests in developmode, run all tests in releasemode
             filters="test_par or test_netcdf"
           fi
-          # comparison fails on macos-14 with optimization=1
-          if [[ "${{ matrix.os }}" == "macos-14" ]]; then
+          # comparison fails on macos with optimization=1
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
             if [[ "$filters" != "" ]]; then
               filters="$filters and not test028_sfr_rewet"
             else
@@ -218,28 +218,22 @@ jobs:
           fi
           echo "filters=$filters" >> $GITHUB_OUTPUT
 
-      - name: Set GCC_LIBPATH
-        if: runner.os == 'macOS'
-        run: |
-          echo "GCC_LIBPATH=$(brew --prefix)" >> $GITHUB_ENV
-
-      # for statically linked gfortran mac build
+      # static link gfortran libs
       - name: Hide dylibs (macOS)
         if: runner.os == 'macOS'
         run: |
           version="${{ matrix.version }}"
-          libpath="${{ env.GCC_LIBPATH }}/opt/gcc@$version/lib/gcc/$version"
+          brew_prefix="$(brew --prefix)"
+          libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
+      # use classic xcode linker
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          os_ver=$(sw_vers -productVersion | cut -d'.' -f1)
-          if (( "$os_ver" > 12 )); then
-            ldflags="$LDFLAGS -Wl,-ld_classic"
-            echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
-          fi
+          ldflags="$LDFLAGS -Wl,-ld_classic"
+          echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Get executables
         if: inputs.run_tests == true && runner.os != 'Windows'
@@ -254,10 +248,10 @@ jobs:
         run: |
           pixi run setup builddir -Doptimization=${{ matrix.optimization }}
           pixi run build builddir
-          # skip tests on arm mac, test-drive seems to collect results incorrectly
+          # skip tests on mac, test-drive seems to collect results incorrectly
           arch=$(uname -m || echo "unknown")
-          if [[ "${{ runner.os }}" == "macOS" ]] && [[ "$arch" == "arm64" ]]; then
-            echo "Skipping unit tests on ARM mac"
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            echo "Skipping unit tests on mac"
           else
             pixi run test builddir
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,16 @@ jobs:
         working-directory: modflow6
         run: pixi run test builddir
 
+      - name: Restore dylibs (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          version="${{ matrix.version }}"
+          brew_prefix="$(brew --prefix)"
+          libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgcc_s.1.1.dylib.bak $libpath/libgcc_s.1.1.dylib
+          mv $libpath/libgfortran.5.dylib.bak $libpath/libgfortran.5.dylib
+          mv $libpath/libquadmath.0.dylib.bak $libpath/libquadmath.0.dylib
+
       - name: Check architecture (macOS)
         working-directory: modflow6/bin
         if: runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,11 +237,11 @@ jobs:
           mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
-      # static link libgcc
+      # use classic xcode linker, static link libgcc
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          ldflags="$LDFLAGS -static-libgcc"
+          ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Get executables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,10 +259,24 @@ jobs:
           pixi run setup-mf5to6 builddir -Doptimization=${{ matrix.optimization }}
           pixi run build-mf5to6 builddir
 
-      - name: Unit test MF6
-        if: (!(runner.os == 'Windows' && matrix.extended) && !(runner.os == 'macOS'))
+      - name: Show build log
+        if: failure()
         working-directory: modflow6
-        run: pixi run test builddir
+        run: cat builddir/meson-logs/meson-log.txt
+
+      - name: Upload build log
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.version }}-meson-log.txt
+          path: modflow6/builddir/meson-logs/meson-log.txt
+
+      - name: Check arch/libs (macOS)
+        if: runner.os == 'macOS'
+        working-directory: modflow6/bin
+        run: |
+          otool -L mf6
+          lipo -info mf6 
 
       - name: Restore dylibs (macOS)
         if: runner.os == 'macOS'
@@ -274,12 +288,11 @@ jobs:
           mv $libpath/libgfortran.5.dylib.bak $libpath/libgfortran.5.dylib
           mv $libpath/libquadmath.0.dylib.bak $libpath/libquadmath.0.dylib
 
-      - name: Check architecture (macOS)
-        working-directory: modflow6/bin
-        if: runner.os == 'macOS'
-        run: |
-          otool -L mf6
-          lipo -info mf6 
+      - name: Unit test MF6
+        # temporarily skip macOS.. why don't these fail in the normal CI?
+        if: (!(runner.os == 'Windows' && matrix.extended) && !(runner.os == 'macOS'))
+        working-directory: modflow6
+        run: pixi run test builddir
 
       - name: Get executables
         if: inputs.run_tests == true && runner.os != 'Windows'
@@ -302,12 +315,7 @@ jobs:
           MARKERS: ${{ steps.set_markers.outputs.markers }}
           FILTERS: ${{ steps.set_filters.outputs.filters }}
 
-      - name: Show build log
-        if: failure()
-        working-directory: modflow6
-        run: cat builddir/meson-logs/meson-log.txt
-
-      - name: Copy deps to bin dir
+      - name: Copy deps to bin dir (Windows)
         if: runner.os == 'Windows' && matrix.extended
         working-directory: modflow6/bin
         shell: cmd
@@ -343,7 +351,7 @@ jobs:
 
           :: remove rebuilt and downloaded dirs
           if exist rebuilt rd /s /q rebuilt
-          if exist rebuilt rd /s /q downloaded
+          if exist downloaded rd /s /q downloaded
 
       - name: Upload binaries
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,13 @@ jobs:
             version: 13
             optimization: 1
             extended: false
+            xcode-version: '15.1.0'
           - os: macos-15-intel
             compiler: gcc
             version: 13
             optimization: 1
             extended: false
+            xcode-version: '16.1.0'
           - os: windows-2022
             compiler: ${{ inputs.compiler_toolchain }}
             version: ${{ inputs.compiler_version }}
@@ -222,7 +224,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.1.0'
+          xcode-version: ${{ matrix.xcode-version }}
 
       # static link gfortran libs
       - name: Hide dylibs (macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,7 @@ jobs:
           pixi run build-mf5to6 builddir
 
       - name: Unit test MF6
+        working-directory: modflow6
         run: pixi run test builddir
 
       - name: Check architecture (macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,13 +257,7 @@ jobs:
         run: |
           pixi run setup builddir -Doptimization=${{ matrix.optimization }}
           pixi run build builddir
-          # skip tests on mac, test-drive seems to collect results incorrectly
-          # arch=$(uname -m || echo "unknown")
-          # if [[ "${{ runner.os }}" == "macOS" ]]; then
-          #   echo "Skipping unit tests on mac"
-          # else
-          #   pixi run test builddir
-          # fi
+          pixi run test builddir
 
       - name: Build mf5to6 converter
         if: (!(runner.os == 'Windows' && matrix.extended))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 14.5
+          xcode-version: '15.1.0'
 
       # static link gfortran libs
       - name: Hide dylibs (macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,14 @@ jobs:
           repository: MODFLOW-ORG/modflow6-examples
           path: modflow6-examples
 
+      - name: Setup ${{ matrix.compiler }} ${{ matrix.version }}
+        if: (!(runner.os == 'Windows' && matrix.extended))
+        id: setup-fortran
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: ${{ matrix.compiler }}
+          version: ${{ matrix.version }}
+
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.9.4
         with:
@@ -140,14 +148,6 @@ jobs:
         if: matrix.extended
         working-directory: modflow6
         run: pixi run pip install xarray netcdf4
-
-      - name: Setup ${{ matrix.compiler }} ${{ matrix.version }}
-        if: (!(runner.os == 'Windows' && matrix.extended))
-        id: setup-fortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: ${{ matrix.compiler }}
-          version: ${{ matrix.version }}
       
       - name: Set version number
         id: set_version
@@ -289,8 +289,7 @@ jobs:
           mv $libpath/libquadmath.0.dylib.bak $libpath/libquadmath.0.dylib
 
       - name: Unit test MF6
-        # temporarily skip macOS.. why don't these fail in the normal CI?
-        if: (!(runner.os == 'Windows' && matrix.extended) && !(runner.os == 'macOS'))
+        if: (!(runner.os == 'Windows' && matrix.extended))
         working-directory: modflow6
         run: pixi run test builddir
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,20 +244,12 @@ jobs:
           ldflags="$LDFLAGS -Wl,-ld_classic -static-libgcc"
           echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
-      - name: Get executables
-        if: inputs.run_tests == true && runner.os != 'Windows'
-        working-directory: modflow6
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: pixi run get-exes -s
-
       - name: Build MF6
         if: (!(runner.os == 'Windows' && matrix.extended))
         working-directory: modflow6
         run: |
           pixi run setup builddir -Doptimization=${{ matrix.optimization }}
           pixi run build builddir
-          pixi run test builddir
 
       - name: Build mf5to6 converter
         if: (!(runner.os == 'Windows' && matrix.extended))
@@ -266,12 +258,22 @@ jobs:
           pixi run setup-mf5to6 builddir -Doptimization=${{ matrix.optimization }}
           pixi run build-mf5to6 builddir
 
+      - name: Unit test MF6
+        run: pixi run test builddir
+
       - name: Check architecture (macOS)
         working-directory: modflow6/bin
         if: runner.os == 'macOS'
         run: |
           otool -L mf6
           lipo -info mf6 
+
+      - name: Get executables
+        if: inputs.run_tests == true && runner.os != 'Windows'
+        working-directory: modflow6
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pixi run get-exes -s
 
       - name: Build binaries (Windows)
         if: runner.os == 'Windows' && matrix.extended && !inputs.run_tests

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -171,15 +171,15 @@ jobs:
       branch: ${{ needs.set_options.outputs.branch }}
       # If the workflow is manually triggered, the maintainer must manually set releasemode to true, otherwise the default is false.
       # If triggered by pushing a release branch, the release is developmode if the branch name contains "rc", otherwise releasemode.
-      releasemode: ${{ (github.event_name == 'workflow_dispatch' && inputs.releasemode == 'true') || github.event_name != 'workflow_dispatch' }}
+      releasemode: ${{ (github.event_name == 'workflow_dispatch' && inputs.releasemode == true) || github.event_name != 'workflow_dispatch' }}
       # If the workflow is manually triggered, the maintainer must manually set run_tests to false, otherwise the default is true.
       # If triggered by pushing a release branch, tests are enabled.
-      run_tests: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_tests == 'true') || github.event_name != 'workflow_dispatch' }}
+      run_tests: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_tests == true) || github.event_name != 'workflow_dispatch' }}
       version: ${{ needs.set_options.outputs.version }}
-      patch: ${{ (github.event_name == 'workflow_dispatch' && inputs.patch == 'true') || (github.event_name != 'workflow_dispatch' && needs.set_options.outputs.patch == 'true') }}
+      patch: ${{ (github.event_name == 'workflow_dispatch' && inputs.patch == true) || (github.event_name != 'workflow_dispatch' && needs.set_options.outputs.patch == 'true') }}
   pr:
     name: Draft release PR
-    if: ${{ github.ref_name != 'master' && ((github.event_name == 'workflow_dispatch' && inputs.releasemode == 'true') || (github.event_name != 'workflow_dispatch' && !contains(github.ref_name, 'rc'))) }}
+    if: ${{ github.ref_name != 'master' && ((github.event_name == 'workflow_dispatch' && inputs.releasemode == true) || (github.event_name != 'workflow_dispatch' && !contains(github.ref_name, 'rc'))) }}
     needs:
       - set_options
       - make_dist

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -161,7 +161,7 @@ jobs:
           echo "patch=$patch" >> $GITHUB_OUTPUT
   make_dist:
     name: Make distribution
-    uses: MODFLOW-ORG/modflow6/.github/workflows/release.yml@develop
+    uses: wpbonelli/modflow6/.github/workflows/release.yml@ci
     needs: set_options
     with:
       # If the workflow is manually triggered, the maintainer must manually set approve=true to approve a release.

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -161,7 +161,7 @@ jobs:
           echo "patch=$patch" >> $GITHUB_OUTPUT
   make_dist:
     name: Make distribution
-    uses: wpbonelli/modflow6/.github/workflows/release.yml@ci
+    uses: MODFLOW-ORG/modflow6/.github/workflows/release.yml@develop
     needs: set_options
     with:
       # If the workflow is manually triggered, the maintainer must manually set approve=true to approve a release.

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -35,7 +35,7 @@ if test_drive.found() and not fc_id.contains('intel')
     'tester',
     sources: test_srcs,
     link_with: mf6core,
-    dependencies: test_drive,
+    dependencies: [test_drive] + dependencies + extra_deps,
   )
 
   test('Test source modules', tester)

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ fc_id = fc.get_id()
 message('Compiler ID:', fc_id)
 compile_args = []
 link_args = []
+extra_deps = []
 
 # Command line options for gfortran
 if fc_id == 'gcc'
@@ -38,7 +39,14 @@ if fc_id == 'gcc'
                    '-Wno-maybe-uninitialized',   # "Uninitialized" flags produce false positives with allocatables
                    '-Wno-uninitialized',
                    ]
-  
+
+  # Link quadmath library on macOS (required for gfortran runtime)
+  # Preventive measure for any code that might trigger quad-precision I/O paths
+  if build_machine.system() == 'darwin'
+    quadmath_dep = fc.find_library('quadmath', required: true, static: true)
+    extra_deps += [quadmath_dep]
+  endif
+
   # Define OS with gfortran for OS specific code
   # These are identical to pre-defined macros available with ifort
   system = build_machine.system()

--- a/src/meson.build
+++ b/src/meson.build
@@ -561,16 +561,16 @@ if build_machine.system() == 'windows' and (with_petsc or with_netcdf)
   mf6exe = executable(buildname,
                       'mf6.f90',
                       link_with: [mf6core],
-                      dependencies: dependencies,
+                      dependencies: dependencies + extra_deps,
                       install: true)
 else
-  mf6core = static_library('mf6core', 
-                           modflow_sources,  
+  mf6core = static_library('mf6core',
+                           modflow_sources,
                            dependencies: dependencies,
                            link_with: [mf6_external])
-  mf6exe = executable(buildname, 
-                      'mf6.f90', 
-                      link_with: [mf6core],  
-                      dependencies: dependencies, 
+  mf6exe = executable(buildname,
+                      'mf6.f90',
+                      link_with: [mf6core],
+                      dependencies: dependencies + extra_deps,
                       install: true)
 endif


### PR DESCRIPTION
Make the macOS build static(ish) everywhere. Previously it was dynamic in the normal CI, static in the release. A fully static build isn't possible on macOS, we can static link everything but `libSystem` by hiding dylibs, using `-static-libgcc`, and setting up libquadmath as an explicit meson dependency. A bit redundant it would seem, but I found it the only reliably way across macOS/xcode versions.

There are gridgen test errors if the hidden dylibs are not restored before testing. This reveals that the gridgen binary is not static and depends on gcc libraries as noted in https://github.com/MODFLOW-ORG/gridgen/issues/21. After gridgen is fixed in the next executables release, we will no longer need to restore the dylibs for testing