### PR TITLE
fix(dfn2f90.py): fix jinja codegen, add ci test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,16 @@ jobs:
       - name: Check CITATION.cff
         run: pixi run check-citations
 
+      - name: Check generated Fortran IDM files are up to date
+        run: |
+          pixi run update-fortran-definitions
+          if ! git diff --exit-code src/Idm/; then
+            echo "::error::Generated Fortran IDM files are out of date!"
+            echo "::error::Run 'pixi run update-fortran-definitions' and commit changes."
+            git diff --stat src/Idm/
+            exit 1
+          fi
+
   build:
     name: Build
     runs-on: ubuntu-22.04

--- a/src/Idm/chf-disv1didm.f90
+++ b/src/Idm/chf-disv1didm.f90
@@ -1,5 +1,5 @@
 ! ** Do Not Modify! MODFLOW 6 system generated file. **
-module ChfDisv1DInputModule
+module ChfDisv1dInputModule
   use ConstantsModule, only: LENVARNAME
   use InputDefinitionModule, only: InputParamDefinitionType, &
                                    InputBlockDefinitionType
@@ -590,4 +590,4 @@ module ChfDisv1DInputModule
     ) &
     ]
 
-end module ChfDisv1DInputModule
+end module ChfDisv1dInputModule

--- a/src/Idm/exg-gwfgweidm.f90
+++ b/src/Idm/exg-gwfgweidm.f90
@@ -74,7 +74,7 @@ module ExgGwfgweInputModule
     '', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_varaible
+    .false. & ! block_variable
     ) &
     ]
 

--- a/src/Idm/exg-gwfgwtidm.f90
+++ b/src/Idm/exg-gwfgwtidm.f90
@@ -74,7 +74,7 @@ module ExgGwfgwtInputModule
     '', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_varaible
+    .false. & ! block_variable
     ) &
     ]
 

--- a/src/Idm/exg-gwfprtidm.f90
+++ b/src/Idm/exg-gwfprtidm.f90
@@ -74,7 +74,7 @@ module ExgGwfprtInputModule
     '', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_varaible
+    .false. & ! block_variable
     ) &
     ]
 

--- a/src/Idm/olf-dis2didm.f90
+++ b/src/Idm/olf-dis2didm.f90
@@ -1,5 +1,5 @@
 ! ** Do Not Modify! MODFLOW 6 system generated file. **
-module OlfDis2DInputModule
+module OlfDis2dInputModule
   use ConstantsModule, only: LENVARNAME
   use InputDefinitionModule, only: InputParamDefinitionType, &
                                    InputBlockDefinitionType
@@ -429,4 +429,4 @@ module OlfDis2DInputModule
     ) &
     ]
 
-end module OlfDis2DInputModule
+end module OlfDis2dInputModule

--- a/src/Idm/olf-disv2didm.f90
+++ b/src/Idm/olf-disv2didm.f90
@@ -1,5 +1,5 @@
 ! ** Do Not Modify! MODFLOW 6 system generated file. **
-module OlfDisv2DInputModule
+module OlfDisv2dInputModule
   use ConstantsModule, only: LENVARNAME
   use InputDefinitionModule, only: InputParamDefinitionType, &
                                    InputBlockDefinitionType
@@ -590,4 +590,4 @@ module OlfDisv2DInputModule
     ) &
     ]
 
-end module OlfDisv2DInputModule
+end module OlfDisv2dInputModule

--- a/src/Idm/selector/IdmChfDfnSelector.f90
+++ b/src/Idm/selector/IdmChfDfnSelector.f90
@@ -6,7 +6,7 @@ module IdmChfDfnSelectorModule
   use InputDefinitionModule, only: InputParamDefinitionType, &
                                    InputBlockDefinitionType
   use ChfNamInputModule
-  use ChfDisv1DInputModule
+  use ChfDisv1dInputModule
   use ChfCxsInputModule
   use ChfDfwInputModule
   use ChfIcInputModule

--- a/src/Idm/selector/IdmOlfDfnSelector.f90
+++ b/src/Idm/selector/IdmOlfDfnSelector.f90
@@ -6,8 +6,8 @@ module IdmOlfDfnSelectorModule
   use InputDefinitionModule, only: InputParamDefinitionType, &
                                    InputBlockDefinitionType
   use OlfNamInputModule
-  use OlfDis2DInputModule
-  use OlfDisv2DInputModule
+  use OlfDis2dInputModule
+  use OlfDisv2dInputModule
   use OlfDfwInputModule
   use OlfIcInputModule
   use OlfOcInputModule

