### PR TITLE
refactor(idm): rename idm_ad to idm_ts_advance

### DIFF
--- a/src/Utilities/Idm/IdmLoad.f90
+++ b/src/Utilities/Idm/IdmLoad.f90
@@ -27,7 +27,7 @@ module IdmLoadModule
   public :: load_exchanges
   public :: idm_df
   public :: idm_rp
-  public :: idm_ad
+  public :: idm_timeseries_advance
   public :: idm_da
 
 contains
@@ -58,15 +58,15 @@ contains
 
   !> @brief advance package dynamic data for period steps
   !<
-  subroutine idm_ad()
+  subroutine idm_timeseries_advance()
     use InputLoadTypeModule, only: GetDynamicModelFromList
     class(ModelDynamicPkgsType), pointer :: model_dynamic_input
     integer(I4B) :: n
     do n = 1, model_inputs%Count()
       model_dynamic_input => GetDynamicModelFromList(model_inputs, n)
-      call model_dynamic_input%ad()
+      call model_dynamic_input%timeseries_advance()
     end do
-  end subroutine idm_ad
+  end subroutine idm_timeseries_advance
 
   !> @brief idm deallocate routine
   !<

--- a/src/Utilities/Idm/IdmLoad.f90
+++ b/src/Utilities/Idm/IdmLoad.f90
@@ -27,7 +27,7 @@ module IdmLoadModule
   public :: load_exchanges
   public :: idm_df
   public :: idm_rp
-  public :: idm_timeseries_advance
+  public :: idm_ts_advance
   public :: idm_da
 
 contains
@@ -58,15 +58,15 @@ contains
 
   !> @brief advance package dynamic data for period steps
   !<
-  subroutine idm_timeseries_advance()
+  subroutine idm_ts_advance()
     use InputLoadTypeModule, only: GetDynamicModelFromList
     class(ModelDynamicPkgsType), pointer :: model_dynamic_input
     integer(I4B) :: n
     do n = 1, model_inputs%Count()
       model_dynamic_input => GetDynamicModelFromList(model_inputs, n)
-      call model_dynamic_input%timeseries_advance()
+      call model_dynamic_input%ts_advance()
     end do
-  end subroutine idm_timeseries_advance
+  end subroutine idm_ts_advance
 
   !> @brief idm deallocate routine
   !<

--- a/src/Utilities/Idm/InputLoadType.f90
+++ b/src/Utilities/Idm/InputLoadType.f90
@@ -95,7 +95,7 @@ module InputLoadTypeModule
   contains
     procedure :: init => dynamic_init
     procedure :: df => dynamic_df
-    procedure :: ad => dynamic_ad
+    procedure :: timeseries_advance => dynamic_ad
     procedure :: destroy => dynamic_destroy
   end type DynamicPkgLoadType
 
@@ -144,7 +144,7 @@ module InputLoadTypeModule
     procedure :: get => dynamicpkgs_get
     procedure :: rp => dynamicpkgs_rp
     procedure :: df => dynamicpkgs_df
-    procedure :: ad => dynamicpkgs_ad
+    procedure :: timeseries_advance => dynamicpkgs_ad
     procedure :: size => dynamicpkgs_size
     procedure :: destroy => dynamicpkgs_destroy
   end type ModelDynamicPkgsType
@@ -689,7 +689,7 @@ contains
     integer(I4B) :: n
     do n = 1, this%pkglist%Count()
       dynamic_pkg => this%get(n)
-      call dynamic_pkg%ad()
+      call dynamic_pkg%timeseries_advance()
     end do
   end subroutine dynamicpkgs_ad
 

--- a/src/Utilities/Idm/InputLoadType.f90
+++ b/src/Utilities/Idm/InputLoadType.f90
@@ -95,7 +95,7 @@ module InputLoadTypeModule
   contains
     procedure :: init => dynamic_init
     procedure :: df => dynamic_df
