### PR TITLE
ci: trigger test workflow on pixi env update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,6 @@ on:
       - "doc/**.xlsx"
       - ".hpc/**"
   workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Branch to test'
-        required: false
-        default: 'develop'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ on:
       - "doc/**.sh"
       - "doc/**.xlsx"
       - ".hpc/**"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch to test'
+        required: false
+        default: 'develop'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -24,6 +24,7 @@ jobs:
           pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
 
       - uses: peter-evans/create-pull-request@v8
+        id: create-pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update/pixi-lock
@@ -32,3 +33,10 @@ jobs:
           body-path: diff.md
           add-paths: pixi.lock
           author: "GitHub <noreply@github.com>"
+      
+      - name: Trigger CI workflow
+        if: steps.create-pr.outputs.pull-request-number
+        run: gh workflow run ci.yml --ref update/pixi-lock
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Automatic pixi environment update PRs are convenient, but don't currently trigger the CI tests, so we have to pull the branch and test the updates locally. Add a trigger so we get CI testing on pixi environment update.