### PR TITLE
fix(gwe-est): set defaults in fortran to match corresponding dfn defaults

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -17,4 +17,4 @@ netcdf = "NETCDF"
 [[items]]
 section = "fixes"
 subsection = "stress"
-description = "The default values for DENSITY\_WATER, HEAT\_CAPACITY\_WATER, LATENT\_HEAT\_VAPORIZATION specified in the OPTIONS block were not set as indicated in the MF6IO guide.  Defaults for these three variables now set as documented in the MF6IO guide." 
+description = "The default values for DENSITY\\_WATER, HEAT\\_CAPACITY\\_WATER, LATENT\\_HEAT\\_VAPORIZATION specified in the OPTIONS block were not set as indicated in the MF6IO guide.  Defaults for these three variables now set as documented in the MF6IO guide." 

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -13,3 +13,8 @@ solution = "SOLUTION"
 exchanges = "EXCHANGES"
 parallel = "PARALLEL"
 netcdf = "NETCDF"
+
+[[items]]
+section = "fixes"
+subsection = "stress"
+description = "The default values for DENSITY\_WATER, HEAT\_CAPACITY\_WATER, LATENT\_HEAT\_VAPORIZATION specified in the OPTIONS block were not set as indicated in the MF6IO guide.  Defaults for these three variables now set as documented in the MF6IO guide." 

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -665,9 +665,9 @@ contains
     call mem_allocate(this%idcysrc, 'IDCYSRC', this%memoryPath)
     !
     ! -- Initialize
-    this%cpw = DZERO
-    this%rhow = DZERO
-    this%latheatvap = DZERO
+    this%cpw = 4184.0_DP
+    this%rhow = DEP3
+    this%latheatvap = 2453500.0_DP
     this%idcy = IZERO
     this%idcysrc = IZERO
   end subroutine allocate_scalars


### PR DESCRIPTION
Defaults for `density_water`, `heat_capacity_water`, and `latent_heat_vaporization` were not set in the gwe-est.f90 src code.  Defaults are listed in the dfn files and employed by [`flopy`](https://github.com/modflowpy/flopy).  MODFLOW 6 and FloPy defaults for these three variables now match.

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
