### PR TITLE
refactor(exg): move exg_ad to base, call in explicit solution prepare

### DIFF
--- a/src/Exchange/BaseExchange.f90
+++ b/src/Exchange/BaseExchange.f90
@@ -12,6 +12,7 @@ module BaseExchangeModule
   private :: CastAsBaseExchangeClass
 
   type, abstract :: BaseExchangeType
+    character(len=7) :: typename !< name of the type (e.g., 'GWF-GWF')
     character(len=LENEXCHANGENAME) :: name !< the name of this exchange
     character(len=LENMEMPATH) :: memoryPath !< the location in the memory manager where the variables are stored
     character(len=LENMEMPATH) :: input_mempath
@@ -26,6 +27,7 @@ module BaseExchangeModule
     procedure :: exg_ot
     procedure :: exg_fp
     procedure :: exg_da
+    procedure :: exg_ad
     procedure :: connects_model
   end type BaseExchangeType
 
@@ -46,73 +48,57 @@ module BaseExchangeModule
 contains
 
   !> @brief Read and prepare
-  !<
   subroutine exg_rp(this)
-    ! -- modules
-    use TdisModule, only: readnewdata
-    ! -- dummy
     class(BaseExchangeType) :: this
-    !
-    ! -- Check with TDIS on whether or not it is time to RP
-    if (.not. readnewdata) return
-    !
-    ! -- Nothing to do for RP
   end subroutine exg_rp
 
   !> @brief Calculate time step length
-  !<
   subroutine exg_dt(this)
-    ! -- dummy
     class(BaseExchangeType) :: this
-    !
-    ! -- Nothing to do for TU
   end subroutine exg_dt
 
   !> @brief Run output routines
-  !<
   subroutine exg_ot(this)
-    ! -- dummy
     class(BaseExchangeType) :: this
   end subroutine exg_ot
 
   !> @brief Final processing
-  !<
   subroutine exg_fp(this)
-    ! -- dummy
     class(BaseExchangeType) :: this
   end subroutine exg_fp
 
   !> @brief Deallocate memory
-  !<
   subroutine exg_da(this)
-    ! -- dummy
     class(BaseExchangeType) :: this
   end subroutine exg_da
+
+  !> @brief Advance
+  subroutine exg_ad(this)
+    class(BaseExchangeType) :: this
+  end subroutine exg_ad
 
   !> @brief Should return true when the exchange should be added to the
   !! solution where the model resides
   !<
   function connects_model(this, model) result(is_connected)
-    ! -- dummy
+    ! dummy
     class(BaseExchangeType) :: this !< the instance of the exchange
     class(BaseModelType), pointer, intent(in) :: model !< the model to which the exchange might hold a connection
-    ! -- return
+    ! return
     logical(LGP) :: is_connected !< true, when connected
-    !
     is_connected = .false.
   end function
 
   !> @brief Cast the object passed in as BaseExchangeType and return it
-  !<
   function CastAsBaseExchangeClass(obj) result(res)
-    ! -- dummy
+    ! dummy
     class(*), pointer, intent(inout) :: obj
-    ! -- return
+    ! return
     class(BaseExchangeType), pointer :: res
-    !
+
     res => null()
     if (.not. associated(obj)) return
-    !
+
     select type (obj)
     class is (BaseExchangeType)
       res => obj
@@ -120,28 +106,26 @@ contains
   end function CastAsBaseExchangeClass
 
   !> @brief Add the exchange object (BaseExchangeType) to a list
-  !<
   subroutine AddBaseExchangeToList(list, exchange)
-    ! -- dummy
+    ! dummy
     type(ListType), intent(inout) :: list
     class(BaseExchangeType), pointer, intent(inout) :: exchange
-    ! -- local
+    ! local
     class(*), pointer :: obj
-    !
+
     obj => exchange
     call list%Add(obj)
   end subroutine AddBaseExchangeToList
 
   !> @brief Retrieve a specific BaseExchangeType object from a list
-  !<
   function GetBaseExchangeFromList(list, idx) result(res)
