### PR TITLE
fix(netcdf): list each face node connectivity vertex once

### DIFF
--- a/src/Utilities/Export/DisvNCMesh.f90
+++ b/src/Utilities/Export/DisvNCMesh.f90
@@ -497,6 +497,9 @@ contains
         verts(iv) = icvert(m)
       end do
 
+      ! don't close the cell
+      if (verts(iv) == verts(1)) verts(iv) = NF90_FILL_INT
+
       ! write face nodes array to netcdf file
       call nf_verify(nf90_put_var(this%ncid, this%var_ids%mesh_face_nodes, &
                                   verts, start=(/1, n/), &


### PR DESCRIPTION
This update changes the `DISV` based `UGRID NetCDF` output file `face_node_connectivity` array so that cells are not closed- i.e. the first and last vertex of a given face are not the same. 

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
