### PR TITLE
refactor(prt): switch to ExplicitModel, improve error checking

### DIFF
--- a/autotest/test_sim_config_errors.py
+++ b/autotest/test_sim_config_errors.py
@@ -1,0 +1,151 @@
+"""
+Test to verify simulation configuration error checking.
+
+Tests the following error conditions:
+1. IMS6 solver paired with PRT model (should require EMS6)
+2. EMS6 solver paired with GWF model (should require IMS6)
+"""
+
+import flopy
+import pytest
+from framework import TestFramework
+
+simname = "cfgerr"
+cases = [
+    f"{simname}_ims_prt",
+    f"{simname}_ems_gwf",
+]
+
+
+def build_ims_with_prt_sim(test):
+    name = test.name
+    ws = test.workspace
+    mf6 = test.targets["mf6"]
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name,
+        exe_name=mf6,
+        version="mf6",
+        sim_ws=ws,
+    )
+
+    flopy.mf6.ModflowTdis(
+        sim,
+        pname="tdis",
+        time_units="DAYS",
+        nper=1,
+        perioddata=[(1.0, 1, 1.0)],
+    )
+
+    prt_name = "prt1"
+    prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name)
+
+    flopy.mf6.modflow.mfgwfdis.ModflowGwfdis(
+        prt,
+        pname="dis",
+        nlay=1,
+        nrow=10,
+        ncol=10,
+    )
+
+    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=0.1)
+
+    releasepts = [[0, 0, 0, 0, 0.5, 0.5, 0.5]]
+    flopy.mf6.ModflowPrtprp(
+        prt,
+        pname="prp1",
+        filename=f"{prt_name}_1.prp",
+        nreleasepts=len(releasepts),
+        packagedata=releasepts,
+        perioddata={0: [("FIRST",)]},
+    )
+
+    flopy.mf6.ModflowPrtoc(prt, pname="oc")
+    flopy.mf6.ModflowPrtfmi(
+        prt,
+        packagedata=[
+            ("GWFHEAD", "dummy.hds"),
+            ("GWFBUDGET", "dummy.bud"),
+        ],
+    )
+
+    # Add IMS solver (wrong - PRT needs EMS)
+    ims = flopy.mf6.ModflowIms(sim, pname="ims")
+    sim.register_solution_package(ims, [prt.name])
+
+    return sim
+
+
+def build_ems_with_gwf_sim(test):
+    name = test.name
+    ws = test.workspace
+    mf6 = test.targets["mf6"]
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name,
+        exe_name=mf6,
+        version="mf6",
+        sim_ws=ws,
+    )
+
+    flopy.mf6.ModflowTdis(
+        sim,
+        pname="tdis",
+        time_units="DAYS",
+        nper=1,
+        perioddata=[(1.0, 1, 1.0)],
+    )
+
+    gwf_name = "gwf1"
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwf_name)
+
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=1,
+        nrow=10,
+        ncol=10,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=0.0)
+    flopy.mf6.ModflowGwfnpf(gwf, save_flows=True)
+
+    chd_data = {0: [[(0, 0, 0), 1.0], [(0, 9, 9), 0.0]]}
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd_data)
+
+    # Add EMS solver (wrong - GWF needs IMS)
+    ems = flopy.mf6.ModflowEms(sim, pname="ems", filename=f"{gwf_name}.ems")
+    sim.register_solution_package(ems, [gwf.name])
+
+    return sim
+
+
+def build_models(test):
+    if "ims_prt" in test.name:
+        return build_ims_with_prt_sim(test)
+    elif "ems_gwf" in test.name:
+        return build_ems_with_gwf_sim(test)
+
+
+def check_output(test):
+    name = test.name
+    buff = test.buffs[0] if len(test.buffs) > 0 else []
+
+    if "ims_prt" in name:
+        assert any("explicit model" in line.lower() and "ims6" in line.lower()
+                   for line in buff)
+    elif "ems_gwf" in name:
+        assert any("numerical model" in line.lower() and "ems6" in line.lower()
+                   for line in buff)
+
+
+@pytest.mark.parametrize("name", cases)
+def test_sln_config_errors(name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(t),
+        check=lambda t: check_output(t),
+        targets=targets,
+        compare=None,
+        xfail=True,
+    )
+    test.run()

--- a/autotest/test_sim_config_errors.py
+++ b/autotest/test_sim_config_errors.py
@@ -130,11 +130,14 @@ def check_output(test):
     buff = test.buffs[0] if len(test.buffs) > 0 else []
 
     if "ims_prt" in name:
-        assert any("explicit model" in line.lower() and "ims6" in line.lower()
-                   for line in buff)
+        assert any(
+            "explicit model" in line.lower() and "ims6" in line.lower() for line in buff
+        )
     elif "ems_gwf" in name:
-        assert any("numerical model" in line.lower() and "ems6" in line.lower()
-                   for line in buff)
+        assert any(
+            "numerical model" in line.lower() and "ems6" in line.lower()
+            for line in buff
+        )
 
 
 @pytest.mark.parametrize("name", cases)

--- a/make/makefile
+++ b/make/makefile
@@ -41,20 +41,19 @@ SOURCEDIR34=../src/Utilities/Export
 SOURCEDIR35=../src/Utilities/Idm
 SOURCEDIR36=../src/Utilities/Idm/mf6blockfile
 SOURCEDIR37=../src/Utilities/Idm/netcdf
-SOURCEDIR38=../src/Utilities/InterpolationScheme
-SOURCEDIR39=../src/Utilities/Libraries
-SOURCEDIR40=../src/Utilities/Libraries/blas
-SOURCEDIR41=../src/Utilities/Libraries/daglib
-SOURCEDIR42=../src/Utilities/Libraries/rcm
-SOURCEDIR43=../src/Utilities/Libraries/sparsekit
-SOURCEDIR44=../src/Utilities/Libraries/sparskit2
-SOURCEDIR45=../src/Utilities/Matrix
-SOURCEDIR46=../src/Utilities/Memory
-SOURCEDIR47=../src/Utilities/Observation
-SOURCEDIR48=../src/Utilities/OutputControl
-SOURCEDIR49=../src/Utilities/Performance
-SOURCEDIR50=../src/Utilities/TimeSeries
-SOURCEDIR51=../src/Utilities/Vector
+SOURCEDIR38=../src/Utilities/Libraries
+SOURCEDIR39=../src/Utilities/Libraries/blas
+SOURCEDIR40=../src/Utilities/Libraries/daglib
+SOURCEDIR41=../src/Utilities/Libraries/rcm
+SOURCEDIR42=../src/Utilities/Libraries/sparsekit
+SOURCEDIR43=../src/Utilities/Libraries/sparskit2
+SOURCEDIR44=../src/Utilities/Matrix
+SOURCEDIR45=../src/Utilities/Memory
+SOURCEDIR46=../src/Utilities/Observation
+SOURCEDIR47=../src/Utilities/OutputControl
+SOURCEDIR48=../src/Utilities/Performance
+SOURCEDIR49=../src/Utilities/TimeSeries
+SOURCEDIR50=../src/Utilities/Vector
 
 VPATH = \
 ${SOURCEDIR1} \
@@ -106,8 +105,7 @@ ${SOURCEDIR46} \
 ${SOURCEDIR47} \
 ${SOURCEDIR48} \
 ${SOURCEDIR49} \
-${SOURCEDIR50} \
-${SOURCEDIR51} 
+${SOURCEDIR50} 
 
 .SUFFIXES: .f90 .F90 .o
 
