### PR TITLE
fix(fmi): trap invalid tdis in final stress period

### DIFF
--- a/autotest/test_gwt_fmi02.py
+++ b/autotest/test_gwt_fmi02.py
@@ -1,20 +1,40 @@
-"""Tests to ability to run flow model first followed by transport model"""
+"""
+Tests ability to run a transport model in an independent
+simulation, consuming flows with a flow model interface.
 
-import os
+Includes 4 cases, first with the transport model's TDIS
+exactly matching the flow model's TDIS, then with more
+time steps per transport model stress period (allowed),
+then two more cases with fewer in the transport model,
+which is forbidden.
+
+The last test case is needed because the error trap is
+implemented separately for the simulation's last period.
+"""
 
 import flopy
+import pytest
+from framework import TestFramework
 
-testgroup = "fmi02"
+simname = "gwtfmi02"
+cases = [
+    f"{simname}_a",  # matching TDIS
+    f"{simname}_b",  # transport nstp > flow nstp = 1 (allowed)
+    f"{simname}_c",  # transport nstp < flow nstp (not allowed)
+    f"{simname}_d",  # like c, but only in final stress period
+]
 
 
-def run_flow_model(dir, exe):
-    name = "flow"
-    ws = os.path.join(dir, testgroup, name)
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=ws, exe_name=exe)
-    pd = [(1.0, 1, 1.0), (1.0, 1, 1.0)]
-    tdis = flopy.mf6.ModflowTdis(sim, nper=len(pd), perioddata=pd)
+def get_model_name(name, mdl):
+    return f"{name}_{mdl}"
+
+
+def build_gwf_sim(name, ws, mf6, tdis_pd):
+    gwf_name = get_model_name(name, "gwf")
+    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=ws, exe_name=mf6)
+    tdis = flopy.mf6.ModflowTdis(sim, nper=len(tdis_pd), perioddata=tdis_pd)
     ims = flopy.mf6.ModflowIms(sim)
-    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwf_name, save_flows=True)
     dis = flopy.mf6.ModflowGwfdis(gwf, nrow=10, ncol=10)
     ic = flopy.mf6.ModflowGwfic(gwf)
     npf = flopy.mf6.ModflowGwfnpf(
@@ -27,56 +47,88 @@ def run_flow_model(dir, exe):
     chd = flopy.mf6.ModflowGwfchd(
         gwf, pname="CHD-1", stress_period_data=spd, auxiliary=["concentration"]
     )
-    budget_file = name + ".bud"
-    head_file = name + ".hds"
     oc = flopy.mf6.ModflowGwfoc(
         gwf,
-        budget_filerecord=budget_file,
-        head_filerecord=head_file,
+        budget_filerecord=f"{gwf_name}.bud",
+        head_filerecord=f"{gwf_name}.hds",
         saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
     )
-    sim.write_simulation()
-    sim.run_simulation()
-    fname = os.path.join(ws, budget_file)
-    assert os.path.isfile(fname)
-    fname = os.path.join(ws, head_file)
-    assert os.path.isfile(fname)
+    return sim
 
 
-def run_transport_model(dir, exe):
-    name = "transport"
-    ws = os.path.join(dir, testgroup, name)
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=ws, exe_name=exe)
-    pd = [(1.0, 10, 1.0), (1.0, 10, 1.0)]
-    tdis = flopy.mf6.ModflowTdis(sim, nper=len(pd), perioddata=pd)
+def build_gwt_sim(name, gwf_ws, gwt_ws, mf6, tdis_pd):
+    gwf_name = get_model_name(name, "gwf")
+    gwt_name = get_model_name(name, "gwt")
+    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=gwt_ws, exe_name=mf6)
+    tdis = flopy.mf6.ModflowTdis(sim, nper=len(tdis_pd), perioddata=tdis_pd)
     ims = flopy.mf6.ModflowIms(sim, linear_acceleration="BICGSTAB")
-    gwt = flopy.mf6.ModflowGwt(sim, modelname=name, save_flows=True)
+    gwt = flopy.mf6.ModflowGwt(sim, modelname=gwt_name, save_flows=True)
     dis = flopy.mf6.ModflowGwtdis(gwt, nrow=10, ncol=10)
     ic = flopy.mf6.ModflowGwtic(gwt)
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.2)
     adv = flopy.mf6.ModflowGwtadv(gwt)
