### PR TITLE
fix(idm): split long lines in generated fortran source

### DIFF
--- a/.github/common/check_format.py
+++ b/.github/common/check_format.py
@@ -24,11 +24,7 @@ excludedirs = [
 ]
 
 # exclude these files from checks
-excludefiles = [
-    PROJ_ROOT / "src" / "Idm" / "gwf-csubidm.f90",
-    PROJ_ROOT / "src" / "Idm" / "gwf-stoidm.f90",
-    PROJ_ROOT / "src" / "Idm" / "gwf-vscidm.f90",
-]
+excludefiles = []
 
 # commands
 fprettify = "fprettify -c .fprettify.yaml"

--- a/src/Idm/gwf-csubidm.f90
+++ b/src/Idm/gwf-csubidm.f90
@@ -216,7 +216,8 @@ module GwfCsubInputModule
     'PRECON_HEAD', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'keyword to indicate that preconsolidation heads will be specified', & ! longname
+    'keyword to indicate that preconsolidation heads will be '// &
+    'specified', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -254,7 +255,8 @@ module GwfCsubInputModule
     'ICOMPRESS', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'keyword to indicate CR and CC are read instead of SSE and SSV', & ! longname
+    'keyword to indicate CR and CC are read instead of SSE and '// &
+    'SSV', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -273,8 +275,8 @@ module GwfCsubInputModule
     'MATPROP', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'keyword to indicate material properties can change during the&
-     & simulations', & ! longname
+    'keyword to indicate material properties can change during '// &
+    'the simulations', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -312,7 +314,8 @@ module GwfCsubInputModule
     'INTERBED_STATE', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'keyword to indicate that absolute initial states will be specified', & ! longname
+    'keyword to indicate that absolute initial states will be '// &
+    'specified', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -331,8 +334,8 @@ module GwfCsubInputModule
     'PRECON_STRESS', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'keyword to indicate that absolute initial preconsolidation stresses&
-     & (head) will be specified', & ! longname
+    'keyword to indicate that absolute initial preconsolidation '// &
+    'stresses (head) will be specified', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -351,8 +354,8 @@ module GwfCsubInputModule
     'DELAY_HEAD', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'keyword to indicate that absolute initial delay bed heads will be&
-     & specified', & ! longname
+    'keyword to indicate that absolute initial delay bed heads '// &
+    'will be specified', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -371,8 +374,8 @@ module GwfCsubInputModule
     'STRESS_LAG', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'keyword to indicate that specific storage will be calculate using the&
-     & effective stress from the previous time step', & ! longname
+    'keyword to indicate that specific storage will be calculate '// &
+    'using the effective stress from the previous time step', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -579,7 +582,8 @@ module GwfCsubInputModule
     'OPTIONS', & ! block
     'COMPACTION_ELASTIC_FILERECORD', & ! tag name
     'CMPELASTICFR', & ! fortran variable
-    'RECORD COMPACTION_ELASTIC FILEOUT ELASTIC_COMPACTION_FILENAME', & ! type
+    'RECORD COMPACTION_ELASTIC FILEOUT '// &
+    'ELASTIC_COMPACTION_FILENAME', & ! type
     '', & ! shape
     '', & ! longname
     .false., & ! required
@@ -636,7 +640,8 @@ module GwfCsubInputModule
     'OPTIONS', & ! block
     'COMPACTION_INELASTIC_FILERECORD', & ! tag name
     'CMPINELASTICFR', & ! fortran variable
-    'RECORD COMPACTION_INELASTIC FILEOUT INELASTIC_COMPACTION_FILENAME', & ! type
+    'RECORD COMPACTION_INELASTIC FILEOUT '// &
+    'INELASTIC_COMPACTION_FILENAME', & ! type
     '', & ! shape
     '', & ! longname
     .false., & ! required
@@ -693,7 +698,8 @@ module GwfCsubInputModule
     'OPTIONS', & ! block
     'COMPACTION_INTERBED_FILERECORD', & ! tag name
     'CMPINTERBEDFR', & ! fortran variable
-    'RECORD COMPACTION_INTERBED FILEOUT INTERBED_COMPACTION_FILENAME', & ! type
+    'RECORD COMPACTION_INTERBED FILEOUT '// &
+    'INTERBED_COMPACTION_FILENAME', & ! type
     '', & ! shape
     '', & ! longname
     .false., & ! required