@@ -456,6 +454,7 @@ $(OBJDIR)/prt-prp.o \
 $(OBJDIR)/prt-oc.o \
 $(OBJDIR)/prt-mip.o \
 $(OBJDIR)/MethodPool.o \
+$(OBJDIR)/ExplicitModel.o \
 $(OBJDIR)/gwf-api.o \
 $(OBJDIR)/swf.o \
 $(OBJDIR)/tsp.o \
@@ -605,8 +604,7 @@ $(OBJDIR)/gwf-sfr-transient.o \
 $(OBJDIR)/gwf-sfr-steady.o \
 $(OBJDIR)/gwf-sfr-constant.o \
 $(OBJDIR)/RectangularGeometry.o \
-$(OBJDIR)/CircularGeometry.o \
-$(OBJDIR)/ExplicitModel.o
+$(OBJDIR)/CircularGeometry.o
 
 # Define the objects that make up the program
 $(PROGRAM) : $(OBJECTS)

--- a/src/Model/BaseModel.f90
+++ b/src/Model/BaseModel.f90
@@ -1,8 +1,11 @@
 module BaseModelModule
 
-  use KindModule, only: DP, I4B
+  use KindModule, only: DP, I4B, LGP
   use ConstantsModule, only: LENMODELNAME, LINELENGTH, LENMEMPATH
   use ListModule, only: ListType
+  use BaseDisModule, only: DisBaseType
+  use InputOutputModule, only: openfile, getunit
+  use VersionModule, only: write_listfile_header
   implicit none
 
   private
@@ -13,6 +16,7 @@ module BaseModelModule
   type :: BaseModelType
     character(len=LENMEMPATH) :: memoryPath !< the location in the memory manager where the variables are stored
     character(len=LENMODELNAME), pointer :: name => null() !< name of the model
+    character(len=LINELENGTH), pointer :: filename => null() !< input file name
     character(len=3), pointer :: macronym => null() !< 3 letter model acronym (GWF, GWT, ...)
     integer(I4B), pointer :: idsoln => null() !< id of the solution model is in
     integer(I4B), pointer :: id => null() !< model id
@@ -21,6 +25,11 @@ module BaseModelModule
     integer(I4B), pointer :: iprpak => null() !< integer flag to echo input
     integer(I4B), pointer :: iprflow => null() !< flag to print simulated flows
     integer(I4B), pointer :: ipakcb => null() !< save_flows flag
+    integer(I4B), pointer :: nja => null() !< number of connections
+    integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !< ibound
+    real(DP), dimension(:), pointer, contiguous :: flowja => null() !< intercell flows
+    type(ListType), pointer :: bndlist => null() !< array of boundary packages
+    class(DisBaseType), pointer :: dis => null() !< discretization object
   contains
     procedure :: model_df
     procedure :: model_ar
@@ -31,76 +40,67 @@ module BaseModelModule
     procedure :: model_da
     procedure :: allocate_scalars
     procedure :: model_message
+    procedure :: create_lstfile
   end type BaseModelType
 
 contains
 
   !> @brief Define the model
-  !<
   subroutine model_df(this)
     class(BaseModelType) :: this
   end subroutine model_df
 
   !> @brief Allocate and read
-  !<
   subroutine model_ar(this)
     class(BaseModelType) :: this
   end subroutine model_ar
 
   !> @brief Read and prepare
-  !<
   subroutine model_rp(this)
     class(BaseModelType) :: this
   end subroutine model_rp
 
   !> @brief Calculate time step length
-  !<
   subroutine model_dt(this)
     class(BaseModelType) :: this
   end subroutine model_dt
 
   !> @brief Output results
-  !<
   subroutine model_ot(this)
     class(BaseModelType) :: this
   end subroutine model_ot
 
   !> @brief Write line to model iout
-  !<
   subroutine model_message(this, line, fmt)
-    ! -- dummy
+    ! dummy
     class(BaseModelType) :: this
     character(len=*), intent(in) :: line
     character(len=*), intent(in), optional :: fmt
-    ! -- local
+    ! local
     character(len=LINELENGTH) :: cfmt
-    !
-    ! -- process optional variables
+
     if (present(fmt)) then
       cfmt = fmt
     else
       cfmt = '(1x,a)'
     end if
-    !
-    ! -- write line
+
     write (this%iout, trim(cfmt)) trim(line)
   end subroutine model_message
 
   !> @brief Final processing
-  !<
   subroutine model_fp(this)
     class(BaseModelType) :: this
   end subroutine model_fp
 
   !> @brief Allocate scalar variables
-  !<
   subroutine allocate_scalars(this, modelname)
-    ! -- modules
+    ! modules
     use MemoryManagerModule, only: mem_allocate
-    ! -- dummy
+    ! dummy
     class(BaseModelType) :: this
     character(len=*), intent(in) :: modelname
-    !
+
     call mem_allocate(this%name, LENMODELNAME, 'NAME', this%memoryPath)
     call mem_allocate(this%macronym, 3, 'MACRONYM', this%memoryPath)
     call mem_allocate(this%id, 'ID', this%memoryPath)
@@ -110,7 +110,7 @@ contains
     call mem_allocate(this%iprflow, 'IPRFLOW', this%memoryPath)
     call mem_allocate(this%ipakcb, 'IPAKCB', this%memoryPath)
     call mem_allocate(this%idsoln, 'IDSOLN', this%memoryPath)
-    !
+
     this%name = modelname
     this%macronym = ''
     this%idsoln = 0
@@ -123,18 +123,17 @@ contains
   end subroutine allocate_scalars
 
   !> @brief Deallocate
-  !<
   subroutine model_da(this)
-    ! -- modules
+    ! modules
     use MemoryManagerModule, only: mem_deallocate
-    ! -- dummy
+    ! dummy
     class(BaseModelType) :: this
-    !
-    ! -- Strings
+
+    ! deallocate strings
     call mem_deallocate(this%name, 'NAME', this%memoryPath)
     call mem_deallocate(this%macronym, 'MACRONYM', this%memoryPath)
     !
-    ! -- Scalars
+    ! deallocate scalars
     call mem_deallocate(this%id)
     call mem_deallocate(this%iout)
     call mem_deallocate(this%inewton)
@@ -147,10 +146,10 @@ contains
   function CastAsBaseModelClass(obj) result(res)
     class(*), pointer, intent(inout) :: obj
     class(BaseModelType), pointer :: res
-    !
+
     res => null()
     if (.not. associated(obj)) return
-    !
+
     select type (obj)
     class is (BaseModelType)
       res => obj
@@ -158,26 +157,69 @@ contains
   end function CastAsBaseModelClass
 
   subroutine AddBaseModelToList(list, model)
-    ! -- dummy
+    ! dummy
     type(ListType), intent(inout) :: list
     class(BaseModelType), pointer, intent(inout) :: model
-    ! -- local
+    ! local
     class(*), pointer :: obj
-    !
+
     obj => model
     call list%Add(obj)
   end subroutine AddBaseModelToList
 
   function GetBaseModelFromList(list, idx) result(res)
-    ! -- dummy
+    ! dummy
     type(ListType), intent(inout) :: list
     integer(I4B), intent(in) :: idx
     class(BaseModelType), pointer :: res
-    ! -- local
+    ! local
     class(*), pointer :: obj
-    !
+
     obj => list%GetItem(idx)
     res => CastAsBaseModelClass(obj)
   end function GetBaseModelFromList
