### PR TITLE
Modify Freundlich isotherm to improve convergence

### DIFF
--- a/autotest/test_gwt_ist03.py
+++ b/autotest/test_gwt_ist03.py
@@ -69,14 +69,10 @@ def build_models(idx, test):
         print_option="SUMMARY",
         outer_dvclose=hclose,
         outer_maximum=nouter,
-        under_relaxation="DBD",
-        under_relaxation_theta=0.7,
         inner_maximum=ninner,
         inner_dvclose=hclose,
         rcloserecord=rclose,
         linear_acceleration="BICGSTAB",
-        scaling_method="NONE",
-        reordering_method="NONE",
         relaxation_factor=relax,
         filename=f"{gwfname}.ims",
     )
@@ -132,13 +128,10 @@ def build_models(idx, test):
         print_option="SUMMARY",
         outer_dvclose=hclose,
         outer_maximum=nouter,
-        under_relaxation="NONE",
         inner_maximum=ninner,
         inner_dvclose=hclose,
         rcloserecord=rclose,
         linear_acceleration="BICGSTAB",
-        scaling_method="NONE",
-        reordering_method="NONE",
         relaxation_factor=relax,
         filename=f"{gwtname}.ims",
     )
@@ -339,7 +332,7 @@ def check_output(idx, test):
         csrb_answer = np.where(
             conc > 0, distcoef * sp2 * conc / (1 + distcoef * conc), 0
         )
-    if not np.allclose(csrb[:, 1:], csrb_answer[:, 1:]):
+    if not np.allclose(csrb[:, 1:], csrb_answer[:, 1:], atol=1e-6):
         diff = csrb - csrb_answer
         print("min and max difference")
         print(diff)
@@ -355,7 +348,7 @@ def check_output(idx, test):
         cimsrb_answer = np.where(
             cim > 0, distcoef * sp2 * cim / (1 + distcoef * cim), 0
         )
-    if not np.allclose(cimsrb[:, 1:], cimsrb_answer[:, 1:]):
+    if not np.allclose(cimsrb[:, 1:], cimsrb_answer[:, 1:], atol=1e-6):
         diff = cimsrb - cimsrb_answer
         print("min and max difference")
         print(diff.min(), diff.max())

--- a/src/Model/GroundWaterTransport/gwt-ist.f90
+++ b/src/Model/GroundWaterTransport/gwt-ist.f90
@@ -1571,11 +1571,14 @@ contains
     real(DP), intent(in) :: conc !< solute concentration
     real(DP), intent(in) :: kf !< freundlich constant
     real(DP), intent(in) :: a !< freundlich exponent
+    real(DP), parameter :: K = 10.0_dp !< constant to limit derivative at c=0
+    real(DP) :: eps !< small concentration offset
     ! -- return
     real(DP) :: kd !< effective distribution coefficient
     !
+    eps = (K / (a * kf))**(1.0_dp / (a - 1.0_dp))
     if (conc > DZERO) then
-      kd = kf * conc**(a - DONE)
+      kd = kf * (conc + eps)**(a - DONE) - kf * eps**(a - DONE)
     else
       kd = DZERO
     end if

--- a/src/Model/TransportModel/Isotherm/FreundlichIsotherm.f90
+++ b/src/Model/TransportModel/Isotherm/FreundlichIsotherm.f90
@@ -2,6 +2,7 @@ Module FreundlichIsothermModule
 
   use KindModule, only: DP, I4B
   use IsothermInterfaceModule, only: IsothermType
+  use ConstantsModule, only: DZERO
 
   Implicit None
   Private
@@ -10,6 +11,14 @@ Module FreundlichIsothermModule
   !> @brief Freundlich isotherm implementation of `IsothermType`.
   !>
   !> Sorbed concentration is cs = Kf*c^a.
+  !>
+  !> However, this expression has a singularity at c = 0 when a < 1,
+  !> leading to infinite derivative. To avoid this, the Freundlich isotherm
+  !> is modified as follows.
+  !>
+  !> Modified Sorbed concentration is cs = Kf*(c + eps)^a - Kf*eps^a
+  !> where eps = (K/(a*Kf))^(1/(a-1)) and K is a large constant (default 10).
+  !> This ensures that the derivative at c = 0 is below K.
   !<
   type, extends(IsothermType) :: FreundlichIsothermType
     real(DP), pointer, dimension(:) :: Kf => null() !< Freundlich constant
@@ -47,9 +56,13 @@ contains
     class(FreundlichIsothermType), intent(in) :: this
     real(DP), dimension(:), intent(in) :: c !< concentration array
     integer(I4B), intent(in) :: n !< node index
+    real(DP), parameter :: K = 10.0_dp !< constant to limit derivative at c=0
+    real(DP) :: eps !< small concentration offset
 
-    if (c(n) > 0.0_DP) then
-      val = this%Kf(n) * c(n)**this%a(n)
+    eps = (K / (this%a(n) * this%Kf(n)))**(1.0_dp / (this%a(n) - 1.0_dp))
+
+    if (c(n) > DZERO) then
+      val = this%Kf(n) * (c(n) + eps)**this%a(n) - this%Kf(n) * eps**this%a(n)
     else
       val = 0.0_DP
     end if
@@ -64,9 +77,13 @@ contains
     class(FreundlichIsothermType), intent(in) :: this
     real(DP), dimension(:), intent(in) :: c !< concentration array
     integer(I4B), intent(in) :: n !< node index
+    real(DP), parameter :: K = 10.0_dp !< constant to limit derivative at c=0
+    real(DP) :: eps !< small concentration offset
 
-    if (c(n) > 0.0_DP) then
-      derv = this%a(n) * this%Kf(n) * c(n)**(this%a(n) - 1.0_DP)
+    eps = (K / (this%a(n) * this%Kf(n)))**(1.0_dp / (this%a(n) - 1.0_dp))
+
+    if (c(n) > DZERO) then
+      derv = this%a(n) * this%Kf(n) * ((c(n) + eps)**(this%a(n) - 1.0_DP))
     else
       derv = 0.0_DP
     end if


### PR DESCRIPTION
Split of from #2739 
This PR modifies the Freundlich isotherm to improve stability.
The isotherm becomes problematic for $a < 1$.
For those values the derivative goes to infinity causing convergence issues.

The Freundlich Isotherm is given by:
$\overline{C} = K_f C^a$

with its derivative
$\frac{\partial \overline{C}}{\partial C} = a K_f C^{a-1}$

To improve stability a small epsilon is added to keep the derivative finite.
$\overline{C} =  K_f \left(C + \epsilon\right)^{a} - K_f \epsilon^{a}$

Note that in the equation above the value of $\overline{C}$ at 0 equals the original Freundlich equation

The corresponding derivative now becomes finite:
$\frac{\partial \overline{C}}{\partial C} = a K_f \left(C + \epsilon\right)^{a - 1}$



Checklist of items for pull request

- [ ] Replaced section above with description of pull request
- [ ] Closed issue #xxxx
- [ ] Referenced issue or pull request #xxxx
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