@@ -864,7 +870,8 @@ module GwfCsubInputModule
     'OPTIONS', & ! block
     'PACKAGE_CONVERGENCE_FILERECORD', & ! tag name
     'PKGCONVERGEFR', & ! fortran variable
-    'RECORD PACKAGE_CONVERGENCE FILEOUT PACKAGE_CONVERGENCE_FILENAME', & ! type
+    'RECORD PACKAGE_CONVERGENCE FILEOUT '// &
+    'PACKAGE_CONVERGENCE_FILENAME', & ! type
     '', & ! shape
     '', & ! longname
     .false., & ! required
@@ -1509,7 +1516,8 @@ module GwfCsubInputModule
     'PACKAGEDATA', & ! block
     'PACKAGEDATA', & ! tag name
     'PACKAGEDATA', & ! fortran variable
-    'RECARRAY ICSUBNO CELLID CDELAY PCS0 THICK_FRAC RNB SSV_CC SSE_CR THETA KV H0 BOUNDNAME', & ! type
+    'RECARRAY ICSUBNO CELLID CDELAY PCS0 THICK_FRAC RNB SSV_CC '// &
+    'SSE_CR THETA KV H0 BOUNDNAME', & ! type
     'NINTERBEDS', & ! shape
     '', & ! longname
     .false., & ! required

--- a/src/Idm/gwf-evtaidm.f90
+++ b/src/Idm/gwf-evtaidm.f90
@@ -71,7 +71,8 @@ module GwfEvtaInputModule
     'FIXED_CELL', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'if cell is dry do not apply evapotranspiration to underlying cell', & ! longname
+    'if cell is dry do not apply evapotranspiration to underlying '// &
+    'cell', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record

--- a/src/Idm/gwf-evtidm.f90
+++ b/src/Idm/gwf-evtidm.f90
@@ -58,7 +58,8 @@ module GwfEvtInputModule
     'FIXED_CELL', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'if cell is dry do not apply evapotranspiration to underlying cell', & ! longname
+    'if cell is dry do not apply evapotranspiration to underlying '// &
+    'cell', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -581,7 +582,8 @@ module GwfEvtInputModule
     'PERIOD', & ! block
     'STRESS_PERIOD_DATA', & ! tag name
     'SPD', & ! fortran variable
-    'RECARRAY CELLID SURFACE RATE DEPTH PXDP PETM PETM0 AUX BOUNDNAME', & ! type
+    'RECARRAY CELLID SURFACE RATE DEPTH PXDP PETM PETM0 AUX '// &
+    'BOUNDNAME', & ! type
     'MAXBOUND', & ! shape
     '', & ! longname
     .true., & ! required

--- a/src/Idm/gwf-ghbgidm.f90
+++ b/src/Idm/gwf-ghbgidm.f90
@@ -276,7 +276,8 @@ module GwfGhbgInputModule
     'MAXBOUND', & ! fortran variable
     'INTEGER', & ! type
     '', & ! shape
-    'maximum number of general-head boundaries in any stress period', & ! longname
+    'maximum number of general-head boundaries in any stress '// &
+    'period', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record

--- a/src/Idm/gwf-stoidm.f90
+++ b/src/Idm/gwf-stoidm.f90
@@ -86,8 +86,8 @@ module GwfStoInputModule
     'SS_CONFINED_ONLY', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'keyword to indicate specific storage only applied under confined&
-     & conditions', & ! longname
+    'keyword to indicate specific storage only applied under '// &
+    'confined conditions', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record

--- a/src/Idm/gwf-vscidm.f90
+++ b/src/Idm/gwf-vscidm.f90
@@ -86,7 +86,8 @@ module GwfVscInputModule
     'THERMAL_FORM', & ! fortran variable
     'STRING', & ! type
     '', & ! shape
-    'keyword to specify viscosity formulation for the temperature species', & ! longname
+    'keyword to specify viscosity formulation for the temperature '// &
+    'species', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -276,9 +277,10 @@ module GwfVscInputModule
     'DVISCDC', & ! fortran variable
     'DOUBLE', & ! type
     '', & ! shape
