### PR TITLE
test(par-mvt): new autotest for parallel mvr/mvt

### DIFF
--- a/autotest/test_par_gwt_mvt.py
+++ b/autotest/test_par_gwt_mvt.py
@@ -1,0 +1,44 @@
+"""
+This tests reuses the simulation setup in test_gwt_mvt and runs it
+in parallel on two cpus.  test_gwt_mvt.py runs 1 simulation that is explained
+in the header section of that test.  Basically there are two gwf and two gwt
+models that are adjacent to one another.  To run in parallel, one of the gwf
+models and its gwt counterpart will be run on one core while the other gwf-gwt
+doublet will run on another core.
+"""
+
+import pytest
+from framework import TestFramework
+
+cases = ["par_mvt"]
+
+
+def build_models(idx, test):
+    from test_gwt_mvt import build_models as build
+
+    sim, dummy = build(idx, test)
+    return sim, dummy
+
+
+def check_output(idx, test):
+    from test_gwt_mvt import check_output as check
+
+    check(idx, test)
+
+
+@pytest.mark.parallel
+@pytest.mark.developmode
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        compare=None,
+        parallel=True,
+        xfail=True,
+        ncpus=2,
+    )
+    test.run()


### PR DESCRIPTION
A new parallel autotest that leverages the `test_gwt_mvt.py` autotest for confirming that parallel mover transport is working properly.

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #2715
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.