-    ! -- dummy
+    ! dummy
     type(ListType), intent(inout) :: list
     integer(I4B), intent(in) :: idx
     class(BaseExchangeType), pointer :: res
-    ! -- local
+    ! local
     class(*), pointer :: obj
-    !
+
     obj => list%GetItem(idx)
     res => CastAsBaseExchangeClass(obj)
   end function GetBaseExchangeFromList

--- a/src/Exchange/NumericalExchange.f90
+++ b/src/Exchange/NumericalExchange.f90
@@ -14,8 +14,6 @@ module NumericalExchangeModule
             AddNumericalExchangeToList, GetNumericalExchangeFromList
 
   type, extends(BaseExchangeType) :: NumericalExchangeType
-    character(len=7) :: typename !< name of the type (e.g., 'GWF-GWF')
-
   contains
 
     procedure :: exg_df
@@ -23,7 +21,6 @@ module NumericalExchangeModule
     procedure :: exg_mc
     procedure :: exg_ar
     !procedure :: exg_rp (not needed yet; base exg_rp does nothing)
-    procedure :: exg_ad
     procedure :: exg_cf
     procedure :: exg_fc
     procedure :: exg_cc
@@ -37,64 +34,37 @@ module NumericalExchangeModule
 contains
 
   !> @brief Define the exchange
-  !<
   subroutine exg_df(this)
-    ! -- modules
-    use BaseModelModule, only: BaseModelType
-    use InputOutputModule, only: getunit, openfile
-    ! -- dummy
     class(NumericalExchangeType) :: this
   end subroutine exg_df
 
   !> @brief If an implicit exchange then add connections to sparse
-  !<
   subroutine exg_ac(this, sparse)
-    ! -- modules
     use SparseModule, only: sparsematrix
-    ! -- dummy
     class(NumericalExchangeType) :: this
     type(sparsematrix), intent(inout) :: sparse
   end subroutine exg_ac
 
   !> @brief Map the connections in the global matrix
-  !<
   subroutine exg_mc(this, matrix_sln)
-    ! -- module
-    use SparseModule, only: sparsematrix
-    ! -- dummy
     class(NumericalExchangeType) :: this
     class(MatrixBaseType), pointer :: matrix_sln
-    !
-    ! -- Return
   end subroutine exg_mc
 
   !> @brief Allocate and read
-  !<
   subroutine exg_ar(this)
-    !
     class(NumericalExchangeType) :: this
   end subroutine exg_ar
 
-  !> @brief Advance
-  !<
-  subroutine exg_ad(this)
-    ! -- dummy
-    class(NumericalExchangeType) :: this
-  end subroutine exg_ad
-
   !> @brief Calculate conductance, and for explicit exchanges, set the
   !! conductance in the boundary package
-  !<
   subroutine exg_cf(this, kiter)
-    ! -- dummy
     class(NumericalExchangeType) :: this
     integer(I4B), intent(in) :: kiter
   end subroutine exg_cf
 
   !> @brief Fill the matrix
-  !<
   subroutine exg_fc(this, kiter, matrix_sln, rhs_sln, inwtflag)
-    ! -- dummy
     class(NumericalExchangeType) :: this
     integer(I4B), intent(in) :: kiter
     class(MatrixBaseType), pointer :: matrix_sln
@@ -103,19 +73,13 @@ contains
   end subroutine exg_fc
 
   !> @brief Additional convergence check
-  !<
   subroutine exg_cc(this, icnvg)
-    ! -- dummy
     class(NumericalExchangeType) :: this
     integer(I4B), intent(inout) :: icnvg
   end subroutine exg_cc
 
   !> @brief Calculate flow
-  !<
   subroutine exg_cq(this, icnvg, isuppress_output, isolnid)
-    ! -- modules
-    use ConstantsModule, only: LENBUDTXT
-    ! -- dummy
     class(NumericalExchangeType) :: this
     integer(I4B), intent(inout) :: icnvg
     integer(I4B), intent(in) :: isuppress_output
@@ -123,11 +87,7 @@ contains
   end subroutine exg_cq
 
   !> @brief Exchange budget
-  !<
   subroutine exg_bd(this, icnvg, isuppress_output, isolnid)