+
+  subroutine create_lstfile(this, lst_fname, model_fname, defined, headertxt)
+    ! dummy
+    class(BaseModelType) :: this
+    character(len=*), intent(inout) :: lst_fname
+    character(len=*), intent(in) :: model_fname
+    logical(LGP), intent(in) :: defined
+    character(len=*), intent(in) :: headertxt
+    ! local
+    integer(I4B) :: i, istart, istop
+
+    ! set list file name if not provided
+    if (.not. defined) then
+
+      ! initialize
+      lst_fname = ' '
+      istart = 0
+      istop = len_trim(model_fname)
+
+      ! identify '.' character position from back of string
+      do i = istop, 1, -1
+        if (model_fname(i:i) == '.') then
+          istart = i
+          exit
+        end if
+      end do
+
+      ! if not found start from string end
+      if (istart == 0) istart = istop + 1
+
+      ! set list file name
+      lst_fname = model_fname(1:istart)
+      istop = istart + 3
+      lst_fname(istart:istop) = '.lst'
+    end if
+
+    ! create the list file
+    this%iout = getunit()
+    call openfile(this%iout, 0, lst_fname, 'LIST', filstat_opt='REPLACE')
+
+    ! write list file header
+    call write_listfile_header(this%iout, headertxt)
+  end subroutine create_lstfile
 
 end module BaseModelModule

--- a/src/Model/ExplicitModel.f90
+++ b/src/Model/ExplicitModel.f90
@@ -1,12 +1,14 @@
 !> @brief Models that solve themselves
 module ExplicitModelModule
 
-  use KindModule, only: I4B, DP
-  use ConstantsModule, only: LINELENGTH
+  use KindModule, only: I4B, DP, LGP
+  use ConstantsModule, only: LINELENGTH, DZERO
   use ListModule, only: ListType
   use BaseModelModule, only: BaseModelType
   use BaseDisModule, only: DisBaseType
   use MemoryManagerModule, only: mem_allocate, mem_deallocate
+  use InputOutputModule, only: openfile, getunit
+  use VersionModule, only: write_listfile_header
 
   implicit none
   private
@@ -22,7 +24,9 @@ module ExplicitModelModule
   !<
   type, extends(BaseModelType) :: ExplicitModelType
     character(len=LINELENGTH), pointer :: filename => null() !< input file name
+    integer(I4B), pointer :: nja => null() !< number of connections
     integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !< ibound
+    real(DP), dimension(:), pointer, contiguous :: flowja => null() !< intercell flows
     type(ListType), pointer :: bndlist => null() !< array of boundary packages
     class(DisBaseType), pointer :: dis => null() !< discretization object
   contains
@@ -36,6 +40,7 @@ module ExplicitModelModule
     procedure :: allocate_scalars
     procedure :: allocate_arrays
     procedure :: set_idsoln
+    procedure :: create_lstfile
   end type ExplicitModelType
 
 contains
@@ -75,9 +80,11 @@ contains
 
     ! -- deallocate scalars
     deallocate (this%filename)
+    call mem_deallocate(this%nja)
 
     ! -- deallocate arrays
     call mem_deallocate(this%ibound)
+    call mem_deallocate(this%flowja, 'FLOWJA', this%memoryPath)
 
     ! -- nullify pointers
     if (associated(this%ibound)) &
@@ -109,9 +116,17 @@ contains
     class(ExplicitModelType) :: this
     integer(I4B) :: i
 
+    call mem_allocate(this%nja, 'NJA', this%memoryPath)
+    this%nja = this%dis%nja
+
     call mem_allocate(this%ibound, this%dis%nodes, 'IBOUND', this%memoryPath)
     do i = 1, this%dis%nodes
       this%ibound(i) = 1 ! active by default
+    end do
+
+    call mem_allocate(this%flowja, this%nja, 'FLOWJA', this%memoryPath)
+    do i = 1, this%nja
+      this%flowja(i) = DZERO
     end do
   end subroutine allocate_arrays
 
@@ -164,5 +179,50 @@ contains
     integer(I4B), intent(in) :: id
     this%idsoln = id
   end subroutine set_idsoln
+
+  !> @brief Create the list file
+  !<
+  subroutine create_lstfile(this, lst_fname, model_fname, defined, headertxt)
+    ! -- dummy
+    class(ExplicitModelType) :: this
+    character(len=*), intent(inout) :: lst_fname
+    character(len=*), intent(in) :: model_fname
+    logical(LGP), intent(in) :: defined
+    character(len=*), intent(in) :: headertxt
+    ! -- local
+    integer(I4B) :: i, istart, istop
+    !
+    ! -- set list file name if not provided
+    if (.not. defined) then
+      !
+      ! -- initialize
+      lst_fname = ' '
+      istart = 0
+      istop = len_trim(model_fname)
+      !
+      ! -- identify '.' character position from back of string
+      do i = istop, 1, -1
+        if (model_fname(i:i) == '.') then
+          istart = i
+          exit
+        end if
+      end do
+      !
+      ! -- if not found start from string end
+      if (istart == 0) istart = istop + 1
+      !
+      ! -- set list file name
+      lst_fname = model_fname(1:istart)
+      istop = istart + 3
+      lst_fname(istart:istop) = '.lst'
+    end if
+    !
+    ! -- create the list file
+    this%iout = getunit()
+    call openfile(this%iout, 0, lst_fname, 'LIST', filstat_opt='REPLACE')
+    !
+    ! -- write list file header
+    call write_listfile_header(this%iout, headertxt)
+  end subroutine create_lstfile
 
 end module ExplicitModelModule

--- a/src/Model/ExplicitModel.f90
+++ b/src/Model/ExplicitModel.f90
@@ -7,8 +7,6 @@ module ExplicitModelModule
   use BaseModelModule, only: BaseModelType
   use BaseDisModule, only: DisBaseType
   use MemoryManagerModule, only: mem_allocate, mem_deallocate
-  use InputOutputModule, only: openfile, getunit
-  use VersionModule, only: write_listfile_header
 
   implicit none
   private
@@ -23,42 +21,32 @@ module ExplicitModelModule
   !! models and calls solution procedures in a prescribed sequence.
   !<
   type, extends(BaseModelType) :: ExplicitModelType
-    character(len=LINELENGTH), pointer :: filename => null() !< input file name
-    integer(I4B), pointer :: nja => null() !< number of connections
-    integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !< ibound
-    real(DP), dimension(:), pointer, contiguous :: flowja => null() !< intercell flows
-    type(ListType), pointer :: bndlist => null() !< array of boundary packages
-    class(DisBaseType), pointer :: dis => null() !< discretization object
   contains
-    ! -- Overridden methods
+    ! Overridden methods
     procedure :: model_ad
     procedure :: model_solve
     procedure :: model_cq
     procedure :: model_bd
     procedure :: model_da
-    ! -- Utility methods
+    ! Utility methods
     procedure :: allocate_scalars
     procedure :: allocate_arrays
     procedure :: set_idsoln
-    procedure :: create_lstfile
   end type ExplicitModelType
 
 contains
 
   !> @ brief Advance the model
-  !<
   subroutine model_ad(this)
     class(ExplicitModelType) :: this
   end subroutine model_ad
 
   !> @ brief Solve the model
-  !<
   subroutine model_solve(this)
     class(ExplicitModelType) :: this
   end subroutine model_solve
 
   !> @ brief Calculate model flows