-    pd = [("GWFBUDGET", "../flow/flow.bud", None)]
+    pd = [("GWFBUDGET", gwf_ws / f"{gwf_name}.bud", None)]
     fmi = flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd)
     sources = [("CHD-1", "AUX", "CONCENTRATION")]
     ssm = flopy.mf6.ModflowGwtssm(gwt, print_flows=True, sources=sources)
-    budget_file = name + ".bud"
-    concentration_file = name + ".ucn"
     oc = flopy.mf6.ModflowGwtoc(
         gwt,
-        budget_filerecord=budget_file,
-        concentration_filerecord=concentration_file,
+        budget_filerecord=f"{gwt_name}.bud",
+        concentration_filerecord=f"{gwt_name}.ucn",
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
-    sim.write_simulation()
-    sim.run_simulation()
-    fname = os.path.join(ws, budget_file)
-    assert os.path.isfile(fname)
-    fname = os.path.join(ws, concentration_file)
-    assert os.path.isfile(fname)
+    return sim
 
 
-def test_fmi(function_tmpdir, targets):
-    mf6 = targets["mf6"]
-    run_flow_model(str(function_tmpdir), mf6)
-    run_transport_model(str(function_tmpdir), mf6)
+def build_models(idx, test):
+    if "_a" in test.name:
+        gwf_tdis_pd = [(1.0, 3, 1.0), (1.0, 3, 1.0)]
+        gwt_tdis_pd = [(1.0, 3, 1.0), (1.0, 3, 1.0)]
+    elif "_b" in test.name:
+        gwf_tdis_pd = [(1.0, 1, 1.0), (1.0, 1, 1.0)]
+        gwt_tdis_pd = [(1.0, 3, 1.0), (1.0, 3, 1.0)]
+    elif "_c" in test.name:
+        gwf_tdis_pd = [(1.0, 3, 1.0), (1.0, 3, 1.0)]
+        gwt_tdis_pd = [(1.0, 1, 1.0), (1.0, 1, 1.0)]
+    elif "_d" in test.name:
+        gwf_tdis_pd = [(1.0, 3, 1.0), (1.0, 3, 1.0)]
+        gwt_tdis_pd = [(1.0, 3, 1.0), (1.0, 1, 1.0)]
+    gwf_sim = build_gwf_sim(
+        test.name, test.workspace / "gwf", test.targets["mf6"], tdis_pd=gwf_tdis_pd
+    )
+    gwt_sim = build_gwt_sim(
+        test.name,
+        test.workspace / "gwf",
+        test.workspace / "gwt",
+        test.targets["mf6"],
+        tdis_pd=gwt_tdis_pd,
+    )
+    return gwf_sim, gwt_sim
+
+
+def check_output(idx, test):
+    if "_a" in test.name:
+        pass
+    elif "_b" in test.name:
+        pass
+    elif "_c" in test.name:
+        buff = test.buffs[1]
+        assert any("INCOMPATIBLE WITH TIME" in line for line in buff)
+    elif "_d" in test.name:
+        buff = test.buffs[1]
+        assert any("INCOMPATIBLE WITH TIME" in line for line in buff)
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        targets=targets,
+        compare=None,
+        xfail=[False, "_c" in name or "_d" in name],
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -29,3 +29,7 @@ section = "fixes"
 subsection = "exchanges"
 description = "When a MVR connection was included as part of an exchange between two models, it was possible to list a model name in the PACKAGES block of the MVR input file that is not one of the two models included in the exchange.  A check was added that reports an error message stating that a model name listed in the exchange MVR input file is not one of the two models connected by the exchange."
 
+[[items]]
+section = "fixes"
+subsection = "model"
+description = "The Flow Model Interface (FMI) package for transport and tracking models conducts TDIS compatibility checks during each stress period to ensure that the model's time discretization is compatible with that of the flow model. In particular, if a flow model stress period has just one time step, the transport or tracking model may have any number of time steps. However, if a flow model stress period has more than one time step, the transport or tracking model must have the same number of time steps. Simulations would previously stop with an error if the transport or tracking model violated this rule for any stress periods up to the simulation's last, but would not raise an error for the last stress period. The compatibility check was updated to include the last stress period. Simulations will now stop with an error if the transport or tracking model violates this rule for any stress period in the simulation."

--- a/src/Model/ModelUtilities/FlowModelInterface.f90
+++ b/src/Model/ModelUtilities/FlowModelInterface.f90
@@ -593,7 +593,7 @@ contains
   !<
   subroutine advance_bfr(this)
     ! -- modules
-    use TdisModule, only: kstp, kper
+    use TdisModule, only: kstp, kper, endofsimulation
     ! -- dummy
     class(FlowModelInterfaceType) :: this
     ! -- local
@@ -612,6 +612,12 @@ contains
       &FOR KSTP ', i0, ' AND KPER ',        &
       &i0, ' TO BUDGET FILE TERMS FROM &
       &KSTP ', i0, ' AND KPER ', i0)"
+    character(len=*), parameter :: fmtbadtdis = &
+      "(4x, 'TIME DISCRETIZATION IN BUDGET FILE &
+      &IS INCOMPATIBLE WITH TIME DISCRETIZATION IN COUPLED MODEL. &
+      &IF THERE IS MORE THAN ONE TIME STEP IN THE BUDGET FILE FOR A &
+      &GIVEN STRESS PERIOD, BUDGET FILE TIME STEPS MUST MATCH THE &
+      &COUPLED MODEL TIME STEPS ONE-FOR-ONE IN THAT STRESS PERIOD.')"
     !
     ! -- If the latest record read from the budget file is from a stress
     ! -- period with only one time step, reuse that record (do not read a
@@ -653,22 +659,14 @@ contains
         !
         ! -- Ensure kper is same between model and budget file
         if (kper /= this%bfr%header%kper) then
-          write (errmsg, '(4x,a)') 'PERIOD NUMBER IN BUDGET FILE &
-            &DOES NOT MATCH PERIOD NUMBER IN TRANSPORT MODEL.  IF THERE &
-            &IS MORE THAN ONE TIME STEP IN THE BUDGET FILE FOR A GIVEN &
-            &STRESS PERIOD, BUDGET FILE TIME STEPS MUST MATCH GWT MODEL &
-            &TIME STEPS ONE-FOR-ONE IN THAT STRESS PERIOD.'
+          write (errmsg, fmtbadtdis)
           call store_error(errmsg)
           call store_error_unit(this%iubud)
         end if
         !
         ! -- if budget file kstp > 1, then kstp must match
         if (this%bfr%header%kstp > 1 .and. (kstp /= this%bfr%header%kstp)) then
-          write (errmsg, '(4x,a)') 'TIME STEP NUMBER IN BUDGET FILE &
-            &DOES NOT MATCH TIME STEP NUMBER IN TRANSPORT MODEL.  IF THERE &
-         &IS MORE THAN ONE TIME STEP IN THE BUDGET FILE FOR A GIVEN STRESS &
-           &PERIOD, BUDGET FILE TIME STEPS MUST MATCH GWT MODEL TIME STEPS &
-            &ONE-FOR-ONE IN THAT STRESS PERIOD.'
+          write (errmsg, fmtbadtdis)
           call store_error(errmsg)
           call store_error_unit(this%iubud)
         end if
@@ -728,6 +726,16 @@ contains
           end select
         end select
       end do
+
+      ! If this is the final time step, make sure no records
+      ! for this period are being skipped in the budget file.
+      if (endofsimulation .and. .not. this%bfr%endoffile) then
+        if (this%bfr%headernext%kper == kper) then
+          write (errmsg, fmtbadtdis)
+          call store_error(errmsg)
+          call store_error_unit(this%iubud)
+        end if
+      end if
     else
       !
       ! -- write message to indicate that flows are being reused


### PR DESCRIPTION
FMI conducts TDIS compatibility checks during each stress period to ensure that the coupled transport or tracking model's time discretization is compatible with that of the flow model. In particular, if a flow model stress period has just one time step, the transport or tracking model period may have any number of time steps. However, if a flow model stress period has more than one time step, the transport or tracking model must have the same number of time steps.

Simulations would previously stop with an error if the transport or tracking model violated this rule for any stress period up to the simulation's last, but would not raise an error for the last stress period. Update the compatibility check to cover the last stress period. Consolidate the error message and make the language generic (it referred specifically to transport models before). And update `test_gwt_fmi02.py` to use `TestFramework` and exercise the error traps.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request