--- a/src/Idm/selector/IdmSwfDfnSelector.f90
+++ b/src/Idm/selector/IdmSwfDfnSelector.f90
@@ -6,9 +6,9 @@ module IdmSwfDfnSelectorModule
   use InputDefinitionModule, only: InputParamDefinitionType, &
                                    InputBlockDefinitionType
   use SwfNamInputModule
-  use SwfDisv1DInputModule
-  use SwfDis2DInputModule
-  use SwfDisv2DInputModule
+  use SwfDisv1dInputModule
+  use SwfDis2dInputModule
+  use SwfDisv2dInputModule
   use SwfCxsInputModule
   use SwfDfwInputModule
   use SwfIcInputModule

--- a/src/Idm/swf-dis2didm.f90
+++ b/src/Idm/swf-dis2didm.f90
@@ -1,5 +1,5 @@
 ! ** Do Not Modify! MODFLOW 6 system generated file. **
-module SwfDis2DInputModule
+module SwfDis2dInputModule
   use ConstantsModule, only: LENVARNAME
   use InputDefinitionModule, only: InputParamDefinitionType, &
                                    InputBlockDefinitionType
@@ -429,4 +429,4 @@ module SwfDis2DInputModule
     ) &
     ]
 
-end module SwfDis2DInputModule
+end module SwfDis2dInputModule

--- a/src/Idm/swf-disv1didm.f90
+++ b/src/Idm/swf-disv1didm.f90
@@ -1,5 +1,5 @@
 ! ** Do Not Modify! MODFLOW 6 system generated file. **
-module SwfDisv1DInputModule
+module SwfDisv1dInputModule
   use ConstantsModule, only: LENVARNAME
   use InputDefinitionModule, only: InputParamDefinitionType, &
                                    InputBlockDefinitionType
@@ -590,4 +590,4 @@ module SwfDisv1DInputModule
     ) &
     ]
 
-end module SwfDisv1DInputModule
+end module SwfDisv1dInputModule

--- a/src/Idm/swf-disv2didm.f90
+++ b/src/Idm/swf-disv2didm.f90
@@ -1,5 +1,5 @@
 ! ** Do Not Modify! MODFLOW 6 system generated file. **
-module SwfDisv2DInputModule
+module SwfDisv2dInputModule
   use ConstantsModule, only: LENVARNAME
   use InputDefinitionModule, only: InputParamDefinitionType, &
                                    InputBlockDefinitionType
@@ -590,4 +590,4 @@ module SwfDisv2DInputModule
     ) &
     ]
 
-end module SwfDisv2DInputModule
+end module SwfDisv2dInputModule