-  !<
   subroutine model_cq(this, icnvg, isuppress_output)
     class(ExplicitModelType) :: this
     integer(I4B), intent(in) :: icnvg
@@ -66,7 +54,6 @@ contains
   end subroutine model_cq
 
   !> @ brief Calculate model budget
-  !<
   subroutine model_bd(this, icnvg, isuppress_output)
     class(ExplicitModelType) :: this
     integer(I4B), intent(in) :: icnvg
@@ -74,32 +61,30 @@ contains
   end subroutine model_bd
 
   !> @ brief Deallocate the model
-  !<
   subroutine model_da(this)
     class(ExplicitModelType) :: this
 
-    ! -- deallocate scalars
+    ! deallocate scalars
     deallocate (this%filename)
     call mem_deallocate(this%nja)
 
-    ! -- deallocate arrays
+    ! deallocate arrays
     call mem_deallocate(this%ibound)
     call mem_deallocate(this%flowja, 'FLOWJA', this%memoryPath)
 
-    ! -- nullify pointers
+    ! nullify pointers
     if (associated(this%ibound)) &
       call mem_deallocate(this%ibound, 'IBOUND', this%memoryPath)
 
-    ! -- member derived types
+    ! deallocate derived types
     call this%bndlist%Clear()
     deallocate (this%bndlist)
 
-    ! -- deallocate base type
+    ! deallocate base type
     call this%BaseModelType%model_da()
   end subroutine model_da
 
   !> @ brief Allocate scalar variables
-  !<
   subroutine allocate_scalars(this, modelname)
     class(ExplicitModelType) :: this
     character(len=*), intent(in) :: modelname
@@ -111,7 +96,6 @@ contains
   end subroutine allocate_scalars
 
   !> @brief Allocate array variables
-  !<
   subroutine allocate_arrays(this)
     class(ExplicitModelType) :: this
     integer(I4B) :: i
@@ -131,7 +115,6 @@ contains
   end subroutine allocate_arrays
 
   !> @ brief Cast a generic object into an explicit model
-  !<
   function CastAsExplicitModelClass(obj) result(res)
     class(*), pointer, intent(inout) :: obj
     class(ExplicitModelType), pointer :: res
@@ -146,12 +129,11 @@ contains
   end function CastAsExplicitModelClass
 
   !> @ brief Add explicit model to a generic list
-  !<
   subroutine AddExplicitModelToList(list, model)
-    ! -- dummy
+    ! dummy
     type(ListType), intent(inout) :: list
     class(ExplicitModelType), pointer, intent(inout) :: model
-    ! -- local
+    ! local
     class(*), pointer :: obj
 
     obj => model
@@ -159,13 +141,12 @@ contains
   end subroutine AddExplicitModelToList
 
   !> @ brief Get generic object from list and return as explicit model
-  !<
   function GetExplicitModelFromList(list, idx) result(res)
-    ! -- dummy
+    ! dummy
     type(ListType), intent(inout) :: list
     integer(I4B), intent(in) :: idx
     class(ExplicitModelType), pointer :: res
-    ! -- local
+    ! local
     class(*), pointer :: obj
 
     obj => list%GetItem(idx)
@@ -173,56 +154,10 @@ contains
   end function GetExplicitModelFromList
 
   !> @brief Set the solution ID
-  !<
   subroutine set_idsoln(this, id)
     class(ExplicitModelType) :: this
     integer(I4B), intent(in) :: id
     this%idsoln = id
   end subroutine set_idsoln
-
-  !> @brief Create the list file
-  !<
-  subroutine create_lstfile(this, lst_fname, model_fname, defined, headertxt)
-    ! -- dummy
-    class(ExplicitModelType) :: this
-    character(len=*), intent(inout) :: lst_fname
-    character(len=*), intent(in) :: model_fname
-    logical(LGP), intent(in) :: defined
-    character(len=*), intent(in) :: headertxt
-    ! -- local
-    integer(I4B) :: i, istart, istop
-    !
-    ! -- set list file name if not provided
-    if (.not. defined) then
-      !
-      ! -- initialize
-      lst_fname = ' '
-      istart = 0
-      istop = len_trim(model_fname)
-      !
-      ! -- identify '.' character position from back of string
-      do i = istop, 1, -1
-        if (model_fname(i:i) == '.') then
-          istart = i
-          exit
-        end if
-      end do
-      !
-      ! -- if not found start from string end
-      if (istart == 0) istart = istop + 1
-      !
-      ! -- set list file name
-      lst_fname = model_fname(1:istart)
-      istop = istart + 3
-      lst_fname(istart:istop) = '.lst'
-    end if
-    !
-    ! -- create the list file
-    this%iout = getunit()
-    call openfile(this%iout, 0, lst_fname, 'LIST', filstat_opt='REPLACE')
-    !
-    ! -- write list file header
-    call write_listfile_header(this%iout, headertxt)
-  end subroutine create_lstfile
 
 end module ExplicitModelModule

--- a/src/Model/NumericalModel.f90
+++ b/src/Model/NumericalModel.f90
@@ -3,11 +3,9 @@ module NumericalModelModule
   use KindModule, only: DP, I4B
   use ConstantsModule, only: LINELENGTH, LENBUDTXT, LENPAKLOC
   use BaseModelModule, only: BaseModelType
-  use BaseDisModule, only: DisBaseType
   use SparseModule, only: sparsematrix
   use TimeArraySeriesManagerModule, only: TimeArraySeriesManagerType
   use ListModule, only: ListType
-  use VersionModule, only: write_listfile_header
   use MatrixBaseModule
   use VectorBaseModule
 
@@ -17,34 +15,24 @@ module NumericalModelModule
             GetNumericalModelFromList
 
   type, extends(BaseModelType) :: NumericalModelType
-    character(len=LINELENGTH), pointer :: filename => null() !input file name
-    integer(I4B), pointer :: neq => null() !number of equations
-    integer(I4B), pointer :: nja => null() !number of connections
-    integer(I4B), pointer :: moffset => null() !offset of this model in the solution
-    integer(I4B), pointer :: icnvg => null() !convergence flag
-    integer(I4B), dimension(:), pointer, contiguous :: ia => null() !csr row pointer
-    integer(I4B), dimension(:), pointer, contiguous :: ja => null() !csr columns
-    real(DP), dimension(:), pointer, contiguous :: x => null() !dependent variable (head, conc, etc)
-    real(DP), dimension(:), pointer, contiguous :: rhs => null() !right-hand side vector
-    real(DP), dimension(:), pointer, contiguous :: cond => null() !conductance matrix
-    integer(I4B), dimension(:), pointer, contiguous :: idxglo => null() !pointer to position in solution matrix
-    real(DP), dimension(:), pointer, contiguous :: xold => null() !dependent variable for previous timestep
-    real(DP), dimension(:), pointer, contiguous :: flowja => null() !intercell flows
-    integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !ibound array
-    !
-    ! -- Derived types
-    type(ListType), pointer :: bndlist => null() !array of boundary packages for this model
-    class(DisBaseType), pointer :: dis => null() !discretization object
+    integer(I4B), pointer :: neq => null() !< number of equations
+    integer(I4B), pointer :: moffset => null() !< offset of this model in the solution
+    integer(I4B), pointer :: icnvg => null() !< convergence flag
+    integer(I4B), dimension(:), pointer, contiguous :: ia => null() !< csr row pointer
+    integer(I4B), dimension(:), pointer, contiguous :: ja => null() !< csr columns
+    real(DP), dimension(:), pointer, contiguous :: x => null() !< dependent variable (head, conc, etc)
+    real(DP), dimension(:), pointer, contiguous :: rhs => null() !< right-hand side vector
+    real(DP), dimension(:), pointer, contiguous :: cond => null() !< conductance matrix
+    integer(I4B), dimension(:), pointer, contiguous :: idxglo => null() !< pointer to position in solution matrix
+    real(DP), dimension(:), pointer, contiguous :: xold => null() !< dependent variable for previous timestep
 
   contains