-    ! -- modules
-    use ConstantsModule, only: LENBUDTXT
-    ! -- dummy
     class(NumericalExchangeType) :: this
     integer(I4B), intent(inout) :: icnvg
     integer(I4B), intent(in) :: isuppress_output
@@ -135,40 +95,29 @@ contains
   end subroutine exg_bd
 
   !> @brief Output
-  !<
   subroutine exg_ot(this)
-    ! -- dummy
     class(NumericalExchangeType) :: this
   end subroutine exg_ot
 
   !> @brief Deallocate memory
-  !<
   subroutine exg_da(this)
-    ! -- modules
-    use MemoryManagerModule, only: mem_deallocate
-    ! -- dummy
     class(NumericalExchangeType) :: this
   end subroutine exg_da
 
   function get_iasym(this) result(iasym)
-    ! -- dummy
     class(NumericalExchangeType) :: this
-    ! -- return
     integer(I4B) :: iasym
-    !
     iasym = 0
   end function get_iasym
 
   function CastAsNumericalExchangeClass(obj) result(res)
     implicit none
-    ! -- dummy
     class(*), pointer, intent(inout) :: obj
-    ! -- return
     class(NumericalExchangeType), pointer :: res
-    !
+
     res => null()
     if (.not. associated(obj)) return
-    !
+
     select type (obj)
     class is (NumericalExchangeType)
       res => obj
@@ -176,30 +125,24 @@ contains
   end function CastAsNumericalExchangeClass
 
   !> @brief Add numerical exchange to a list
-  !<
   subroutine AddNumericalExchangeToList(list, exchange)
     implicit none
-    ! -- dummy
     type(ListType), intent(inout) :: list
     class(NumericalExchangeType), pointer, intent(in) :: exchange
-    ! -- local
     class(*), pointer :: obj
-    !
+
     obj => exchange
     call list%Add(obj)
   end subroutine AddNumericalExchangeToList
 
   !> @brief Retrieve a specific numerical exchange from a list
-  !<
   function GetNumericalExchangeFromList(list, idx) result(res)
     implicit none
-    ! -- dummy
     type(ListType), intent(inout) :: list
     integer(I4B), intent(in) :: idx
     class(NumericalExchangeType), pointer :: res
-    ! -- local
     class(*), pointer :: obj
-    !
+
     obj => list%GetItem(idx)
     res => CastAsNumericalExchangeClass(obj)
   end function GetNumericalExchangeFromList

--- a/src/Solution/ExplicitSolution.f90
+++ b/src/Solution/ExplicitSolution.f90
@@ -22,7 +22,7 @@ module ExplicitSolutionModule
   use ExplicitModelModule, only: ExplicitModelType, &
                                  AddExplicitModelToList, &
                                  GetExplicitModelFromList
-  use BaseExchangeModule, only: BaseExchangeType
+  use BaseExchangeModule, only: BaseExchangeType, GetBaseExchangeFromList
   use BaseSolutionModule, only: BaseSolutionType, AddBaseSolutionToList
   use ListModule, only: ListType
   use ListsModule, only: basesolutionlist
@@ -73,7 +73,7 @@ module ExplicitSolutionModule
 
 contains
 
-  !> @ brief Create a new solution
+  !> @brief Create a new solution
   !!
   !! Create a new solution using the data in filename, assign this new
   !! solution an id number and store the solution in the basesolutionlist.
@@ -115,7 +115,7 @@ contains
     call exp_sol%parser%Initialize(exp_sol%iu, iout)
   end subroutine create_explicit_solution
 
-  !> @ brief Allocate scalars
+  !> @brief Allocate scalars
   subroutine allocate_scalars(this)
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
 
@@ -132,24 +132,24 @@ contains
     this%icnvg = 0
   end subroutine allocate_scalars
 
-  !> @ brief Define the solution
+  !> @brief Define the solution
   subroutine sln_df(this)
     class(ExplicitSolutionType) :: this
   end subroutine
 
-  !> @ brief Allocate and read
+  !> @brief Allocate and read
   subroutine sln_ar(this)
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
     ! close ems input file
     call this%parser%Clear()
   end subroutine sln_ar
 