--- a/utils/idmloader/devtools-dfn-plan.md
+++ b/utils/idmloader/devtools-dfn-plan.md
@@ -1,0 +1,198 @@
+# Plan: update modflow-devtools `dfn` branch for IDM code generation
+
+When devtools v2 ships, `dfn2f90.py` should be updated to use the new `dfn`
+package instead of `_load_v1_flat`. This document tracks the two small changes
+needed in devtools to make that possible, plus the corresponding update to
+`dfn2f90.py`.
+
+---
+
+## Context
+
+The `dfn` branch restructures `modflow_devtools.dfn` into a package with a
+proper `FieldV1` dataclass that already preserves every IDM-critical attribute
+(`in_record`, `preserve_case`, `mf6internal`, `layered`, `block_variable`,
+`developmode`). The `MapV1To2` stripping of those attributes is an explicit
+opt-in for the flopy path — it does not affect a caller that uses schema v1.
+
+Two small gaps prevent `dfn2f90.py` from using `FieldV1` directly today.
+
+---
+
+## Changes needed in devtools (`dfn` branch)
+
+### 1. Add `time_series` to `FieldV1`
+
+**File:** `modflow_devtools/dfn/schema/v1.py`
+
+`time_series` is a DFN attribute used to mark IDM timeseries parameters. It is
+currently silently dropped by `FieldV1.from_dict(strict=False)`.
+
+```python
+# before
+@dataclass(kw_only=True)
+class FieldV1(Field):
+    valid: tuple[str, ...] | None = None
+    reader: Reader = "urword"
+    tagged: bool = False
+    in_record: bool = False
+    layered: bool | None = None
+    preserve_case: bool = False
+    numeric_index: bool = False
+    deprecated: bool = False
+    removed: bool = False
+    mf6internal: str | None = None
+    block_variable: bool = False
+    just_data: bool = False
+
+# after — add one line
+    time_series: bool = False
+```
+
+### 2. Capture `# mf6 subpackage` comments in `parse_dfn`
+
+**File:** `modflow_devtools/dfn/parse.py`
+
+Six DFN files (`gwf-dis`, `gwf-disv`, `gwt-dis`, `gwt-disv`, `gwe-dis`,
+`gwe-disv`) declare their subpackage using `# mf6 subpackage <abbr>` rather
+than the flopy-style `# flopy subpackage <key> <abbr> <param> <val>`. The
+current parser only captures `# flopy ...` comments so these are lost.
+
+```python
+# in parse_dfn(), in the comment-line handling block:
+
+# before
+if line.startswith("#"):
+    _, sep, tail = line.partition("flopy")
+    if sep == "flopy":
+        if (
+            "multi-package" in tail
+            or "solution_package" in tail
+            or "subpackage" in tail
+            or "parent" in tail
+        ):
+            metadata.append(tail.strip())
+    _, sep, tail = line.partition("package-type")
+    if sep == "package-type":
+        metadata.append(f"package-type {tail.strip()}")
+    continue
+
+# after — add mf6 subpackage capture
+if line.startswith("#"):
+    _, sep, tail = line.partition("flopy")
+    if sep == "flopy":
+        if (
+            "multi-package" in tail
+            or "solution_package" in tail
+            or "subpackage" in tail
+            or "parent" in tail
+        ):
+            metadata.append(tail.strip())
+    _, sep, tail = line.partition("package-type")
+    if sep == "package-type":
+        metadata.append(f"package-type {tail.strip()}")
+    _, sep, tail = line.partition("mf6 subpackage")
+    if sep == "mf6 subpackage":
+        metadata.append(f"mf6-subpackage {tail.strip()}")
+    continue
+```
+
+Then add a helper alongside the existing ones in `parse.py`:
+
+```python
+def parse_mf6_subpackages(meta: list[str]) -> list[str]:
+    """
+    Return MF6 subpackage abbreviations declared via '# mf6 subpackage <abbr>'.
+    These are distinct from flopy subpackages ('# flopy subpackage ...').
+    """
+    result = []
+    for m in meta:
+        if m.startswith("mf6-subpackage "):
+            abbr = m.removeprefix("mf6-subpackage ").strip().upper()
+            result.append(abbr)
+    return result
+```
+
+---
+
+## Corresponding update to `dfn2f90.py`
+
+Once the devtools changes above are released, `parse_dfn` in `dfn2f90.py` can
+be replaced with a thin wrapper over `modflow_devtools.dfn.load()`.
+
+The IDM-specific logic that stays in `dfn2f90.py`:
+- `_normalize_type()` / `_BASE_TYPE_MAP` — IDM Fortran type strings are an
+  MF6 code-generation concern, not a devtools concern
+- Shape processing (`NAUX NCPL`, `EXG CELLIDM` overrides, etc.)
+- Longname wrapping for Fortran line length
+- `Param` / `Block` / `DfnFile` dataclasses (or inline template access)
+- Block-required inference logic
+
+Sketch of the new `parse_dfn`:
+
+```python
+from modflow_devtools.dfn import load as load_dfn
+from modflow_devtools.dfn.parse import parse_mf6_subpackages
+from modflow_devtools.dfn.schema.v1 import FieldV1
+
+def parse_dfn(dfnfspec: Path) -> DfnFile:
+    component, subcomponent = dfnfspec.stem.upper().split("-")
+
+    with dfnfspec.open(encoding="utf-8") as f:
+        dfn = load_dfn(f, name=dfnfspec.stem, format="dfn")
+
+    multi_package = dfn.multi
+    mf6_subpkgs = parse_mf6_subpackages(...)  # needs meta exposed — see note below
+    subpackages = [s.ljust(16) for s in mf6_subpkgs] or [" " * 16]
+
+    block_names_ordered = []
+    block_data = {}
+    params = []
+
+    for field in dfn.fields.values(multi=True):  # FieldV1 objects
+        blockname_upper = (field.block or "").upper()
+        if not blockname_upper:
+            continue
+
+        # ... same block tracking logic as today ...
+
+        if field.block_variable:
+            block_data[blockname_upper]["has_block_var"] = True
+            continue
+
+        vn = field.name.upper()
+        mf6vn = (field.mf6internal or field.name).upper()
+        shape = _process_shape(field.shape or "", component, vn, mf6vn)
+        shapelist = shape.strip().split() if shape.strip() else []
+        t = _normalize_type(field.type or "", " ".join(shapelist), len(shapelist),
+                            (field.type or "").startswith("recarray"))
+
+        # longname, required, etc. same as today but reading from FieldV1 attributes
+        required = not field.optional
+        in_record = field.in_record
+        preserve_case = field.preserve_case
+        layered = field.layered or False
+        timeseries = field.time_series  # available after devtools change #1
+        developmode = field.developmode
+
+        params.append(Param(...))
+
+    # ... rest of block building unchanged ...
+```
+
+**Note:** `load()` in the `dfn` branch does not currently expose the raw
+metadata list after building the `Dfn`. To access `mf6-subpackage` metadata
+(change #2 above), either:
+- Call `parse_dfn(f)` directly for metadata, then `load()` for the `Dfn`, or
+- Add a `metadata: list[str]` field to `Dfn` populated by `load()` —
+  the cleaner option, worth suggesting in the devtools PR.
+
+---
+
+## Summary of devtools changes
+
+| File | Change |
+|------|--------|
+| `modflow_devtools/dfn/schema/v1.py` | Add `time_series: bool = False` to `FieldV1` |
+| `modflow_devtools/dfn/parse.py` | Capture `# mf6 subpackage` in metadata; add `parse_mf6_subpackages()` helper |
+| `modflow_devtools/dfn/__init__.py` | (optional) Add `metadata: list[str]` to `Dfn` dataclass, populated by `load()` |

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -103,7 +103,7 @@ class DfnFile:
         return [p for p in self.params if p.aggregate]
 
 
-def parse_dfn(dfnfspec: Path) -> DfnFile:
+def parse_dfn(dfnfspec: Path, common: dict = None) -> DfnFile:
     """Parse a DFN file into a DfnFile object."""
     component, subcomponent = dfnfspec.stem.upper().split("-")
 
@@ -126,7 +126,7 @@ def parse_dfn(dfnfspec: Path) -> DfnFile:
 
     # Parse variable entries using modflow_devtools
     with dfnfspec.open(encoding="utf-8") as f:
-        flat, _ = Dfn._load_v1_flat(f)
+        flat, _ = Dfn._load_v1_flat(f, common=common)
 
     # Track blocks in DFN order
     block_names_ordered = []
@@ -305,12 +305,21 @@ def make_all(
     )
     selector_template = template_env.get_template("IdmDfnSelector.f90.jinja")
 
+    # Load common variables for description substitution
+    common_path = DFN_PATH / "common.dfn"
+    common = None
+    if common_path.is_file():
+        if verbose:
+            print(f"  loading {common_path}")
+        with common_path.open(encoding="utf-8") as f:
+            common, _ = Dfn._load_v1_flat(f)
+
     # Parse all DFN files
     dfn_files = []
     for path in dfn_paths:
         if verbose:
             print(f"  parsing {path}")
-        dfn_files.append(parse_dfn(path))
+        dfn_files.append(parse_dfn(path, common=common))
 
     # Write component IDM files
     for dfn in dfn_files:
@@ -356,9 +365,10 @@ def _expand_dfns(dfns_arg) -> list:
     or a directory to a list of DFN Paths.
     """
     if isinstance(dfns_arg, list):
-        paths = [Path(p) for p in dfns_arg]
+        # Strip whitespace (including \r from Windows line endings) from each path
+        paths = [Path(str(p).strip()) for p in dfns_arg]
     elif isinstance(dfns_arg, (str, Path)):
-        paths = [Path(dfns_arg)]
+        paths = [Path(str(dfns_arg).strip())]
     else:
         raise TypeError(f"Unexpected type: {type(dfns_arg)}")
 
@@ -378,7 +388,7 @@ def _expand_dfns(dfns_arg) -> list:
             # Check if it's a simple filename that needs DFN_PATH prepended
             if len(path.parts) == 1:
                 path = DFN_PATH / path
-            if path.is_file():
+            if path.exists() and path.is_file():
                 result.append(path)
 
     return result

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -374,10 +374,12 @@ def _expand_dfns(dfns_arg) -> list:
                     p = DFN_PATH / fname
                     if p.is_file():
                         result.append(p)
-        elif path.is_file():
+        else:
+            # Check if it's a simple filename that needs DFN_PATH prepended
             if len(path.parts) == 1:
                 path = DFN_PATH / path
-            result.append(path)
+            if path.is_file():
+                result.append(path)
 
     return result
 

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
 from pprint import pprint
+from typing import Optional
 
 from filters import Filters
 from jinja2 import Environment, FileSystemLoader
@@ -103,7 +104,7 @@ class DfnFile:
         return [p for p in self.params if p.aggregate]
 
 
-def parse_dfn(dfnfspec: Path, common: dict = None) -> DfnFile:
+def parse_dfn(dfnfspec: Path, common: Optional[dict] = None) -> DfnFile:
     """Parse a DFN file into a DfnFile object."""
     component, subcomponent = dfnfspec.stem.upper().split("-")
 


### PR DESCRIPTION
#2291 was broken (missing statements in generated files). Fix it, and add a CI test to diff the regenerated fortran modules and fail if anything has changed. This would have caught the issue before. Also check in the regenerated modules as there are a few cosmetic changes. And a few other minor fixes in the codegen script: handle windows line endings in the IDM/DFN integration file `dfns.txt` and make sure description text substitutions happen correctly.