-    procedure :: timeseries_advance => dynamic_ad
+    procedure :: ts_advance => dynamic_ad
     procedure :: destroy => dynamic_destroy
   end type DynamicPkgLoadType
 
@@ -144,7 +144,7 @@ module InputLoadTypeModule
     procedure :: get => dynamicpkgs_get
     procedure :: rp => dynamicpkgs_rp
     procedure :: df => dynamicpkgs_df
-    procedure :: timeseries_advance => dynamicpkgs_ad
+    procedure :: ts_advance => dynamicpkgs_ad
     procedure :: size => dynamicpkgs_size
     procedure :: destroy => dynamicpkgs_destroy
   end type ModelDynamicPkgsType
@@ -689,7 +689,7 @@ contains
     integer(I4B) :: n
     do n = 1, this%pkglist%Count()
       dynamic_pkg => this%get(n)
-      call dynamic_pkg%timeseries_advance()
+      call dynamic_pkg%ts_advance()
     end do
   end subroutine dynamicpkgs_ad
 

--- a/src/Utilities/Idm/mf6blockfile/IdmMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/IdmMf6File.f90
@@ -44,7 +44,7 @@ module IdmMf6FileModule
   contains
     procedure :: init => dynamic_init
     procedure :: df => dynamic_df
-    procedure :: timeseries_advance => dynamic_ad
+    procedure :: ts_advance => dynamic_ad
     procedure :: rp => dynamic_rp
     procedure :: read_ionper => dynamic_read_ionper
     procedure :: create_loader => dynamic_create_loader
@@ -198,7 +198,7 @@ contains
   subroutine dynamic_ad(this)
     class(Mf6FileDynamicPkgLoadType), intent(inout) :: this
     ! invoke loader advance
-    call this%rp_loader%timeseries_advance()
+    call this%rp_loader%ts_advance()
   end subroutine dynamic_ad
 
   !> @brief read and prepare routine for dynamic loader

--- a/src/Utilities/Idm/mf6blockfile/IdmMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/IdmMf6File.f90
@@ -44,7 +44,7 @@ module IdmMf6FileModule
   contains
     procedure :: init => dynamic_init
     procedure :: df => dynamic_df
-    procedure :: ad => dynamic_ad
+    procedure :: timeseries_advance => dynamic_ad
     procedure :: rp => dynamic_rp
     procedure :: read_ionper => dynamic_read_ionper
     procedure :: create_loader => dynamic_create_loader
@@ -198,7 +198,7 @@ contains
   subroutine dynamic_ad(this)
     class(Mf6FileDynamicPkgLoadType), intent(inout) :: this
     ! invoke loader advance
-    call this%rp_loader%ad()
+    call this%rp_loader%timeseries_advance()
   end subroutine dynamic_ad
 
   !> @brief read and prepare routine for dynamic loader

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
@@ -33,7 +33,7 @@ module GridArrayLoadModule
   contains
     procedure :: ainit
     procedure :: df
-    procedure :: timeseries_advance
+    procedure :: ts_advance
     procedure :: rp
     procedure :: destroy
     procedure :: reset
@@ -94,9 +94,9 @@ contains
     class(GridArrayLoadType), intent(inout) :: this
   end subroutine df
 
-  subroutine timeseries_advance(this)
+  subroutine ts_advance(this)
     class(GridArrayLoadType), intent(inout) :: this
-  end subroutine timeseries_advance
+  end subroutine ts_advance
 
   subroutine rp(this, parser)
     use BlockParserModule, only: BlockParserType

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileGridArray.f90
@@ -33,7 +33,7 @@ module GridArrayLoadModule
   contains
     procedure :: ainit
     procedure :: df
-    procedure :: ad
+    procedure :: timeseries_advance
     procedure :: rp
     procedure :: destroy
     procedure :: reset
@@ -94,9 +94,9 @@ contains
     class(GridArrayLoadType), intent(inout) :: this
   end subroutine df
 
-  subroutine ad(this)
+  subroutine timeseries_advance(this)
     class(GridArrayLoadType), intent(inout) :: this
