### PR TITLE
ci(release): relocate windows netcdf dll copy

### DIFF
--- a/.github/actions/test-extended-win/action.yml
+++ b/.github/actions/test-extended-win/action.yml
@@ -24,16 +24,6 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: pixi run get-exes
 
-    - name: Copy Unidata netcdf DLLs alongside mf6.exe
-      shell: bash
-      run: |
-        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/hdf5.dll      $GITHUB_WORKSPACE/modflow6/bin/
-        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/hdf5_hl.dll   $GITHUB_WORKSPACE/modflow6/bin/
-        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/netcdf.dll    $GITHUB_WORKSPACE/modflow6/bin/
-        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/zlib1.dll     $GITHUB_WORKSPACE/modflow6/bin/
-        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/libcurl.dll   $GITHUB_WORKSPACE/modflow6/bin/
-        cp $GITHUB_WORKSPACE/netcdf/netcdf-fortran-4.6.2/build/fortran/netcdff.dll $GITHUB_WORKSPACE/modflow6/bin/
-
     - name: Convert unix2dos
       shell: cmd
       run: |

--- a/.github/actions/test-extended-win/action.yml
+++ b/.github/actions/test-extended-win/action.yml
@@ -7,16 +7,6 @@ runs:
     - name: Build MF6 parallel
       uses: ./modflow6/.github/actions/build-extended-win
 
-    - name: Copy Unidata netcdf DLLs alongside mf6.exe
-      shell: bash
-      run: |
-        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/hdf5.dll      $GITHUB_WORKSPACE/modflow6/bin/
-        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/hdf5_hl.dll   $GITHUB_WORKSPACE/modflow6/bin/
-        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/netcdf.dll    $GITHUB_WORKSPACE/modflow6/bin/
-        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/zlib1.dll     $GITHUB_WORKSPACE/modflow6/bin/
-        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/libcurl.dll   $GITHUB_WORKSPACE/modflow6/bin/
-        cp $GITHUB_WORKSPACE/netcdf/netcdf-fortran-4.6.2/build/fortran/netcdff.dll $GITHUB_WORKSPACE/modflow6/bin/
-
     - name: Update flopy
       working-directory: modflow6
       shell: cmd
@@ -33,6 +23,16 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: pixi run get-exes
+
+    - name: Copy Unidata netcdf DLLs alongside mf6.exe
+      shell: bash
+      run: |
+        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/hdf5.dll      $GITHUB_WORKSPACE/modflow6/bin/
+        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/hdf5_hl.dll   $GITHUB_WORKSPACE/modflow6/bin/
+        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/netcdf.dll    $GITHUB_WORKSPACE/modflow6/bin/
+        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/zlib1.dll     $GITHUB_WORKSPACE/modflow6/bin/
+        cp $GITHUB_WORKSPACE/netcdf/netCDF4.9.3-NC4-64/bin/libcurl.dll   $GITHUB_WORKSPACE/modflow6/bin/
+        cp $GITHUB_WORKSPACE/netcdf/netcdf-fortran-4.6.2/build/fortran/netcdff.dll $GITHUB_WORKSPACE/modflow6/bin/
 
     - name: Convert unix2dos
       shell: cmd

--- a/.github/common/test_modflow6_extended.bat
+++ b/.github/common/test_modflow6_extended.bat
@@ -1,2 +1,10 @@
+:: Copy Unidata netCDF/HDF5 DLLs into mf6 bin dir immediately before testing, which ensures the
+:: MSVC-built Unidata DLLs are the last thing written to bin/ so they are linked at runtime.
+copy /Y "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\hdf5.dll"    "%GITHUB_WORKSPACE%\modflow6\bin\"
+copy /Y "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\hdf5_hl.dll" "%GITHUB_WORKSPACE%\modflow6\bin\"
+copy /Y "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\netcdf.dll"  "%GITHUB_WORKSPACE%\modflow6\bin\"
+copy /Y "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\zlib1.dll"   "%GITHUB_WORKSPACE%\modflow6\bin\"
+copy /Y "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\libcurl.dll" "%GITHUB_WORKSPACE%\modflow6\bin\"
+copy /Y "%GITHUB_WORKSPACE%\netcdf\netcdf-fortran-4.6.2\build\fortran\netcdff.dll" "%GITHUB_WORKSPACE%\modflow6\bin\"
 cd "%GITHUB_WORKSPACE%\modflow6\autotest"
 pixi run autotest -m "%MARKERS%" -k "%FILTERS%" --netcdf --parallel


### PR DESCRIPTION
Fix the nightly build, copy netcdf dlls to bin directory immediately before running tests.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