-    !
-    ! -- Required for all models (override procedures defined in BaseModelType)
+    ! Overridden methods
     procedure :: model_df
     procedure :: model_ar
     procedure :: model_fp
     procedure :: model_da
-    !
-    ! -- Methods specific to a numerical model
+    ! Specific methods
     procedure :: model_ac
     procedure :: model_mc
     procedure :: model_rp
@@ -64,8 +52,7 @@ module NumericalModelModule
     procedure :: model_bdsave
     procedure :: model_ot
     procedure :: model_bdentry
-    !
-    ! -- Utility methods
+    ! Utility methods
     procedure :: allocate_scalars
     procedure :: allocate_arrays
     procedure :: set_moffset
@@ -78,13 +65,10 @@ module NumericalModelModule
     procedure :: get_mnodeu
     procedure :: get_iasym
     procedure :: get_idv_scale
-    procedure :: create_lstfile
   end type NumericalModelType
 
 contains
-  !
-  ! -- Type-bound procedures for a numerical model
-  !
+
   subroutine model_df(this)
     class(NumericalModelType) :: this
   end subroutine model_df
@@ -221,34 +205,34 @@ contains
   end subroutine model_fp
 
   subroutine model_da(this)
-    ! -- modules
+    ! modules
     use MemoryManagerModule, only: mem_deallocate
     class(NumericalModelType) :: this
 
-    ! -- Scalars
+    ! deallocate scalars
     call mem_deallocate(this%neq)
     call mem_deallocate(this%nja)
     call mem_deallocate(this%icnvg)
     call mem_deallocate(this%moffset)
     deallocate (this%filename)
-    !
-    ! -- Arrays
+
+    ! deallocate arrays
     call mem_deallocate(this%xold)
     call mem_deallocate(this%flowja, 'FLOWJA', this%memoryPath)
     call mem_deallocate(this%idxglo)
-    !
-    ! -- derived types
+
+    ! deallocate derived types
     call this%bndlist%Clear()
     deallocate (this%bndlist)
-    !
-    ! -- nullify pointers
+
+    ! nullify pointers
     call mem_deallocate(this%x, 'X', this%memoryPath)
     call mem_deallocate(this%rhs, 'RHS', this%memoryPath)
     call mem_deallocate(this%ibound, 'IBOUND', this%memoryPath)
-    !
-    ! -- BaseModelType
+
+    ! base deallocation
     call this%BaseModelType%model_da()
-    !
+
   end subroutine model_da
 
   subroutine set_moffset(this, moffset)
@@ -275,18 +259,18 @@ contains
     use MemoryManagerModule, only: mem_allocate
     class(NumericalModelType) :: this
     character(len=*), intent(in) :: modelname
-    !
-    ! -- allocate basetype members
+
+    ! allocate base members
     call this%BaseModelType%allocate_scalars(modelname)
-    !
-    ! -- allocate members from this type
+
+    ! allocate members from this type
     call mem_allocate(this%neq, 'NEQ', this%memoryPath)
     call mem_allocate(this%nja, 'NJA', this%memoryPath)
     call mem_allocate(this%icnvg, 'ICNVG', this%memoryPath)
     call mem_allocate(this%moffset, 'MOFFSET', this%memoryPath)
     allocate (this%filename)
     allocate (this%bndlist)
-    !
+
     this%filename = ''
     this%neq = 0
     this%nja = 0
@@ -299,12 +283,11 @@ contains
     use MemoryManagerModule, only: mem_allocate
     class(NumericalModelType) :: this
     integer(I4B) :: i
-    !
+
     call mem_allocate(this%xold, this%neq, 'XOLD', this%memoryPath)
     call mem_allocate(this%flowja, this%nja, 'FLOWJA', this%memoryPath)
     call mem_allocate(this%idxglo, this%nja, 'IDXGLO', this%memoryPath)
-    !
-    ! -- initialize
+
     do i = 1, size(this%flowja)
       this%flowja(i) = DZERO
     end do
@@ -312,15 +295,15 @@ contains
 
   subroutine set_xptr(this, xsln, sln_offset, varNameTgt, memPathTgt)
     use MemoryManagerModule, only: mem_checkin
-    ! -- dummy
+    ! dummy
     class(NumericalModelType) :: this
     real(DP), dimension(:), pointer, contiguous, intent(in) :: xsln
     integer(I4B) :: sln_offset
     character(len=*), intent(in) :: varNameTgt
     character(len=*), intent(in) :: memPathTgt
-    ! -- local
+    ! local
     integer(I4B) :: offset
-    ! -- code
+
     offset = this%moffset - sln_offset
     this%x => xsln(offset + 1:offset + this%neq)
     call mem_checkin(this%x, 'X', this%memoryPath, varNameTgt, memPathTgt)
@@ -328,15 +311,15 @@ contains
 
   subroutine set_rhsptr(this, rhssln, sln_offset, varNameTgt, memPathTgt)
     use MemoryManagerModule, only: mem_checkin
-    ! -- dummy
+    ! dummy
     class(NumericalModelType) :: this
     real(DP), dimension(:), pointer, contiguous, intent(in) :: rhssln
     integer(I4B) :: sln_offset
     character(len=*), intent(in) :: varNameTgt
     character(len=*), intent(in) :: memPathTgt
-    ! -- local
+    ! local
     integer(I4B) :: offset
-    ! -- code
+
     offset = this%moffset - sln_offset
     this%rhs => rhssln(offset + 1:offset + this%neq)
     call mem_checkin(this%rhs, 'RHS', this%memoryPath, varNameTgt, memPathTgt)
@@ -344,15 +327,15 @@ contains
 
   subroutine set_iboundptr(this, iboundsln, sln_offset, varNameTgt, memPathTgt)
     use MemoryManagerModule, only: mem_checkin
-    ! -- dummy
+    ! dummy
     class(NumericalModelType) :: this
     integer(I4B), dimension(:), pointer, contiguous, intent(in) :: iboundsln
     integer(I4B) :: sln_offset
     character(len=*), intent(in) :: varNameTgt
     character(len=*), intent(in) :: memPathTgt
-    ! -- local
+    ! local
     integer(I4B) :: offset