-  end subroutine ad
+  end subroutine timeseries_advance
 
   subroutine rp(this, parser)
     use BlockParserModule, only: BlockParserType

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileKeystring.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileKeystring.f90
@@ -47,7 +47,7 @@ module Mf6FileKeystringModule
   contains
     procedure :: ainit
     procedure :: df
-    procedure :: ad
+    procedure :: timeseries_advance
     procedure :: rp
     procedure :: reset
     procedure :: destroy
@@ -156,10 +156,10 @@ contains
     end do
   end subroutine df
 
-  subroutine ad(this)
+  subroutine timeseries_advance(this)
     class(KeystringLoadType), intent(inout) :: this
     call this%tsmanager%ad()
-  end subroutine ad
+  end subroutine timeseries_advance
 
   subroutine rp(this, parser)
     use IdmLoggerModule, only: idm_log_header, idm_log_close

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileKeystring.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileKeystring.f90
@@ -47,7 +47,7 @@ module Mf6FileKeystringModule
   contains
     procedure :: ainit
     procedure :: df
-    procedure :: timeseries_advance
+    procedure :: ts_advance
     procedure :: rp
     procedure :: reset
     procedure :: destroy
@@ -156,10 +156,10 @@ contains
     end do
   end subroutine df
 
-  subroutine timeseries_advance(this)
+  subroutine ts_advance(this)
     class(KeystringLoadType), intent(inout) :: this
     call this%tsmanager%ad()
-  end subroutine timeseries_advance
+  end subroutine ts_advance
 
   subroutine rp(this, parser)
     use IdmLoggerModule, only: idm_log_header, idm_log_close

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileLayerArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileLayerArray.f90
@@ -40,7 +40,7 @@ module LayerArrayLoadModule
   contains
     procedure :: ainit
     procedure :: df
-    procedure :: timeseries_advance
+    procedure :: ts_advance
     procedure :: rp
     procedure :: destroy
     procedure :: reset
@@ -118,10 +118,10 @@ contains
     call this%tasmanager%tasmanager_df()
   end subroutine df
 
-  subroutine timeseries_advance(this)
+  subroutine ts_advance(this)
     class(LayerArrayLoadType), intent(inout) :: this
     call this%tasmanager%ad()
-  end subroutine timeseries_advance
+  end subroutine ts_advance
 
   subroutine rp(this, parser)
     use MemoryManagerModule, only: mem_setptr

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileLayerArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileLayerArray.f90
@@ -40,7 +40,7 @@ module LayerArrayLoadModule
   contains
     procedure :: ainit
     procedure :: df
-    procedure :: ad
+    procedure :: timeseries_advance
     procedure :: rp
     procedure :: destroy
     procedure :: reset
@@ -118,10 +118,10 @@ contains
     call this%tasmanager%tasmanager_df()
   end subroutine df
 
-  subroutine ad(this)
+  subroutine timeseries_advance(this)
     class(LayerArrayLoadType), intent(inout) :: this
     call this%tasmanager%ad()
-  end subroutine ad
+  end subroutine timeseries_advance
 
   subroutine rp(this, parser)
     use MemoryManagerModule, only: mem_setptr

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileList.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileList.f90
@@ -37,7 +37,7 @@ module ListLoadModule
   contains
     procedure :: ainit
     procedure :: df
-    procedure :: ad
+    procedure :: timeseries_advance
     procedure :: reset
     procedure :: rp
     procedure :: destroy
@@ -125,11 +125,11 @@ contains
     end do
   end subroutine df
 
-  subroutine ad(this)
+  subroutine timeseries_advance(this)
     class(ListLoadType), intent(inout) :: this
     ! advance timeseries
     call this%tsmanager%ad()
-  end subroutine ad
+  end subroutine timeseries_advance
 
   subroutine reset(this)
     use StructArrayModule, only: StructArrayType

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileList.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileList.f90
@@ -37,7 +37,7 @@ module ListLoadModule
   contains
     procedure :: ainit
     procedure :: df