-  !> @ brief Calculate time step length
+  !> @brief Calculate time step length
   subroutine sln_dt(this)
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
   end subroutine sln_dt
 
-  !> @ brief Advance the solution
+  !> @brief Advance the solution
   subroutine sln_ad(this)
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
 
@@ -157,7 +157,7 @@ contains
     this%icnvg = 0
   end subroutine sln_ad
 
-  !> @ brief Output
+  !> @brief Output
   subroutine sln_ot(this)
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
   end subroutine sln_ot
@@ -166,7 +166,7 @@ contains
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
   end subroutine sln_fp
 
-  !> @ brief Deallocate
+  !> @brief Deallocate
   subroutine sln_da(this)
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
 
@@ -183,7 +183,7 @@ contains
     call mem_deallocate(this%icnvg)
   end subroutine sln_da
 
-  !> @ brief Calculate
+  !> @brief Calculate
   subroutine sln_ca(this, isgcnvg, isuppress_output)
     ! dummy
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
@@ -218,17 +218,24 @@ contains
     end select
   end subroutine sln_ca
 
-  !> @ brief Prepare to solve
+  !> @brief Prepare to solve
   subroutine prepareSolve(this)
     ! dummy
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
     ! local
-    integer(I4B) :: im
+    integer(I4B) :: i
     class(ExplicitModelType), pointer :: mp => null()
+    class(BaseExchangeType), pointer :: ep => null()
 
-    ! advance model
-    do im = 1, this%modellist%Count()
-      mp => GetExplicitModelFromList(this%modellist, im)
+    ! advance exchanges
+    do i = 1, this%exchangelist%Count()
+      ep => GetBaseExchangeFromList(this%exchangelist, i)
+      call ep%exg_ad()
+    end do
+
+    ! advance models
+    do i = 1, this%modellist%Count()
+      mp => GetExplicitModelFromList(this%modellist, i)
       call mp%model_ad()
     end do
 
@@ -236,7 +243,7 @@ contains
     call this%sln_ad()
   end subroutine prepareSolve
 
-  !> @ brief Solve models
+  !> @brief Solve models
   subroutine solve(this, kiter)
     ! dummy
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
@@ -273,7 +280,7 @@ contains
     this%icnvg = 1
   end subroutine solve
 
-  !> @ brief Finalize solve
+  !> @brief Finalize solve
   subroutine finalizeSolve(this, kiter, isgcnvg, isuppress_output)
     ! dummy
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
@@ -297,7 +304,7 @@ contains
     end do
   end subroutine finalizeSolve
 
-  !> @ brief Save output
+  !> @brief Save output
   subroutine save(this, filename)
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
     character(len=*), intent(in) :: filename !< filename to save solution data
@@ -308,7 +315,7 @@ contains
     close (inunit)
   end subroutine save
 
-  !> @ brief Add explicit model to list
+  !> @brief Add explicit model to list
   subroutine add_model(this, mp)
     class(ExplicitSolutionType) :: this !< ExplicitSolutionType instance
     class(BaseModelType), pointer, intent(in) :: mp !< model instance
@@ -327,7 +334,7 @@ contains
     models => this%modellist
   end function get_models
 
-  !> @ brief Add exchange to list of exchanges
+  !> @brief Add exchange to list of exchanges
   subroutine add_exchange(this, exchange)
     class(ExplicitSolutionType) :: this
     class(BaseExchangeType), pointer, intent(in) :: exchange
@@ -336,7 +343,7 @@ contains
     call this%exchangelist%Add(obj)
   end subroutine add_exchange
 
-  !> @ brief Get list of exchanges
+  !> @brief Get list of exchanges
   function get_exchanges(this) result(exchanges)
     class(ExplicitSolutionType) :: this
     type(ListType), pointer :: exchanges


### PR DESCRIPTION
Move `exg_ad()` from `NumericalExchange` to `BaseExchangeType`. The advance routine may be relevant for explicit models/solutions too (immediate motivation is PRT). Call it from `ExplicitSolution%prepareSolve()`. Also move `typename` to the base type, and some cleanup.