-    ! -- code
+
     offset = this%moffset - sln_offset
     this%ibound => iboundsln(offset + 1:offset + this%neq)
     call mem_checkin(this%ibound, 'IBOUND', this%memoryPath, varNameTgt, &
@@ -361,10 +344,11 @@ contains
 
   subroutine get_mcellid(this, node, mcellid)
     use BndModule, only: BndType, GetBndFromList
+    ! dummy
     class(NumericalModelType) :: this
     integer(I4B), intent(in) :: node
     character(len=*), intent(inout) :: mcellid
-    ! -- local
+    ! local
     character(len=20) :: cellid
     integer(I4B) :: ip, ipaknode, istart, istop
     class(BndType), pointer :: packobj
@@ -399,7 +383,7 @@ contains
     class(NumericalModelType) :: this
     integer(I4B), intent(in) :: node
     integer(I4B), intent(inout) :: nodeu
-    ! -- local
+
     if (node <= this%dis%nodes) then
       nodeu = this%dis%get_nodeuser(node)
     else
@@ -423,10 +407,10 @@ contains
     implicit none
     class(*), pointer, intent(inout) :: obj
     class(NumericalModelType), pointer :: res
-    !
+
     res => null()
     if (.not. associated(obj)) return
-    !
+
     select type (obj)
     class is (NumericalModelType)
       res => obj
@@ -435,73 +419,27 @@ contains
 
   subroutine AddNumericalModelToList(list, model)
     implicit none
-    ! -- dummy
+    ! dummy
     type(ListType), intent(inout) :: list
     class(NumericalModelType), pointer, intent(inout) :: model
-    ! -- local
+    ! local
     class(*), pointer :: obj
-    !
+
     obj => model
     call list%Add(obj)
   end subroutine AddNumericalModelToList
 
   function GetNumericalModelFromList(list, idx) result(res)
     implicit none
-    ! -- dummy
+    ! dummy
     type(ListType), intent(inout) :: list
     integer(I4B), intent(in) :: idx
     class(NumericalModelType), pointer :: res
-    ! -- local
+    ! local
     class(*), pointer :: obj
-    !
+
     obj => list%GetItem(idx)
     res => CastAsNumericalModelClass(obj)
   end function GetNumericalModelFromList
-
-  subroutine create_lstfile(this, lst_fname, model_fname, defined, headertxt)
-    ! -- modules
-    use KindModule, only: LGP
-    use InputOutputModule, only: openfile, getunit
-    ! -- dummy
-    class(NumericalModelType) :: this
-    character(len=*), intent(inout) :: lst_fname
-    character(len=*), intent(in) :: model_fname
-    logical(LGP), intent(in) :: defined
-    character(len=*), intent(in) :: headertxt
-    ! -- local
-    integer(I4B) :: i, istart, istop
-    !
-    ! -- set list file name if not provided
-    if (.not. defined) then
-      !
-      ! -- initialize
-      lst_fname = ' '
-      istart = 0
-      istop = len_trim(model_fname)
-      !
-      ! -- identify '.' character position from back of string
-      do i = istop, 1, -1
-        if (model_fname(i:i) == '.') then
-          istart = i
-          exit
-        end if
-      end do
-      !
-      ! -- if not found start from string end
-      if (istart == 0) istart = istop + 1
-      !
-      ! -- set list file name
-      lst_fname = model_fname(1:istart)
-      istop = istart + 3
-      lst_fname(istart:istop) = '.lst'
-    end if
-    !
-    ! -- create the list file
-    this%iout = getunit()
-    call openfile(this%iout, 0, lst_fname, 'LIST', filstat_opt='REPLACE')
-    !
-    ! -- write list file header
-    call write_listfile_header(this%iout, headertxt)
-  end subroutine create_lstfile
 
 end module NumericalModelModule

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -6,7 +6,7 @@ module PrtModule
                              LENPAKLOC, LENPACKAGETYPE, LENBUDTXT, MNORMAL, &
                              LINELENGTH, LENAUXNAME
   use VersionModule, only: write_listfile_header
-  use NumericalModelModule, only: NumericalModelType
+  use ExplicitModelModule, only: ExplicitModelType
   use BaseModelModule, only: BaseModelType
   use BndModule, only: BndType, AddBndToList, GetBndFromList
   use DisModule, only: DisType, dis_cr
@@ -42,7 +42,7 @@ module PrtModule
   data budtxt/'         STORAGE', '     TERMINATION'/
 
   !> @brief Particle tracking (PRT) model
-  type, extends(NumericalModelType) :: PrtModelType
+  type, extends(ExplicitModelType) :: PrtModelType
     type(PrtFmiType), pointer :: fmi => null() ! flow model interface
     type(PrtMipType), pointer :: mip => null() ! model input package
     type(PrtOcType), pointer :: oc => null() ! output control package
@@ -880,7 +880,7 @@ contains
     deallocate (this%events)
     deallocate (this%tracks)
 
-    call this%NumericalModelType%model_da()
+    call this%ExplicitModelType%model_da()
   end subroutine prt_da
 
   !> @brief Allocate memory for scalars
@@ -890,7 +890,7 @@ contains
     character(len=*), intent(in) :: modelname
 
     ! allocate members from parent class
-    call this%NumericalModelType%allocate_scalars(modelname)
+    call this%ExplicitModelType%allocate_scalars(modelname)
 
     ! allocate members that are part of model class
     call mem_allocate(this%infmi, 'INFMI', this%memoryPath)
@@ -918,11 +918,10 @@ contains
     class(PrtModelType) :: this
     integer(I4B) :: n
 
-    ! Allocate arrays in parent type
-    this%nja = this%dis%nja
-    call this%NumericalModelType%allocate_arrays()
+    ! Allocate arrays in parent type (ibound, flowja, nja)
+    call this%ExplicitModelType%allocate_arrays()
 
-    ! Allocate and initialize arrays
+    ! Allocate and initialize PRT-specific arrays
     call mem_allocate(this%masssto, this%dis%nodes, &
                       'MASSSTO', this%memoryPath)
     call mem_allocate(this%massstoold, this%dis%nodes, &
@@ -933,19 +932,12 @@ contains
                       'MASSTRM', this%memoryPath)
     call mem_allocate(this%ratetrm, this%dis%nodes, &
                       'RATETRM', this%memoryPath)
-    ! explicit model, so these must be manually allocated
-    call mem_allocate(this%x, this%dis%nodes, 'X', this%memoryPath)
-    call mem_allocate(this%rhs, this%dis%nodes, 'RHS', this%memoryPath)
-    call mem_allocate(this%ibound, this%dis%nodes, 'IBOUND', this%memoryPath)
     do n = 1, this%dis%nodes
       this%masssto(n) = DZERO
       this%massstoold(n) = DZERO
       this%ratesto(n) = DZERO
       this%masstrm(n) = DZERO
       this%ratetrm(n) = DZERO
-      this%x(n) = DZERO
-      this%rhs(n) = DZERO
-      this%ibound(n) = 1
     end do
   end subroutine allocate_arrays
 

--- a/src/SimulationCreate.f90
+++ b/src/SimulationCreate.f90
@@ -210,6 +210,7 @@ contains
     use OlfModule, only: olf_cr
     use PrtModule, only: prt_cr
     use NumericalModelModule, only: NumericalModelType, GetNumericalModelFromList
+    use ExplicitModelModule, only: ExplicitModelType, GetExplicitModelFromList
     use VirtualGwfModelModule, only: add_virtual_gwf_model
     use VirtualGwtModelModule, only: add_virtual_gwt_model
     use VirtualGweModelModule, only: add_virtual_gwe_model
@@ -226,7 +227,9 @@ contains
     type(CharacterStringType), dimension(:), contiguous, &
       pointer :: mnames !< model names
     integer(I4B) :: im
+    class(BaseModelType), pointer :: model_ptr
     class(NumericalModelType), pointer :: num_model
+    class(ExplicitModelType), pointer :: explicit_model
     character(len=LINELENGTH) :: model_type
     character(len=LINELENGTH) :: fname, model_name
     integer(I4B) :: n, nr_models_glob
@@ -267,7 +270,9 @@ contains
       ! increment global model id
       model_names(n) = model_name(1:LENMODELNAME)
       model_loc_idx(n) = -1
+      model_ptr => null()
       num_model => null()
+      explicit_model => null()
       !
       ! -- add a new (local or global) model
       select case (model_type)
@@ -277,7 +282,11 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
             n, ' will be created'
           call gwf_cr(fname, n, model_names(n))
-          num_model => GetNumericalModelFromList(basemodellist, im)
+          model_ptr => GetBaseModelFromList(basemodellist, im)
+          select type (model_ptr)
+          class is (NumericalModelType)
+            num_model => model_ptr
+          end select
           model_loc_idx(n) = im
         end if
         call add_virtual_gwf_model(n, model_names(n), num_model)
@@ -287,7 +296,11 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
             n, ' will be created'
           call gwt_cr(fname, n, model_names(n))
-          num_model => GetNumericalModelFromList(basemodellist, im)
+          model_ptr => GetBaseModelFromList(basemodellist, im)
+          select type (model_ptr)
+          class is (NumericalModelType)
+            num_model => model_ptr
+          end select
           model_loc_idx(n) = im
         end if
         call add_virtual_gwt_model(n, model_names(n), num_model)
@@ -297,7 +310,11 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
             n, ' will be created'
           call gwe_cr(fname, n, model_names(n))
-          num_model => GetNumericalModelFromList(basemodellist, im)
+          model_ptr => GetBaseModelFromList(basemodellist, im)
+          select type (model_ptr)
+          class is (NumericalModelType)
+            num_model => model_ptr
+          end select
           model_loc_idx(n) = im
         end if
         call add_virtual_gwe_model(n, model_names(n), num_model)
@@ -309,7 +326,11 @@ contains
           call chf_cr(fname, n, model_names(n))
           call developmode('CHF is still under development, install the &
             &nightly build or compile from source with IDEVELOPMODE = 1.')
-          num_model => GetNumericalModelFromList(basemodellist, im)
+          model_ptr => GetBaseModelFromList(basemodellist, im)
+          select type (model_ptr)
+          class is (NumericalModelType)
+            num_model => model_ptr
+          end select
           model_loc_idx(n) = im
         end if
       case ('OLF6')
@@ -320,16 +341,28 @@ contains
           call olf_cr(fname, n, model_names(n))
           call developmode('OLF is still under development, install the &
             &nightly build or compile from source with IDEVELOPMODE = 1.')
-          num_model => GetNumericalModelFromList(basemodellist, im)
+          model_ptr => GetBaseModelFromList(basemodellist, im)
+          select type (model_ptr)
+          class is (NumericalModelType)
+            num_model => model_ptr
+          end select
           model_loc_idx(n) = im
         end if
       case ('PRT6')
-        im = im + 1
-        write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
-          n, ' will be created'
-        call prt_cr(fname, n, model_names(n))
-        ! PRT is an explicit model (no virtual model support needed)
-        model_loc_idx(n) = im
+        if (model_ranks(n) == proc_id) then
+          im = im + 1
+          write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
+            n, ' will be created'
+          call prt_cr(fname, n, model_names(n))
+          model_ptr => GetBaseModelFromList(basemodellist, im)
+          select type (model_ptr)
+          class is (ExplicitModelType)
+            explicit_model => model_ptr
+          end select
+          model_loc_idx(n) = im
+        end if
+        ! When virtual PRT is implemented, uncomment:
+        ! call add_virtual_prt_model(n, model_names(n), explicit_model)
       case default
         write (errmsg, '(a,a)') &
           'Unknown simulation model type: ', trim(model_type)
@@ -547,6 +580,8 @@ contains
     use BaseModelModule, only: BaseModelType
     use BaseExchangeModule, only: BaseExchangeType
     use InputOutputModule, only: parseline, upcase
+    use NumericalModelModule, only: NumericalModelType
+    use ExplicitModelModule, only: ExplicitModelType
     ! -- dummy
     ! -- local
     character(len=LENMEMPATH) :: input_mempath
@@ -668,10 +703,25 @@ contains
           !
           mp => GetBaseModelFromList(basemodellist, loc_idx)
           !
+          ! -- Check for solver-model type mismatch
+          select type (mp)
+          class is (ExplicitModelType)
+            write (errmsg, '(4a)') &
+              'Model "', trim(words(j)), &
+              '" is an explicit model and cannot be added to an IMS6 ', &
+              'solution. Explicit models require EMS6.'
+            call store_error(errmsg)
+          end select
+          !
           ! -- Add the model to the solution
           call sp%add_model(mp)
           mp%idsoln = isoln
         end do
+        !
+        ! -- Check for any errors
+        if (count_errors() > 0) then
+          call store_error_filename('mfsim.nam')
+        end if
       case ('EMS6')
         !
         ! -- increment solution counters
@@ -705,10 +755,25 @@ contains
           !
           mp => GetBaseModelFromList(basemodellist, loc_idx)
           !
+          ! -- Check for solver-model type mismatch
+          select type (mp)
+          class is (NumericalModelType)
+            write (errmsg, '(4a)') &
+              'Model "', trim(words(j)), &
+              '" is a numerical model and cannot be added to an EMS6 ', &
+              'solution. Numerical models require IMS6.'
+            call store_error(errmsg)
+          end select
+          !
           ! -- Add the model to the solution
           call sp%add_model(mp)
           mp%idsoln = isoln
         end do
+        !
+        ! -- Check for any errors
+        if (count_errors() > 0) then
+          call store_error_filename('mfsim.nam')
+        end if
       case default
       end select
       !

--- a/src/SimulationCreate.f90
+++ b/src/SimulationCreate.f90
@@ -227,9 +227,8 @@ contains
     type(CharacterStringType), dimension(:), contiguous, &
       pointer :: mnames !< model names
     integer(I4B) :: im
-    class(BaseModelType), pointer :: model_ptr
     class(NumericalModelType), pointer :: num_model
-    class(ExplicitModelType), pointer :: explicit_model
+    class(ExplicitModelType), pointer :: exp_model
     character(len=LINELENGTH) :: model_type
     character(len=LINELENGTH) :: fname, model_name
     integer(I4B) :: n, nr_models_glob
@@ -270,9 +269,8 @@ contains
       ! increment global model id
       model_names(n) = model_name(1:LENMODELNAME)
       model_loc_idx(n) = -1
-      model_ptr => null()
       num_model => null()
-      explicit_model => null()
+      exp_model => null()
       !
       ! -- add a new (local or global) model
       select case (model_type)
@@ -282,11 +280,7 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
             n, ' will be created'
           call gwf_cr(fname, n, model_names(n))
-          model_ptr => GetBaseModelFromList(basemodellist, im)
-          select type (model_ptr)
-          class is (NumericalModelType)
-            num_model => model_ptr
-          end select
+          num_model => GetNumericalModelFromList(basemodellist, im)
           model_loc_idx(n) = im
         end if
         call add_virtual_gwf_model(n, model_names(n), num_model)
@@ -296,11 +290,7 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
             n, ' will be created'
           call gwt_cr(fname, n, model_names(n))
-          model_ptr => GetBaseModelFromList(basemodellist, im)
-          select type (model_ptr)
-          class is (NumericalModelType)
-            num_model => model_ptr
-          end select
+          num_model => GetNumericalModelFromList(basemodellist, im)
           model_loc_idx(n) = im
         end if
         call add_virtual_gwt_model(n, model_names(n), num_model)
@@ -310,11 +300,7 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
             n, ' will be created'
           call gwe_cr(fname, n, model_names(n))
-          model_ptr => GetBaseModelFromList(basemodellist, im)
-          select type (model_ptr)
-          class is (NumericalModelType)
-            num_model => model_ptr
-          end select
+          num_model => GetNumericalModelFromList(basemodellist, im)
           model_loc_idx(n) = im
         end if
         call add_virtual_gwe_model(n, model_names(n), num_model)
@@ -326,11 +312,7 @@ contains
           call chf_cr(fname, n, model_names(n))
           call developmode('CHF is still under development, install the &
             &nightly build or compile from source with IDEVELOPMODE = 1.')
-          model_ptr => GetBaseModelFromList(basemodellist, im)
-          select type (model_ptr)
-          class is (NumericalModelType)
-            num_model => model_ptr
-          end select
+          num_model => GetNumericalModelFromList(basemodellist, im)
           model_loc_idx(n) = im
         end if
       case ('OLF6')
@@ -341,11 +323,7 @@ contains
           call olf_cr(fname, n, model_names(n))
           call developmode('OLF is still under development, install the &
             &nightly build or compile from source with IDEVELOPMODE = 1.')
-          model_ptr => GetBaseModelFromList(basemodellist, im)
-          select type (model_ptr)
-          class is (NumericalModelType)
-            num_model => model_ptr
-          end select
+          num_model => GetNumericalModelFromList(basemodellist, im)
           model_loc_idx(n) = im
         end if
       case ('PRT6')
@@ -354,15 +332,11 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
             n, ' will be created'
           call prt_cr(fname, n, model_names(n))
-          model_ptr => GetBaseModelFromList(basemodellist, im)
-          select type (model_ptr)
-          class is (ExplicitModelType)
-            explicit_model => model_ptr
-          end select
+          exp_model => GetExplicitModelFromList(basemodellist, im)
           model_loc_idx(n) = im
         end if
         ! When virtual PRT is implemented, uncomment:
-        ! call add_virtual_prt_model(n, model_names(n), explicit_model)
+        ! call add_virtual_prt_model(n, model_names(n), exp_model)
       case default
         write (errmsg, '(a,a)') &
           'Unknown simulation model type: ', trim(model_type)

--- a/src/SimulationCreate.f90
+++ b/src/SimulationCreate.f90
@@ -328,7 +328,7 @@ contains
         write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
           n, ' will be created'
         call prt_cr(fname, n, model_names(n))
-        num_model => GetNumericalModelFromList(basemodellist, im)
+        ! PRT is an explicit model (no virtual model support needed)
         model_loc_idx(n) = im
       case default
         write (errmsg, '(a,a)') &

--- a/src/Solution/ExplicitSolution.f90
+++ b/src/Solution/ExplicitSolution.f90
@@ -13,9 +13,9 @@ module ExplicitSolutionModule
                              MNORMAL, LINELENGTH, DZERO
   use MemoryHelperModule, only: create_mem_path
   use BaseModelModule, only: BaseModelType
-  use NumericalModelModule, only: NumericalModelType, &
-                                  AddNumericalModelToList, &
-                                  GetNumericalModelFromList
+  use ExplicitModelModule, only: ExplicitModelType, &
+                                 AddExplicitModelToList, &
+                                 GetExplicitModelFromList
   use BaseExchangeModule, only: BaseExchangeType
   use BaseSolutionModule, only: BaseSolutionType, AddBaseSolutionToList
   use ListModule, only: ListType
@@ -194,7 +194,7 @@ contains
     integer(I4B), intent(inout) :: isgcnvg !< solution group convergence flag
     integer(I4B), intent(in) :: isuppress_output !< flag for suppressing output
     ! -- local variables
-    class(NumericalModelType), pointer :: mp => null()
+    class(ExplicitModelType), pointer :: mp => null()
     character(len=LINELENGTH) :: line
     character(len=LINELENGTH) :: fmt
     integer(I4B) :: im
@@ -210,7 +210,7 @@ contains
       line = 'mode="validation" -- Skipping assembly and solution.'
       fmt = "(/,1x,a,/)"
       do im = 1, this%modellist%Count()
-        mp => GetNumericalModelFromList(this%modellist, im)
+        mp => GetExplicitModelFromList(this%modellist, im)
         call mp%model_message(line, fmt=fmt)
       end do
     case (MNORMAL)
@@ -230,11 +230,11 @@ contains
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
     ! -- local variables
     integer(I4B) :: im
-    class(NumericalModelType), pointer :: mp => null()
+    class(ExplicitModelType), pointer :: mp => null()
 
     ! -- Model advance
     do im = 1, this%modellist%Count()
-      mp => GetNumericalModelFromList(this%modellist, im)
+      mp => GetExplicitModelFromList(this%modellist, im)
       call mp%model_ad()
     end do
 
@@ -249,13 +249,13 @@ contains
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
     integer(I4B), intent(in) :: kiter !< Picard iteration (1 for explicit)
     ! -- local variables
-    class(NumericalModelType), pointer :: mp => null()
+    class(ExplicitModelType), pointer :: mp => null()
     integer(I4B) :: im
     real(DP) :: ttsoln
 
     call code_timer(0, ttsoln, this%ttsoln)
     do im = 1, this%modellist%Count()
-      mp => GetNumericalModelFromList(this%modellist, im)
+      mp => GetExplicitModelFromList(this%modellist, im)
       call mp%model_solve()
     end do
     call code_timer(1, ttsoln, this%ttsoln)
@@ -272,17 +272,17 @@ contains
     integer(I4B), intent(in) :: isuppress_output !< flag for suppressing output
     ! -- local variables
     integer(I4B) :: im
-    class(NumericalModelType), pointer :: mp => null()
+    class(ExplicitModelType), pointer :: mp => null()
 
     ! -- Calculate flow for each model
     do im = 1, this%modellist%Count()
-      mp => GetNumericalModelFromList(this%modellist, im)
+      mp => GetExplicitModelFromList(this%modellist, im)
       call mp%model_cq(this%icnvg, isuppress_output)
     end do
 
     ! -- Budget terms for each model
     do im = 1, this%modellist%Count()
-      mp => GetNumericalModelFromList(this%modellist, im)
+      mp => GetExplicitModelFromList(this%modellist, im)
       call mp%model_bd(this%icnvg, isuppress_output)
     end do
   end subroutine finalizeSolve
@@ -309,13 +309,13 @@ contains
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
     class(BaseModelType), pointer, intent(in) :: mp !< model instance
     ! -- local variables
-    class(NumericalModelType), pointer :: m => null()
+    class(ExplicitModelType), pointer :: m => null()
 
     ! -- add a model
     select type (mp)
-    class is (NumericalModelType)
+    class is (ExplicitModelType)
       m => mp
-      call AddNumericalModelToList(this%modellist, m)
+      call AddExplicitModelToList(this%modellist, m)
     end select
   end subroutine add_model
 


### PR DESCRIPTION
Make PRT an `ExplicitModel` instead of `NumericalModel` and refactor the model types, moving shared things into `BaseModel`
* `create_lstfile` routine
* `nja`
* `flowja`
* `filename`
* `bndlist`
* `dis`

@christianlangevin and I discussed and were not sure if everything belongs in the base type, e.g. do all models share the concept of a single set of face flows, or might that change someday, but this is all easily changed if/when needed.

Making PRT an explicit model is more correct and unlocks error-checking the solution/model match i.e. IMS is used with GWF/GWT/GWE and EMS with PRT, which is a common stumbling block. Add a test for this.
___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Removed checklist items not relevant to this pull request