-    procedure :: timeseries_advance
+    procedure :: ts_advance
     procedure :: reset
     procedure :: rp
     procedure :: destroy
@@ -125,11 +125,11 @@ contains
     end do
   end subroutine df
 
-  subroutine timeseries_advance(this)
+  subroutine ts_advance(this)
     class(ListLoadType), intent(inout) :: this
     ! advance timeseries
     call this%tsmanager%ad()
-  end subroutine timeseries_advance
+  end subroutine ts_advance
 
   subroutine reset(this)
     use StructArrayModule, only: StructArrayType

--- a/src/mf6core.f90
+++ b/src/mf6core.f90
@@ -508,7 +508,7 @@ contains
     use BaseSolutionModule, only: BaseSolutionType, GetBaseSolutionFromList
     use SimModule, only: converge_reset
     use SimVariablesModule, only: isim_mode
-    use IdmLoadModule, only: idm_rp, idm_ad
+    use IdmLoadModule, only: idm_rp, idm_timeseries_advance
     use SourceLoadModule, only: export_post_prepare
     ! -- local variables
     class(BaseModelType), pointer :: mp => null()
@@ -605,8 +605,8 @@ contains
     ! -- set time step
     call tdis_set_timestep()
 
-    ! advance IDM
-    call idm_ad()
+    ! timeseries advance
+    call idm_timeseries_advance()
 
     ! stop timer
     call g_prof%stop(g_prof%tmr_prep_tstp)
@@ -627,7 +627,7 @@ contains
     use ListsModule, only: solutiongrouplist
     use SimVariablesModule, only: iFailedStepRetry
     use SolutionGroupModule, only: SolutionGroupType, GetSolutionGroupFromList
-    use IdmLoadModule, only: idm_ad
+    use IdmLoadModule, only: idm_timeseries_advance
     ! -- local variables
     class(SolutionGroupType), pointer :: sgp => null()
     integer(I4B) :: isg
@@ -645,8 +645,8 @@ contains
     retryloop: do
 
       if (iFailedStepRetry > 0) then
-        ! advance IDM
-        call idm_ad()
+        ! timeseries advance
+        call idm_timeseries_advance()
       end if
 
       do isg = 1, solutiongrouplist%Count()

--- a/src/mf6core.f90
+++ b/src/mf6core.f90
@@ -508,7 +508,7 @@ contains
     use BaseSolutionModule, only: BaseSolutionType, GetBaseSolutionFromList
     use SimModule, only: converge_reset
     use SimVariablesModule, only: isim_mode
-    use IdmLoadModule, only: idm_rp, idm_timeseries_advance
+    use IdmLoadModule, only: idm_rp, idm_ts_advance
     use SourceLoadModule, only: export_post_prepare
     ! -- local variables
     class(BaseModelType), pointer :: mp => null()
@@ -606,7 +606,7 @@ contains
     call tdis_set_timestep()
 
     ! timeseries advance
-    call idm_timeseries_advance()
+    call idm_ts_advance()
 
     ! stop timer
     call g_prof%stop(g_prof%tmr_prep_tstp)
@@ -627,7 +627,7 @@ contains
     use ListsModule, only: solutiongrouplist
     use SimVariablesModule, only: iFailedStepRetry
     use SolutionGroupModule, only: SolutionGroupType, GetSolutionGroupFromList
-    use IdmLoadModule, only: idm_timeseries_advance
+    use IdmLoadModule, only: idm_ts_advance
     ! -- local variables
     class(SolutionGroupType), pointer :: sgp => null()
     integer(I4B) :: isg
@@ -646,7 +646,7 @@ contains
 
       if (iFailedStepRetry > 0) then
         ! timeseries advance
-        call idm_timeseries_advance()
+        call idm_ts_advance()
       end if
 
       do isg = 1, solutiongrouplist%Count()


### PR DESCRIPTION
Refactor for clarity and readability- interface name change reflects `IDM` intent to advance timeseries, not the model.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
