### PR TITLE
chore(dependencies): exclude modflow-devtools 1.9.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - numpy
   - pip
   - pip:
-      - modflow-devtools[test,dfn,models]>=1.7.0,<2
+      - modflow-devtools[test,dfn,models]>=1.7.0,!=1.9.0,<2
       - git+https://github.com/modflowpy/flopy.git
       - git+https://github.com/modflowpy/pymake.git
       - git+https://github.com/Deltares/xmipy.git

--- a/pixi.toml
+++ b/pixi.toml
@@ -45,7 +45,7 @@ xmipy = "*"
 xugrid = "*"
 
 [pypi-dependencies]
-modflow-devtools = { version = ">=1.7.0,<2", extras = ["test", "dfn", "models"] }
+modflow-devtools = { version = ">=1.7.0,!=1.9.0,<2", extras = ["test", "dfn", "models"] }
 
 [feature.rtd.dependencies]
 numpy = "*"


### PR DESCRIPTION
I borked devtools 1.9.0 https://github.com/MODFLOW-ORG/modflow-devtools/pull/299, make sure we don't use it