### PR TITLE
fix(gwe error messaging): error msgs in GWE advanced packages need context

### DIFF
--- a/src/Model/GroundWaterEnergy/gwe-lke.f90
+++ b/src/Model/GroundWaterEnergy/gwe-lke.f90
@@ -1329,7 +1329,8 @@ contains
       ! -- check for duplicate or missing lakes
       do n = 1, this%ncv
         if (nboundchk(n) == 0) then
-          write (errmsg, '(a,1x,i0)') 'No data specified for feature', n
+          write (errmsg, '(a,1x,i0,1x,a)') 'No data specified for feature', n, &
+            'in LKE PACKAGEDATA block'
           call store_error(errmsg)
         else if (nboundchk(n) > 1) then
           write (errmsg, '(a,1x,i0,1x,a,1x,i0,1x,a)') &

--- a/src/Model/GroundWaterEnergy/gwe-mwe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-mwe.f90
@@ -1112,7 +1112,8 @@ contains
       ! -- check for duplicate or missing lakes
       do n = 1, this%ncv
         if (nboundchk(n) == 0) then
-          write (errmsg, '(a,1x,i0)') 'No data specified for feature', n
+          write (errmsg, '(a,1x,i0,1x,a)') 'No data specified for feature', n, &
+            'MWE PACKAGEDATA block'
           call store_error(errmsg)
         else if (nboundchk(n) > 1) then
           write (errmsg, '(a,1x,i0,1x,a,1x,i0,1x,a)') &

--- a/src/Model/GroundWaterEnergy/gwe-sfe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-sfe.f90
@@ -1295,7 +1295,8 @@ contains
       ! -- check for duplicate or missing lakes
       do n = 1, this%ncv
         if (nboundchk(n) == 0) then
-          write (errmsg, '(a,1x,i0)') 'No data specified for feature', n
+          write (errmsg, '(a,1x,i0,1x,a)') 'No data specified for feature', n, &
+            'in SFE PACKAGEDATA block'
           call store_error(errmsg)
         else if (nboundchk(n) > 1) then
           write (errmsg, '(a,1x,i0,1x,a,1x,i0,1x,a)') &


### PR DESCRIPTION
The same error message was produced by three different advanced packages in GWE.  Adding a little bit more information to help the user determine where exactly the error message is originating from.

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`