-    'slope of the line that defines the linear relationship between&
-     & viscosity and temperature or between viscosity and concentration,&
-     & depending on the type of species entered on each line.', & ! longname
+    'slope of the line that defines the linear relationship '// &
+    'between viscosity and temperature or between viscosity and '// &
+    'concentration, depending on the type of species entered on '// &
+    'each line.', & ! longname
     .true., & ! required
     .false., & ! developmode
     .true., & ! multi-record

--- a/src/Idm/gwt-istidm.f90
+++ b/src/Idm/gwt-istidm.f90
@@ -599,7 +599,8 @@ module GwtIstInputModule
     'ZETAIM', & ! fortran variable
     'DOUBLE1D', & ! type
     'NODES', & ! shape
-    'mass transfer rate coefficient between the mobile and immobile domains', & ! longname
+    'mass transfer rate coefficient between the mobile and '// &
+    'immobile domains', & ! longname
     .true., & ! required
     .false., & ! developmode
     .false., & ! multi-record

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -41,6 +41,28 @@ def _normalize_type(t_raw: str, shape_str: str, ndim: int, aggregate: bool) -> s
     return t_raw.upper()
 
 
+def _wrap_f90_content(raw: str, max_width: int = 60) -> str:
+    """Wrap a string for use in a Fortran string literal.
+
+    Returns the raw text split into newline-separated segments, each at
+    most ``max_width`` characters wide.  The ``| value`` Jinja filter
+    detects the embedded newlines and emits ``// &`` string concatenation
+    so that the generated Fortran source lines stay within the project
+    line-length limit.  Single-segment strings are returned as-is.
+    """
+    llist = textwrap.wrap(raw, max_width)
+    if not llist:
+        return ""
+    if len(llist) == 1:
+        return llist[0]
+    # Preserve the inter-word space at each line break: the space between
+    # the last word of one segment and the first word of the next is dropped
+    # by textwrap.wrap, so add it back as a trailing space on each non-last
+    # segment.  The | value filter will join quoted segments with //.
+    parts = [ln + " " for ln in llist[:-1]] + [llist[-1]]
+    return "\n".join(parts)
+
+
 @dataclass
 class Param:
     """Represents a single input parameter definition from a DFN file."""
@@ -179,19 +201,14 @@ def parse_dfn(dfnfspec: Path, common: Optional[dict] = None) -> DfnFile:
         shape_str = " ".join(shapelist)
 
         t = _normalize_type(t_raw, shape_str, ndim, aggregate_t)
+        if len(t) > 60:
+            t = _wrap_f90_content(t, max_width=60)
 
         # Longname wrapping
         longname = ""
         if vd.get("longname"):
             raw = vd["longname"].replace("'", "")
-            llist = textwrap.wrap(raw, 70)
-            if len(llist) == 1:
-                longname = llist[0]
-            elif len(llist) > 1:
-                longname = f"{llist[0]}&\n"
-                for ln in llist[1:-1]:
-                    longname += f"     & {ln}&\n"
-                longname += f"     & {llist[-1]}"
+            longname = _wrap_f90_content(raw, max_width=60)
 
         required = vd.get("optional", "").lower() != "true"
         developmode = vd.get("developmode", "").lower() == "true"

--- a/utils/idmloader/scripts/filters.py
+++ b/utils/idmloader/scripts/filters.py
@@ -9,9 +9,17 @@ class Filters:
         """
         Format a value to appear in the RHS of an assignment or an argument-passing
         expression. Booleans become .true./.false.; everything else gets wrapped in
-        single quotes.
+        single quotes.  Multi-line strings (produced by _wrap_f90_content in
+        dfn2f90.py) are emitted as adjacent quoted strings joined with ``// &``
+        Fortran concatenation so that each source line fits within the project
+        line-length limit.
         """
         v = try_get_enum_value(v)
         if isinstance(v, bool):
             return ".true." if v else ".false."
+        s = str(v)
+        if "\n" in s:
+            parts = s.split("\n")
+            quoted = [f"'{p}'" for p in parts]
+            return "// &\n    ".join(quoted)
         return f"'{v}'"


### PR DESCRIPTION
Use // string concatenation for long generated strings
  - applied to `type` and `longname` dfn fields

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
