### PR TITLE
feat(memory): support param input context deallocation

### DIFF
--- a/src/Exchange/DisConnExchange.f90
+++ b/src/Exchange/DisConnExchange.f90
@@ -251,6 +251,7 @@ contains
   subroutine source_data(this, iout)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr
+    use MemoryManagerExtModule, only: memorystore_release
     ! -- dummy
     class(DisConnExchangeType) :: this !< instance of exchange object
     integer(I4B), intent(in) :: iout !< the output file unit
@@ -389,6 +390,15 @@ contains
       call store_error('Errors encountered in exchange input file.')
       call store_error_filename(this%filename)
     end if
+    !
+    call memorystore_release('CELLIDM1', this%input_mempath)
+    call memorystore_release('CELLIDM2', this%input_mempath)
+    call memorystore_release('IHC', this%input_mempath)
+    call memorystore_release('CL1', this%input_mempath)
+    call memorystore_release('CL2', this%input_mempath)
+    call memorystore_release('HWVA', this%input_mempath)
+    call memorystore_release('AUXVAR', this%input_mempath)
+    call memorystore_release('BOUNDNAME', this%input_mempath)
   end subroutine source_data
 
   !> @brief Allocate scalars and initialize to defaults

--- a/src/Exchange/DisConnExchange.f90
+++ b/src/Exchange/DisConnExchange.f90
@@ -104,12 +104,13 @@ contains
     integer(I4B) :: ival, n
     !
     ! -- update defaults with idm sourced values
-    call mem_set_value(this%naux, 'NAUX', this%input_mempath, found%naux)
+    call mem_set_value(this%naux, 'NAUX', this%input_mempath, found%naux, &
+                       release=.false.)
     call mem_set_value(this%ipakcb, 'IPAKCB', this%input_mempath, found%ipakcb)
     call mem_set_value(this%iprpak, 'IPRPAK', this%input_mempath, found%iprpak)
     call mem_set_value(this%iprflow, 'IPRFLOW', this%input_mempath, found%iprflow)
     call mem_set_value(this%inamedbound, 'BOUNDNAMES', this%input_mempath, &
-                       found%boundnames)
+                       found%boundnames, release=.false.)
     call mem_set_value(this%dev_ifmod_on, 'DEV_IFMOD_ON', this%input_mempath, &
                        found%dev_ifmod_on)
     !
@@ -120,7 +121,7 @@ contains
       call mem_reallocate(this%auxname_cst, LENAUXNAME, this%naux, &
                           'AUXNAME_CST', this%memoryPath)
       call mem_set_value(this%auxname_cst, 'AUXILIARY', this%input_mempath, &
-                         found%auxiliary)
+                         found%auxiliary, release=.false.)
       !
       do n = 1, this%naux
         this%auxname(n) = this%auxname_cst(n)

--- a/src/Exchange/DisConnExchange.f90
+++ b/src/Exchange/DisConnExchange.f90
@@ -251,7 +251,7 @@ contains
   subroutine source_data(this, iout)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr
-    use MemoryManagerExtModule, only: memorystore_release
+    !use MemoryManagerExtModule, only: memorystore_release
     ! -- dummy
     class(DisConnExchangeType) :: this !< instance of exchange object
     integer(I4B), intent(in) :: iout !< the output file unit
@@ -391,14 +391,14 @@ contains
       call store_error_filename(this%filename)
     end if
     !
-    call memorystore_release('CELLIDM1', this%input_mempath)
-    call memorystore_release('CELLIDM2', this%input_mempath)
-    call memorystore_release('IHC', this%input_mempath)
-    call memorystore_release('CL1', this%input_mempath)
-    call memorystore_release('CL2', this%input_mempath)
-    call memorystore_release('HWVA', this%input_mempath)
-    call memorystore_release('AUXVAR', this%input_mempath)
-    call memorystore_release('BOUNDNAME', this%input_mempath)
+    !call memorystore_release('CELLIDM1', this%input_mempath)
+    !call memorystore_release('CELLIDM2', this%input_mempath)
+    !call memorystore_release('IHC', this%input_mempath)
+    !call memorystore_release('CL1', this%input_mempath)
+    !call memorystore_release('CL2', this%input_mempath)
+    !call memorystore_release('HWVA', this%input_mempath)
+    !call memorystore_release('AUXVAR', this%input_mempath)
+    !call memorystore_release('BOUNDNAME', this%input_mempath)
   end subroutine source_data
 
   !> @brief Allocate scalars and initialize to defaults

--- a/src/Exchange/DisConnExchange.f90
+++ b/src/Exchange/DisConnExchange.f90
@@ -251,7 +251,7 @@ contains
   subroutine source_data(this, iout)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr
-    !use MemoryManagerExtModule, only: memorystore_release
+    use MemoryManagerExtModule, only: memorystore_release
     ! -- dummy
     class(DisConnExchangeType) :: this !< instance of exchange object
     integer(I4B), intent(in) :: iout !< the output file unit
@@ -391,14 +391,14 @@ contains
       call store_error_filename(this%filename)
     end if
     !
-    !call memorystore_release('CELLIDM1', this%input_mempath)
-    !call memorystore_release('CELLIDM2', this%input_mempath)
-    !call memorystore_release('IHC', this%input_mempath)
-    !call memorystore_release('CL1', this%input_mempath)
-    !call memorystore_release('CL2', this%input_mempath)
-    !call memorystore_release('HWVA', this%input_mempath)
-    !call memorystore_release('AUXVAR', this%input_mempath)
-    !call memorystore_release('BOUNDNAME', this%input_mempath)
+    call memorystore_release('CELLIDM1', this%input_mempath)
+    call memorystore_release('CELLIDM2', this%input_mempath)
+    call memorystore_release('IHC', this%input_mempath)
+    call memorystore_release('CL1', this%input_mempath)
+    call memorystore_release('CL2', this%input_mempath)
+    Call memorystore_release('HWVA', this%input_mempath)
+    call memorystore_release('AUXVAR', this%input_mempath)
+    call memorystore_release('BOUNDNAME', this%input_mempath)
   end subroutine source_data
 
   !> @brief Allocate scalars and initialize to defaults

--- a/src/Exchange/exg-chfgwf.f90
+++ b/src/Exchange/exg-chfgwf.f90
@@ -191,6 +191,7 @@ contains
   subroutine source_data(this, iout)
     !  modules
     use MemoryManagerModule, only: mem_setptr
+    use MemoryManagerExtModule, only: memorystore_release
     !  dummy
     class(ChfGwfExchangeType) :: this !< instance of exchange object
     integer(I4B), intent(in) :: iout !< the output file unit
@@ -281,6 +282,11 @@ contains
       call store_error('Errors encountered in exchange input file.')
       call store_error_filename(this%filename)
     end if
+
+    call memorystore_release('CELLIDM1', this%input_mempath)
+    call memorystore_release('CELLIDM2', this%input_mempath)
+    call memorystore_release('BEDLEAK', this%input_mempath)
+    call memorystore_release('CFACT', this%input_mempath)
 
   end subroutine source_data
 

--- a/src/Exchange/exg-olfgwf.f90
+++ b/src/Exchange/exg-olfgwf.f90
@@ -191,6 +191,7 @@ contains
   subroutine source_data(this, iout)
     !  modules
     use MemoryManagerModule, only: mem_setptr
+    use MemoryManagerExtModule, only: memorystore_release
     !  dummy
     class(OlfGwfExchangeType) :: this !< instance of exchange object
     integer(I4B), intent(in) :: iout !< the output file unit
@@ -281,6 +282,11 @@ contains
       call store_error('Errors encountered in exchange input file.')
       call store_error_filename(this%filename)
     end if
+
+    call memorystore_release('CELLIDM1', this%input_mempath)
+    call memorystore_release('CELLIDM2', this%input_mempath)
+    call memorystore_release('BEDLEAK', this%input_mempath)
+    call memorystore_release('CFACT', this%input_mempath)
 
   end subroutine source_data
 

--- a/src/Model/Discretization/Disu.f90
+++ b/src/Model/Discretization/Disu.f90
@@ -13,7 +13,8 @@ module DisuModule
   use BaseDisModule, only: DisBaseType
   use MemoryManagerModule, only: mem_allocate, mem_deallocate, &
                                  mem_reallocate, mem_setptr
-  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove
+  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove, &
+                                    memorystore_release
   use TdisModule, only: kstp, kper, pertim, totim, delt
   use DisvGeom, only: line_unit_vector
 
@@ -813,6 +814,8 @@ contains
       write (this%iout, '(1x,a)') 'Discretization Vertex data loaded'
     end if
     !
+    call memorystore_release('XV', this%input_mempath)
+    call memorystore_release('YV', this%input_mempath)
   end subroutine source_vertices
 
   !> @brief Build data structures to hold cell vertex info
@@ -901,6 +904,11 @@ contains
       write (this%iout, '(1x,a)') 'Discretization Cell2d data loaded'
     end if
     !
+    call memorystore_release('ICELL2D', this%input_mempath)
+    call memorystore_release('NCVERT', this%input_mempath)
+    call memorystore_release('ICVERT', this%input_mempath)
+    call memorystore_release('XC', this%input_mempath)
+    call memorystore_release('YC', this%input_mempath)
   end subroutine source_cell2d
 
   !> @brief Write a binary grid file

--- a/src/Model/Discretization/Disv.f90
+++ b/src/Model/Discretization/Disv.f90
@@ -544,8 +544,8 @@ contains
       write (this%iout, '(1x,a)') 'Discretization Vertex data loaded'
     end if
     !
-    ! call memorystore_release('XV', this%input_mempath)
-    ! call memorystore_release('YV', this%input_mempath)
+    call memorystore_release('XV', this%input_mempath)
+    call memorystore_release('YV', this%input_mempath)
   end subroutine source_vertices
 
   !> @brief Build data structures to hold cell vertex info
@@ -635,11 +635,12 @@ contains
       write (this%iout, '(1x,a)') 'Discretization Cell2d data loaded'
     end if
     !
-    ! call memorystore_release('ICELL2D', this%input_mempath)
+    call memorystore_release('ICELL2D', this%input_mempath)
+    ! NCVERT and ICVERT are export dependency for now
     ! call memorystore_release('NCVERT', this%input_mempath)
     ! call memorystore_release('ICVERT', this%input_mempath)
-    ! call memorystore_release('XC', this%input_mempath)
-    ! call memorystore_release('YC', this%input_mempath)
+    call memorystore_release('XC', this%input_mempath)
+    call memorystore_release('YC', this%input_mempath)
   end subroutine source_cell2d
 
   !> @brief Build grid connections

--- a/src/Model/Discretization/Disv.f90
+++ b/src/Model/Discretization/Disv.f90
@@ -13,7 +13,8 @@ module DisvModule
   use SimVariablesModule, only: errmsg, idm_context
   use DisvGeom, only: DisvGeomType, line_unit_vector
   use MemoryManagerModule, only: mem_allocate, mem_deallocate, mem_setptr
-  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove
+  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove, &
+                                    memorystore_release
   use TdisModule, only: kstp, kper, pertim, totim, delt
 
   implicit none
@@ -543,6 +544,8 @@ contains
       write (this%iout, '(1x,a)') 'Discretization Vertex data loaded'
     end if
     !
+    ! call memorystore_release('XV', this%input_mempath)
+    ! call memorystore_release('YV', this%input_mempath)
   end subroutine source_vertices
 
   !> @brief Build data structures to hold cell vertex info
@@ -632,6 +635,11 @@ contains
       write (this%iout, '(1x,a)') 'Discretization Cell2d data loaded'
     end if
     !
+    ! call memorystore_release('ICELL2D', this%input_mempath)
+    ! call memorystore_release('NCVERT', this%input_mempath)
+    ! call memorystore_release('ICVERT', this%input_mempath)
+    ! call memorystore_release('XC', this%input_mempath)
+    ! call memorystore_release('YC', this%input_mempath)
   end subroutine source_cell2d
 
   !> @brief Build grid connections

--- a/src/Model/Discretization/Disv.f90
+++ b/src/Model/Discretization/Disv.f90
@@ -636,7 +636,7 @@ contains
     end if
     !
     call memorystore_release('ICELL2D', this%input_mempath)
-    ! NCVERT and ICVERT are export dependency for now
+    ! NCVERT and ICVERT are currently an export dependency
     ! call memorystore_release('NCVERT', this%input_mempath)
     ! call memorystore_release('ICVERT', this%input_mempath)
     call memorystore_release('XC', this%input_mempath)

--- a/src/Model/Discretization/Disv1d.f90
+++ b/src/Model/Discretization/Disv1d.f90
@@ -5,7 +5,7 @@ module Disv1dModule
   use SimVariablesModule, only: errmsg, warnmsg
   use MemoryHelperModule, only: create_mem_path
   use MemoryManagerModule, only: mem_allocate, mem_setptr
-  use MemoryManagerExtModule, only: mem_set_value
+  use MemoryManagerExtModule, only: mem_set_value, memorystore_release
   use SimModule, only: count_errors, store_error, store_warning, &
                        store_error_filename
   use InputOutputModule, only: urword
@@ -525,6 +525,8 @@ contains
       write (this%iout, '(1x,a)') 'Setting Discretization Vertices'
       write (this%iout, '(1x,a,/)') 'End setting discretization vertices'
     end if
+    call memorystore_release('XV', idmMemoryPath)
+    call memorystore_release('YV', idmMemoryPath)
   end subroutine source_vertices
 
   !> @brief Copy cell1d information from input data context

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -13,7 +13,8 @@ module Disv2dModule
   use SimVariablesModule, only: errmsg, idm_context
   use DisvGeom, only: DisvGeomType, line_unit_vector
   use MemoryManagerModule, only: mem_allocate, mem_deallocate, mem_setptr
-  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove
+  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove, &
+                                    memorystore_release
   use TdisModule, only: kstp, kper, pertim, totim, delt
 
   implicit none
@@ -497,6 +498,8 @@ contains
       write (this%iout, '(1x,a)') 'Discretization Vertex data loaded'
     end if
     !
+    call memorystore_release('XV', this%input_mempath)
+    call memorystore_release('YV', this%input_mempath)
   end subroutine source_vertices
 
   !> @brief Build data structures to hold cell vertex info
@@ -586,6 +589,11 @@ contains
       write (this%iout, '(1x,a)') 'Discretization Cell2d data loaded'
     end if
     !
+    call memorystore_release('ICELL2D', this%input_mempath)
+    call memorystore_release('NCVERT', this%input_mempath)
+    call memorystore_release('ICVERT', this%input_mempath)
+    call memorystore_release('XC', this%input_mempath)
+    call memorystore_release('YC', this%input_mempath)
   end subroutine source_cell2d
 
   !> @brief Build grid connections

--- a/src/Model/GroundWaterFlow/gwf-buy.f90
+++ b/src/Model/GroundWaterFlow/gwf-buy.f90
@@ -978,7 +978,7 @@ contains
   subroutine source_packagedata(this)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr, mem_allocate
-    use MemoryManagerExtModule, only: mem_set_value
+    use MemoryManagerExtModule, only: mem_set_value, memorystore_release
     use CharacterStringModule, only: CharacterStringType
     ! -- dummy
     class(GwfBuyType), intent(inout) :: this
@@ -1061,6 +1061,11 @@ contains
 
     ! cleanup
     deallocate (itemp)
+    call memorystore_release('IRHOSPEC', this%input_mempath)
+    call memorystore_release('DRHODC', this%input_mempath)
+    call memorystore_release('CRHOREF', this%input_mempath)
+    call memorystore_release('MODELNAME', this%input_mempath)
+    call memorystore_release('AUXSPECIESNAME', this%input_mempath)
   end subroutine source_packagedata
 
   !> @brief Sets package data instead of reading from file

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -1546,7 +1546,6 @@ contains
     end if
 
     call memorystore_release('ICSUBNO', this%input_mempath)
-    ! call memorystore_release('CELLID', this%input_mempath)
     call memorystore_release('CDELAY', this%input_mempath)
     call memorystore_release('PCS0', this%input_mempath)
     call memorystore_release('THICK_FRAC', this%input_mempath)

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -1546,6 +1546,7 @@ contains
     end if
 
     call memorystore_release('ICSUBNO', this%input_mempath)
+    call memorystore_release('CELLID_PKGDATA', this%input_mempath)
     call memorystore_release('CDELAY', this%input_mempath)
     call memorystore_release('PCS0', this%input_mempath)
     call memorystore_release('THICK_FRAC', this%input_mempath)

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -1194,7 +1194,7 @@ contains
   subroutine csub_source_packagedata(this)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr, mem_allocate
-    use MemoryManagerExtModule, only: mem_set_value
+    use MemoryManagerExtModule, only: mem_set_value, memorystore_release
     use CharacterStringModule, only: CharacterStringType
     ! -- dummy variables
     class(GwfCsubType), intent(inout) :: this
@@ -1544,6 +1544,19 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
+
+    call memorystore_release('ICSUBNO', this%input_mempath)
+    ! call memorystore_release('CELLID', this%input_mempath)
+    call memorystore_release('CDELAY', this%input_mempath)
+    call memorystore_release('PCS0', this%input_mempath)
+    call memorystore_release('THICK_FRAC', this%input_mempath)
+    call memorystore_release('RNB', this%input_mempath)
+    call memorystore_release('SSV_CC', this%input_mempath)
+    call memorystore_release('SSE_CR', this%input_mempath)
+    call memorystore_release('THETA', this%input_mempath)
+    call memorystore_release('KV', this%input_mempath)
+    call memorystore_release('H0', this%input_mempath)
+    call memorystore_release('BOUNDNAME', this%input_mempath)
   end subroutine csub_source_packagedata
 
   !> @ brief Print packagedata
@@ -2308,7 +2321,7 @@ contains
 
     call mem_setptr(cellids, 'CELLID', this%input_mempath)
     call mem_set_value(this%nbound, 'NBOUND', this%input_mempath, &
-                       found)
+                       found, release=.false.)
 
     ! -- setup table for period data
     if (this%iprpak /= 0) then

--- a/src/Model/GroundWaterFlow/gwf-npf.f90
+++ b/src/Model/GroundWaterFlow/gwf-npf.f90
@@ -1585,7 +1585,7 @@ contains
     ! -- modules
     use SimModule, only: count_errors, store_error
     use MemoryManagerModule, only: mem_reallocate
-    use MemoryManagerExtModule, only: mem_set_value
+    use MemoryManagerExtModule, only: mem_set_value, memorystore_release
     use GwfNpfInputModule, only: GwfNpfParamFoundType
     ! -- dummy
     class(GwfNpftype) :: this
@@ -1602,7 +1602,8 @@ contains
     ! -- update defaults with idm sourced values
     call mem_set_value(this%icelltype, 'ICELLTYPE', this%input_mempath, map, &
                        found%icelltype)
-    call mem_set_value(this%k11, 'K', this%input_mempath, map, found%k)
+    call mem_set_value(this%k11, 'K', this%input_mempath, map, found%k, &
+                       release=.false.)
     call mem_set_value(this%k33, 'K33', this%input_mempath, map, found%k33)
     call mem_set_value(this%k22, 'K22', this%input_mempath, map, found%k22)
     call mem_set_value(this%wetdry, 'WETDRY', this%input_mempath, map, &
@@ -1648,10 +1649,12 @@ contains
     !
     ! -- handle not found side effects
     if (.not. found%k33) then
-      call mem_set_value(this%k33, 'K', this%input_mempath, map, afound(1))
+      call mem_set_value(this%k33, 'K', this%input_mempath, map, afound(1), &
+                         release=.false.)
     end if
     if (.not. found%k22) then
-      call mem_set_value(this%k22, 'K', this%input_mempath, map, afound(2))
+      call mem_set_value(this%k22, 'K', this%input_mempath, map, afound(2), &
+                         release=.false.)
     end if
     if (.not. found%wetdry) call mem_reallocate(this%wetdry, 1, 'WETDRY', &
                                                 trim(this%memoryPath))
@@ -1661,6 +1664,9 @@ contains
       call mem_reallocate(this%angle2, 0, 'ANGLE2', trim(this%memoryPath))
     if (.not. found%angle3 .and. this%ixt3d == 0) &
       call mem_reallocate(this%angle3, 0, 'ANGLE3', trim(this%memoryPath))
+    !
+    ! -- cleanup
+    call memorystore_release('K', this%input_mempath)
     !
     ! -- log griddata
     if (this%iout > 0) then

--- a/src/Model/GroundWaterFlow/gwf-vsc.f90
+++ b/src/Model/GroundWaterFlow/gwf-vsc.f90
@@ -976,6 +976,7 @@ contains
   subroutine source_packagedata(this)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr
+    use MemoryManagerExtModule, only: memorystore_release
     use CharacterStringModule, only: CharacterStringType
     ! -- dummy
     class(GwfVscType), intent(inout) :: this
@@ -1071,6 +1072,12 @@ contains
 
     ! deallocate
     deallocate (itemp)
+
+    call memorystore_release('IVISCSPEC', this%input_mempath)
+    call memorystore_release('DVISCDC', this%input_mempath)
+    call memorystore_release('CVISCREF', this%input_mempath)
+    call memorystore_release('MODELNAME', this%input_mempath)
+    call memorystore_release('AUXSPECIESNAME', this%input_mempath)
   end subroutine source_packagedata
 
   !> @brief Sets package data instead of reading from file

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -153,7 +153,7 @@ contains
     if (.not. this%readasarrays) then
       ! -- copy nbound from input context
       call mem_set_value(this%nbound, 'NBOUND', this%input_mempath, &
-                         found)
+                         found, release=.false.)
     end if
 
     if (this%readarraygrid) then
@@ -306,12 +306,13 @@ contains
     integer(I4B) :: n
     !
     ! -- update defaults with idm sourced values
-    call mem_set_value(this%naux, 'NAUX', this%input_mempath, found%naux)
+    call mem_set_value(this%naux, 'NAUX', this%input_mempath, found%naux, &
+                       release=.false.)
     call mem_set_value(this%ipakcb, 'IPAKCB', this%input_mempath, found%ipakcb)
     call mem_set_value(this%iprpak, 'IPRPAK', this%input_mempath, found%iprpak)
     call mem_set_value(this%iprflow, 'IPRFLOW', this%input_mempath, found%iprflow)
     call mem_set_value(this%inamedbound, 'BOUNDNAMES', this%input_mempath, &
-                       found%boundnames)
+                       found%boundnames, release=.false.)
     call mem_set_value(sfacauxname, 'AUXMULTNAME', this%input_mempath, &
                        found%auxmultname)
     call mem_set_value(this%inewton, 'INEWTON', this%input_mempath, found%inewton)
@@ -330,7 +331,7 @@ contains
       call mem_reallocate(this%auxname_cst, LENAUXNAME, this%naux, &
                           'AUXNAME_CST', this%memoryPath)
       call mem_set_value(this%auxname_cst, 'AUXILIARY', this%input_mempath, &
-                         found%auxiliary)
+                         found%auxiliary, release=.false.)
       !
       do n = 1, this%naux
         this%auxname(n) = this%auxname_cst(n)
@@ -480,7 +481,7 @@ contains
 
       ! -- update defaults with idm sourced values
       call mem_set_value(this%maxbound, 'MAXBOUND', this%input_mempath, &
-                         found%maxbound)
+                         found%maxbound, release=.false.)
 
       write (this%iout, '(4x,a,i7)') 'MAXBOUND = ', this%maxbound
 

--- a/src/Model/ModelUtilities/FlowModelInterface.f90
+++ b/src/Model/ModelUtilities/FlowModelInterface.f90
@@ -342,7 +342,7 @@ contains
   subroutine source_packagedata(this)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr
-    use MemoryManagerExtModule, only: mem_set_value
+    use MemoryManagerExtModule, only: mem_set_value, memorystore_release
     use CharacterStringModule, only: CharacterStringType
     use OpenSpecModule, only: ACCESS, FORM
     use ConstantsModule, only: LINELENGTH, DEM6, LENPACKAGENAME
@@ -422,6 +422,10 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
+
+    call memorystore_release('FLOWTYPE', this%input_mempath)
+    call memorystore_release('FILEIN', this%input_mempath)
+    call memorystore_release('FNAME', this%input_mempath)
   end subroutine source_packagedata
 
   !> @brief Read/validate flow model grid

--- a/src/Model/ParticleTracking/prt-oc.f90
+++ b/src/Model/ParticleTracking/prt-oc.f90
@@ -336,7 +336,7 @@ contains
   !> @brief source the tracking times block.
   subroutine prt_oc_source_tracktimes(this)
     use ParticleTracksModule, only: TRACKHEADER, TRACKDTYPES
-    use MemoryManagerExtModule, only: mem_set_value
+    use MemoryManagerExtModule, only: mem_set_value, memorystore_release
     use MemoryManagerModule, only: mem_setptr, get_isize
     ! dummy
     class(PrtOcType), intent(inout) :: this
@@ -370,6 +370,8 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end if
+
+    call memorystore_release('TIME', this%input_mempath)
   end subroutine prt_oc_source_tracktimes
 
 end module PrtOcModule

--- a/src/Model/ParticleTracking/prt-oc.f90
+++ b/src/Model/ParticleTracking/prt-oc.f90
@@ -336,7 +336,7 @@ contains
   !> @brief source the tracking times block.
   subroutine prt_oc_source_tracktimes(this)
     use ParticleTracksModule, only: TRACKHEADER, TRACKDTYPES
-    use MemoryManagerExtModule, only: mem_set_value, memorystore_release
+    use MemoryManagerExtModule, only: mem_set_value
     use MemoryManagerModule, only: mem_setptr, get_isize
     ! dummy
     class(PrtOcType), intent(inout) :: this
@@ -370,8 +370,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end if
-
-    call memorystore_release('TIME', this%input_mempath)
   end subroutine prt_oc_source_tracktimes
 
 end module PrtOcModule

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -1073,6 +1073,7 @@ contains
   !> @brief Load package data (release points).
   subroutine prp_packagedata(this)
     use MemoryManagerModule, only: mem_setptr
+    use MemoryManagerExtModule, only: memorystore_release
     use GeomUtilModule, only: get_node
     use CharacterStringModule, only: CharacterStringType
     ! dummy
@@ -1203,6 +1204,13 @@ contains
 
     ! cleanup
     deallocate (nboundchk)
+
+    call memorystore_release('IRPTNO', this%input_mempath)
+    call memorystore_release('CELLID', this%input_mempath)
+    call memorystore_release('XRPT', this%input_mempath)
+    call memorystore_release('YRPT', this%input_mempath)
+    call memorystore_release('ZRPT', this%input_mempath)
+    call memorystore_release('BOUNDNAME', this%input_mempath)
   end subroutine prp_packagedata
 
   !> @brief Load explicitly specified release times.

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -1210,6 +1210,7 @@ contains
     call memorystore_release('XRPT', this%input_mempath)
     call memorystore_release('YRPT', this%input_mempath)
     call memorystore_release('ZRPT', this%input_mempath)
+    call memorystore_release('BOUNDNAME', this%input_mempath)
   end subroutine prp_packagedata
 
   !> @brief Load explicitly specified release times.

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -1210,7 +1210,6 @@ contains
     call memorystore_release('XRPT', this%input_mempath)
     call memorystore_release('YRPT', this%input_mempath)
     call memorystore_release('ZRPT', this%input_mempath)
-    call memorystore_release('BOUNDNAME', this%input_mempath)
   end subroutine prp_packagedata
 
   !> @brief Load explicitly specified release times.

--- a/src/Model/SurfaceWaterFlow/swf-dfw.f90
+++ b/src/Model/SurfaceWaterFlow/swf-dfw.f90
@@ -292,7 +292,7 @@ contains
     ! modules
     use KindModule, only: LGP
     use InputOutputModule, only: getunit, openfile
-    use MemoryManagerExtModule, only: mem_set_value
+    use MemoryManagerExtModule, only: mem_set_value, memorystore_release
     use CharacterStringModule, only: CharacterStringType
     use SwfDfwInputModule, only: SwfDfwParamFoundType
     ! dummy
@@ -351,6 +351,8 @@ contains
       call openfile(this%inobspkg, this%iout, this%obs%inputFilename, 'OBS')
       call this%obs%obs_df(this%iout, this%packName, this%filtyp, this%dis)
       call this%dfw_df_obs()
+
+      call memorystore_release('OBS6_FILENAME', this%input_mempath)
     end if
 
     ! log values to list file

--- a/src/Model/TransportModel/tsp-fmi.f90
+++ b/src/Model/TransportModel/tsp-fmi.f90
@@ -558,7 +558,7 @@ contains
   subroutine gwtfmi_source_packagedata(this)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr
-    use MemoryManagerExtModule, only: mem_set_value
+    use MemoryManagerExtModule, only: mem_set_value, memorystore_release
     use CharacterStringModule, only: CharacterStringType
     use OpenSpecModule, only: ACCESS, FORM
     use ConstantsModule, only: LINELENGTH, DEM6, LENPACKAGENAME
@@ -651,6 +651,10 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
+
+    call memorystore_release('FLOWTYPE', this%input_mempath)
+    call memorystore_release('FILEIN', this%input_mempath)
+    call memorystore_release('FNAME', this%input_mempath)
   end subroutine gwtfmi_source_packagedata
 
   !> @brief Set the pointer to a budget object

--- a/src/Model/TransportModel/tsp-ssm.f90
+++ b/src/Model/TransportModel/tsp-ssm.f90
@@ -772,6 +772,7 @@ contains
     ! -- modules
     !use KindModule, only: LGP
     use MemoryManagerModule, only: mem_setptr
+    use MemoryManagerExtModule, only: memorystore_release
     use CharacterStringModule, only: CharacterStringType
     ! -- dummy
     class(TspSsmType) :: this
@@ -842,6 +843,10 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
+
+    call memorystore_release('PNAME_SOURCES', this%input_mempath)
+    call memorystore_release('SRCTYPE', this%input_mempath)
+    call memorystore_release('AUXNAME', this%input_mempath)
   end subroutine source_sources
 
   !> @brief Source fileinput input block
@@ -851,6 +856,7 @@ contains
   subroutine source_fileinput(this)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr, get_isize
+    use MemoryManagerExtModule, only: memorystore_release
     use CharacterStringModule, only: CharacterStringType
     ! -- dummy
     class(TspSsmType) :: this
@@ -949,6 +955,13 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
+
+    call memorystore_release('PNAME', this%input_mempath)
+    call memorystore_release('SPC6', this%input_mempath)
+    call memorystore_release('FILEIN', this%input_mempath)
+    call memorystore_release('SPC6_FILENAME', this%input_mempath)
+    call memorystore_release('MIXED', this%input_mempath)
+    call memorystore_release('SPC6_MEMPATH', this%input_mempath)
   end subroutine source_fileinput
 
   !> @ brief Set iauxpak array value for package ip

--- a/src/Utilities/Export/DisNCStructured.f90
+++ b/src/Utilities/Export/DisNCStructured.f90
@@ -708,7 +708,8 @@ contains
       ! export input arrays
       if (mempath /= '') then
         ! update export
-        call mem_set_value(export_arrays, 'EXPORT_NC', mempath, found)
+        call mem_set_value(export_arrays, 'EXPORT_NC', mempath, found, &
+                           release=.false.)
 
         if (export_arrays > 0) then
           pkgtype = idm_subcomponent_type(this%modeltype, ptype)

--- a/src/Utilities/Export/DisvNCMesh.f90
+++ b/src/Utilities/Export/DisvNCMesh.f90
@@ -407,13 +407,8 @@ contains
   subroutine add_mesh_data(this)
     use BaseDisModule, only: dis_transform_xy
     class(Mesh2dDisvExportType), intent(inout) :: this
-    integer(I4B), dimension(:), contiguous, pointer :: icell2d => null()
     integer(I4B), dimension(:), contiguous, pointer :: ncvert => null()
     integer(I4B), dimension(:), contiguous, pointer :: icvert => null()
-    real(DP), dimension(:), contiguous, pointer :: cell_x => null()
-    real(DP), dimension(:), contiguous, pointer :: cell_y => null()
-    real(DP), dimension(:), contiguous, pointer :: vert_x => null()
-    real(DP), dimension(:), contiguous, pointer :: vert_y => null()
     real(DP), dimension(:), contiguous, pointer :: cell_xt => null()
     real(DP), dimension(:), contiguous, pointer :: cell_yt => null()
     real(DP), dimension(:), contiguous, pointer :: vert_xt => null()
@@ -425,27 +420,22 @@ contains
     integer(I4B) :: istop
 
     ! set pointers to input context
-    call mem_setptr(icell2d, 'ICELL2D', this%dis_mempath)
     call mem_setptr(ncvert, 'NCVERT', this%dis_mempath)
     call mem_setptr(icvert, 'ICVERT', this%dis_mempath)
-    call mem_setptr(cell_x, 'XC', this%dis_mempath)
-    call mem_setptr(cell_y, 'YC', this%dis_mempath)
-    call mem_setptr(vert_x, 'XV', this%dis_mempath)
-    call mem_setptr(vert_y, 'YV', this%dis_mempath)
 
     ! allocate x, y transform arrays
-    allocate (cell_xt(size(cell_x)))
-    allocate (cell_yt(size(cell_y)))
-    allocate (vert_xt(size(vert_x)))
-    allocate (vert_yt(size(vert_y)))
+    allocate (cell_xt(this%disv%ncpl))
+    allocate (cell_yt(this%disv%ncpl))
+    allocate (vert_xt(this%disv%nvert))
+    allocate (vert_yt(this%disv%nvert))
 
     ! set mesh container variable value to 1
     call nf_verify(nf90_put_var(this%ncid, this%var_ids%mesh, 1), &
                    this%nc_fname)
 
     ! transform vert x and y
-    do n = 1, size(vert_x)
-      call dis_transform_xy(vert_x(n), vert_y(n), &
+    do n = 1, this%disv%nvert
+      call dis_transform_xy(this%disv%vertices(1, n), this%disv%vertices(2, n), &
                             this%disv%xorigin, &
                             this%disv%yorigin, &
                             this%disv%angrot, &
@@ -455,8 +445,8 @@ contains
     end do
 
     ! transform cell x and y
-    do n = 1, size(cell_x)
-      call dis_transform_xy(cell_x(n), cell_y(n), &
+    do n = 1, this%disv%ncpl
+      call dis_transform_xy(this%disv%cellxy(1, n), this%disv%cellxy(2, n), &
                             this%disv%xorigin, &
                             this%disv%yorigin, &
                             this%disv%angrot, &
@@ -486,7 +476,7 @@ contains
 
     ! set face nodes array
     cnt = 0
-    do n = 1, size(ncvert)
+    do n = 1, this%disv%ncpl
       verts = NF90_FILL_INT
       idx = cnt + ncvert(n)
       iv = 0

--- a/src/Utilities/Export/MeshNCModel.f90
+++ b/src/Utilities/Export/MeshNCModel.f90
@@ -412,7 +412,8 @@ contains
       ! export input arrays
       if (mempath /= '') then
         ! update export
-        call mem_set_value(export_arrays, 'EXPORT_NC', mempath, found)
+        call mem_set_value(export_arrays, 'EXPORT_NC', mempath, found, &
+                           release=.false.)
         if (export_arrays > 0) then
           pkgtype = idm_subcomponent_type(this%modeltype, ptype)
           param_dfns => param_definitions(this%modeltype, pkgtype)

--- a/src/Utilities/Export/NCExportCreate.f90
+++ b/src/Utilities/Export/NCExportCreate.f90
@@ -175,7 +175,8 @@ contains
 
       ! update export arrays option
       call mem_set_value(export_arrays, 'EXPORT_NC', &
-                         dynamic_pkg%mf6_input%mempath, found)
+                         dynamic_pkg%mf6_input%mempath, found, &
+                         release=.false.)
 
       readasarrays = (dynamic_pkg%readasarrays .or. dynamic_pkg%readarraygrid)
       if (export_arrays > 0 .and. readasarrays) then

--- a/src/Utilities/Idm/LoadContext.f90
+++ b/src/Utilities/Idm/LoadContext.f90
@@ -979,7 +979,7 @@ contains
     logical(LGP) :: found
     allocate (intptr)
     intptr = 0
-    call mem_set_value(intptr, varname, mempath, found)
+    call mem_set_value(intptr, varname, mempath, found, release=.false.)
   end subroutine setval
 
   !> @brief set intptr to varname

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -42,6 +42,7 @@ module MemoryManagerModule
 
   public :: memorystore
   public :: mem_print_detailed
+  public :: mem_release
 
   type(MemoryStoreType) :: memorystore
   type(TableType), pointer :: memtab => null()
@@ -2649,6 +2650,40 @@ contains
     end do
 
   end function calc_virtual_mem
+
+  !> @brief Release a memory store entry: deallocate data and update counters
+  !!
+  !! Deallocates the data held by mt, zeroes mt%isize, and decrements the
+  !! appropriate nvalues_* counter for master entries. no-op when data has
+  !! already been released.
+  !<
+  subroutine mem_release(mt)
+    type(MemoryType), pointer, intent(inout) :: mt
+
+    if (.not. mt%mt_associated()) return
+
+    if (mt%master) then
+      if (mt%memtype(1:6) == 'STRING') then
+        ! nvalues_astr increments differ: scalar adds element_size (ilen),
+        ! arrays (str1d, charstr1d) add isize only. For IDM release the
+        ! variables are arrays, so decrement by isize to match.
+        if (mt%isize == 1) then
+          nvalues_astr = nvalues_astr - mt%element_size
+        else
+          nvalues_astr = nvalues_astr - mt%isize
+        end if
+      else if (mt%memtype(1:7) == 'LOGICAL') then
+        nvalues_alogical = nvalues_alogical - mt%isize
+      else if (mt%memtype(1:7) == 'INTEGER') then
+        nvalues_aint = nvalues_aint - mt%isize
+      else if (mt%memtype(1:6) == 'DOUBLE') then
+        nvalues_adbl = nvalues_adbl - mt%isize
+      end if
+    end if
+
+    call mt%mt_deallocate()
+    mt%isize = 0
+  end subroutine mem_release
 
   !> @brief Deallocate memory in the memory manager
   !<

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -2655,7 +2655,8 @@ contains
   !!
   !! Deallocates the data held by mt, zeroes mt%isize, and decrements the
   !! appropriate nvalues_* counter for master entries. no-op when data has
-  !! already been released.
+  !! already been released. Primarily intended to support the release of
+  !! input context memory prior to simulation runtime.
   !<
   subroutine mem_release(mt)
     type(MemoryType), pointer, intent(inout) :: mt

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -797,7 +797,7 @@ contains
     end if
     !
     ! -- update counter
-    nvalues_aint = nvalues_aint + 1
+    nvalues_adbl = nvalues_adbl + 1
     !
     ! -- allocate memory type
     allocate (mt)

--- a/src/Utilities/Memory/MemoryManagerExt.f90
+++ b/src/Utilities/Memory/MemoryManagerExt.f90
@@ -2,6 +2,8 @@ module MemoryManagerExtModule
 
   use KindModule, only: DP, LGP, I4B, I8B
   use SimModule, only: store_error
+  use ConstantsModule, only: MVALIDATE
+  use SimVariablesModule, only: isim_mode
   use MemoryTypeModule, only: MemoryType
   use MemoryManagerModule, only: memorystore, get_from_memorystore
   use MemoryContainerIteratorModule, only: MemoryContainerIteratorType
@@ -10,6 +12,13 @@ module MemoryManagerExtModule
   private
   public :: mem_set_value
   public :: memorystore_remove
+  public :: memorystore_release
+
+  ! NOTE(deferred): When release deallocates input context memory, mt%isize and
+  ! the nvalues_* counters in MemoryManagerModule are not updated. This means
+  ! mem_summary_total will report inflated per-type totals (INTEGER, REAL, etc.)
+  ! until a follow-on change zeroes mt%isize in mt_deallocate and decrements the
+  ! nvalues_* counters accordingly.
 
   interface mem_set_value
     module procedure mem_set_value_logical, mem_set_value_int, &
@@ -44,6 +53,8 @@ contains
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
+        ! guard: mt_associated() is false for entries already released via
+        ! mem_set_value(..., release=.true.) prior to this call
         if (mt%path == memory_path .and. mt%mt_associated()) then
           call mt%mt_deallocate()
           removed = .true.
@@ -54,95 +65,148 @@ contains
     end do
   end subroutine memorystore_remove
 
-  !> @brief Set pointer to value of memory list logical variable
+  !> @brief Release a single variable from the memory store
+  !!
+  !! Looks up the variable by name and path and deallocates its data.
+  !! Safe to call when the variable is not found or was already released.
   !<
-  subroutine mem_set_value_logical(p_mem, varname, memory_path, found)
-    logical(LGP), pointer, intent(inout) :: p_mem !< pointer to logical scalar
+  subroutine memorystore_release(varname, memory_path)
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
-    logical(LGP), intent(inout) :: found
     type(MemoryType), pointer :: mt
+    logical(LGP) :: found
     logical(LGP) :: checkfail = .false.
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: already released
+    if (isim_mode /= MVALIDATE) call mt%mt_deallocate()
+  end subroutine memorystore_release
+
+  !> @brief Set pointer to value of memory list logical variable
+  !<
+  subroutine mem_set_value_logical(p_mem, varname, memory_path, found, release)
+    logical(LGP), pointer, intent(inout) :: p_mem !< pointer to logical scalar
+    character(len=*), intent(in) :: varname !< variable name
+    character(len=*), intent(in) :: memory_path !< path where variable is stored
+    logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
+    type(MemoryType), pointer :: mt
+    logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
+
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
+    if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       if (mt%intsclr == 0) then
         p_mem = .false.
       else
         p_mem = .true.
       end if
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_logical
 
   !> @brief Set pointer to value of memory list int variable
   !<
-  subroutine mem_set_value_int(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_int(p_mem, varname, memory_path, found, release)
     integer(I4B), pointer, intent(inout) :: p_mem !< pointer to int scalar
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       p_mem = mt%intsclr
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_int
 
-  subroutine mem_set_value_int_setval(p_mem, varname, memory_path, setval, found)
+  subroutine mem_set_value_int_setval(p_mem, varname, memory_path, setval, &
+                                      found, release)
     integer(I4B), pointer, intent(inout) :: p_mem !< pointer to int scalar
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     integer(I4B), intent(in) :: setval !< set p_mem to setval if varname found
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
 
     p_mem = setval
-
+    if (do_release) call mt%mt_deallocate()
   end subroutine mem_set_value_int_setval
 
-  subroutine mem_set_value_str_mapped_int(p_mem, varname, memory_path, str_list, &
-                                          found)
+  subroutine mem_set_value_str_mapped_int(p_mem, varname, memory_path, &
+                                          str_list, found, release)
     integer(I4B), pointer, intent(inout) :: p_mem !< pointer to int scalar
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     character(len=*), dimension(:), intent(in) :: str_list
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: i
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
       do i = 1, size(str_list)
         if (mt%strsclr == str_list(i)) then
           p_mem = i
         end if
       end do
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_str_mapped_int
 
   !> @brief Set pointer to value of memory list 1d logical array variable
   !<
-  subroutine mem_set_value_logical1d(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_logical1d(p_mem, varname, memory_path, found, &
+                                     release)
     logical(LGP), dimension(:), pointer, contiguous, intent(inout) :: p_mem !< pointer to 1d logical array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: n
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'LOGICAL') then
       if (size(mt%alogical1d) /= size(p_mem)) then
         call store_error('mem_set_value() size mismatch logical1d, varname='//&
@@ -151,24 +215,31 @@ contains
       do n = 1, size(mt%alogical1d)
         p_mem(n) = mt%alogical1d(n)
       end do
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_logical1d
 
   !> @brief Set pointer to value of memory list 1d logical array variable with mapping
   !<
   subroutine mem_set_value_logical1d_mapped(p_mem, varname, memory_path, map, &
-                                            found)
+                                            found, release)
     logical(LGP), dimension(:), pointer, contiguous, intent(inout) :: p_mem !< pointer to 1d logical array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     integer(I4B), dimension(:), pointer, contiguous, intent(in) :: map !< pointer to 1d int mapping array
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: n
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'LOGICAL') then
       if (associated(map)) then
         do n = 1, size(p_mem)
@@ -183,22 +254,29 @@ contains
           p_mem(n) = mt%alogical1d(n)
         end do
       end if
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_logical1d_mapped
 
   !> @brief Set pointer to value of memory list 1d int array variable
   !<
-  subroutine mem_set_value_int1d(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_int1d(p_mem, varname, memory_path, found, release)
     integer(I4B), dimension(:), pointer, contiguous, intent(inout) :: p_mem !< pointer to 1d int array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: n
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       if (size(mt%aint1d) /= size(p_mem)) then
         call store_error('mem_set_value() size mismatch int1d, varname='//&
@@ -207,24 +285,31 @@ contains
       do n = 1, size(mt%aint1d)
         p_mem(n) = mt%aint1d(n)
       end do
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_int1d
 
   !> @brief Set pointer to value of memory list 1d int array variable with mapping
   !<
   subroutine mem_set_value_int1d_mapped(p_mem, varname, memory_path, map, &
-                                        found)
+                                        found, release)
     integer(I4B), dimension(:), pointer, contiguous, intent(inout) :: p_mem !< pointer to 1d int array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     integer(I4B), dimension(:), pointer, contiguous, intent(in) :: map !< pointer to 1d int mapping array
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: n
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       if (associated(map)) then
         do n = 1, size(p_mem)
@@ -239,22 +324,29 @@ contains
           p_mem(n) = mt%aint1d(n)
         end do
       end if
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_int1d_mapped
 
   !> @brief Set pointer to value of memory list 2d int array variable
   !<
-  subroutine mem_set_value_int2d(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_int2d(p_mem, varname, memory_path, found, release)
     integer(I4B), dimension(:, :), pointer, contiguous, intent(inout) :: p_mem !< pointer to 2d int array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: i, j
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       if (size(mt%aint2d, dim=1) /= size(p_mem, dim=1) .or. &
           size(mt%aint2d, dim=2) /= size(p_mem, dim=2)) then
@@ -266,22 +358,29 @@ contains
           p_mem(i, j) = mt%aint2d(i, j)
         end do
       end do
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_int2d
 
   !> @brief Set pointer to value of memory list 3d int array variable
   !<
-  subroutine mem_set_value_int3d(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_int3d(p_mem, varname, memory_path, found, release)
     integer(I4B), dimension(:, :, :), pointer, contiguous, intent(inout) :: p_mem !< pointer to 3d int array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: i, j, k
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       if (size(mt%aint3d, dim=1) /= size(p_mem, dim=1) .or. &
           size(mt%aint3d, dim=2) /= size(p_mem, dim=2) .or. &
@@ -296,39 +395,53 @@ contains
           end do
         end do
       end do
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_int3d
 
   !> @brief Set pointer to value of memory list double variable
   !<
-  subroutine mem_set_value_dbl(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_dbl(p_mem, varname, memory_path, found, release)
     real(DP), pointer, intent(inout) :: p_mem !< pointer to dbl scalar
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       p_mem = mt%dblsclr
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_dbl
 
   !> @brief Set pointer to value of memory list 1d dbl array variable
   !<
-  subroutine mem_set_value_dbl1d(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_dbl1d(p_mem, varname, memory_path, found, release)
     real(DP), dimension(:), pointer, contiguous, intent(inout) :: p_mem !< pointer to 1d dbl array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: n
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       if (size(mt%adbl1d) /= size(p_mem)) then
         call store_error('mem_set_value() size mismatch dbl1d, varname='//&
@@ -337,24 +450,31 @@ contains
       do n = 1, size(mt%adbl1d)
         p_mem(n) = mt%adbl1d(n)
       end do
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_dbl1d
 
   !> @brief Set pointer to value of memory list 1d dbl array variable with mapping
   !<
   subroutine mem_set_value_dbl1d_mapped(p_mem, varname, memory_path, map, &
-                                        found)
+                                        found, release)
     real(DP), dimension(:), pointer, contiguous, intent(inout) :: p_mem !< pointer to 1d dbl array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     integer(I4B), dimension(:), pointer, contiguous, intent(in) :: map !< pointer to 1d int mapping array
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: n
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       if (associated(map)) then
         do n = 1, size(p_mem)
@@ -369,22 +489,29 @@ contains
           p_mem(n) = mt%adbl1d(n)
         end do
       end if
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_dbl1d_mapped
 
   !> @brief Set pointer to value of memory list 2d dbl array variable
   !<
-  subroutine mem_set_value_dbl2d(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_dbl2d(p_mem, varname, memory_path, found, release)
     real(DP), dimension(:, :), pointer, contiguous, intent(inout) :: p_mem !< pointer to 2d dbl array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: i, j
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       if (size(mt%adbl2d, dim=1) /= size(p_mem, dim=1) .or. &
           size(mt%adbl2d, dim=2) /= size(p_mem, dim=2)) then
@@ -396,22 +523,29 @@ contains
           p_mem(i, j) = mt%adbl2d(i, j)
         end do
       end do
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_dbl2d
 
   !> @brief Set pointer to value of memory list 3d dbl array variable
   !<
-  subroutine mem_set_value_dbl3d(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_dbl3d(p_mem, varname, memory_path, found, release)
     real(DP), dimension(:, :, :), pointer, contiguous, intent(inout) :: p_mem !< pointer to 3d dbl array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: i, j, k
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       if (size(mt%adbl3d, dim=1) /= size(p_mem, dim=1) .or. &
           size(mt%adbl3d, dim=2) /= size(p_mem, dim=2) .or. &
@@ -426,41 +560,57 @@ contains
           end do
         end do
       end do
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_dbl3d
 
-  subroutine mem_set_value_str(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_str(p_mem, varname, memory_path, found, release)
     character(len=*), intent(inout) :: p_mem !< pointer to str scalar
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
       p_mem = mt%strsclr
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_str
 
-  subroutine mem_set_value_charstr1d(p_mem, varname, memory_path, found)
+  subroutine mem_set_value_charstr1d(p_mem, varname, memory_path, found, &
+                                     release)
     use CharacterStringModule, only: CharacterStringType
     type(CharacterStringType), dimension(:), &
       pointer, contiguous, intent(inout) :: p_mem !< pointer to charstr 1d array
     character(len=*), intent(in) :: varname !< variable name
     character(len=*), intent(in) :: memory_path !< path where variable is stored
     logical(LGP), intent(inout) :: found
+    logical(LGP), intent(in), optional :: release !< if true (default), deallocate input context memory after copy
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
+    logical(LGP) :: do_release
     integer(I4B) :: n
+
+    do_release = (isim_mode /= MVALIDATE)
+    if (present(release)) do_release = release
 
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
+    if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
       do n = 1, size(mt%acharstr1d)
         p_mem(n) = mt%acharstr1d(n)
       end do
+      if (do_release) call mt%mt_deallocate()
     end if
   end subroutine mem_set_value_charstr1d
 

--- a/src/Utilities/Memory/MemoryManagerExt.f90
+++ b/src/Utilities/Memory/MemoryManagerExt.f90
@@ -5,7 +5,7 @@ module MemoryManagerExtModule
   use ConstantsModule, only: MVALIDATE
   use SimVariablesModule, only: isim_mode
   use MemoryTypeModule, only: MemoryType
-  use MemoryManagerModule, only: memorystore, get_from_memorystore
+  use MemoryManagerModule, only: memorystore, get_from_memorystore, mem_release
   use MemoryContainerIteratorModule, only: MemoryContainerIteratorType
 
   implicit none
@@ -13,12 +13,6 @@ module MemoryManagerExtModule
   public :: mem_set_value
   public :: memorystore_remove
   public :: memorystore_release
-
-  ! NOTE(deferred): When release deallocates input context memory, mt%isize and
-  ! the nvalues_* counters in MemoryManagerModule are not updated. This means
-  ! mem_summary_total will report inflated per-type totals (INTEGER, REAL, etc.)
-  ! until a follow-on change zeroes mt%isize in mt_deallocate and decrements the
-  ! nvalues_* counters accordingly.
 
   interface mem_set_value
     module procedure mem_set_value_logical, mem_set_value_int, &
@@ -56,7 +50,7 @@ contains
         ! guard: mt_associated() is false for entries already released via
         ! mem_set_value(..., release=.true.) prior to this call
         if (mt%path == memory_path .and. mt%mt_associated()) then
-          call mt%mt_deallocate()
+          call mem_release(mt)
           removed = .true.
           deallocate (itr)
           exit
@@ -80,7 +74,7 @@ contains
     call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (.not. mt%mt_associated()) return ! guard: already released
-    if (isim_mode /= MVALIDATE) call mt%mt_deallocate()
+    if (isim_mode /= MVALIDATE) call mem_release(mt)
   end subroutine memorystore_release
 
   !> @brief Set pointer to value of memory list logical variable
@@ -107,7 +101,7 @@ contains
       else
         p_mem = .true.
       end if
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_logical
 
@@ -131,7 +125,7 @@ contains
     if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       p_mem = mt%intsclr
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_int
 
@@ -155,7 +149,7 @@ contains
     if (.not. mt%mt_associated()) return ! guard: entry was previously released
 
     p_mem = setval
-    if (do_release) call mt%mt_deallocate()
+    if (do_release) call mem_release(mt)
   end subroutine mem_set_value_int_setval
 
   subroutine mem_set_value_str_mapped_int(p_mem, varname, memory_path, &
@@ -183,7 +177,7 @@ contains
           p_mem = i
         end if
       end do
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_str_mapped_int
 
@@ -215,7 +209,7 @@ contains
       do n = 1, size(mt%alogical1d)
         p_mem(n) = mt%alogical1d(n)
       end do
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_logical1d
 
@@ -254,7 +248,7 @@ contains
           p_mem(n) = mt%alogical1d(n)
         end do
       end if
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_logical1d_mapped
 
@@ -285,7 +279,7 @@ contains
       do n = 1, size(mt%aint1d)
         p_mem(n) = mt%aint1d(n)
       end do
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_int1d
 
@@ -324,7 +318,7 @@ contains
           p_mem(n) = mt%aint1d(n)
         end do
       end if
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_int1d_mapped
 
@@ -358,7 +352,7 @@ contains
           p_mem(i, j) = mt%aint2d(i, j)
         end do
       end do
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_int2d
 
@@ -395,7 +389,7 @@ contains
           end do
         end do
       end do
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_int3d
 
@@ -419,7 +413,7 @@ contains
     if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       p_mem = mt%dblsclr
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_dbl
 
@@ -450,7 +444,7 @@ contains
       do n = 1, size(mt%adbl1d)
         p_mem(n) = mt%adbl1d(n)
       end do
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_dbl1d
 
@@ -489,7 +483,7 @@ contains
           p_mem(n) = mt%adbl1d(n)
         end do
       end if
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_dbl1d_mapped
 
@@ -523,7 +517,7 @@ contains
           p_mem(i, j) = mt%adbl2d(i, j)
         end do
       end do
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_dbl2d
 
@@ -560,7 +554,7 @@ contains
           end do
         end do
       end do
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_dbl3d
 
@@ -582,7 +576,7 @@ contains
     if (.not. mt%mt_associated()) return ! guard: entry was previously released
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
       p_mem = mt%strsclr
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_str
 
@@ -610,7 +604,7 @@ contains
       do n = 1, size(mt%acharstr1d)
         p_mem(n) = mt%acharstr1d(n)
       end do
-      if (do_release) call mt%mt_deallocate()
+      if (do_release) call mem_release(mt)
     end if
   end subroutine mem_set_value_charstr1d
 

--- a/src/Utilities/Memory/MemoryManagerExt.f90
+++ b/src/Utilities/Memory/MemoryManagerExt.f90
@@ -50,7 +50,7 @@ contains
         ! guard: mt_associated() is false for entries already released via
         ! mem_set_value(..., release=.true.) prior to this call
         if (mt%path == memory_path .and. mt%mt_associated()) then
-          call mem_release(mt)
+          call mt%mt_deallocate()
           removed = .true.
           deallocate (itr)
           exit


### PR DESCRIPTION
Support memory manager per parameter input context deallocation before the numerical model is run.  Significant (>10%) reduction in allocated memory possible; most input context memory not read over the course of the simulation is released before it begins. There are 2 mechanisms:
  - `mem_set_value()` interfaces now take an optional release argument that deallocates memory after copy
  - added `memorystore_release()` which takes arguments for any parameter memory location

Memory counters are updated as part of the deallocation so that memory usage reflects the adjustment.  For comparison, here are local usage (`mfsim.lst`) comparisons with the develop branch for 2 autotests:
  - `npf01a_75x75`: Total => develop: 3.72361 MB;  branch:  3.33675 MB  | difference: 0.38686 MB (10.4%)
  - `csub_subwt02a`: Total => develop: 1.08720 MB; branch:  0.91232 MB  │ difference: 0.17488 MB (16.1%)
 
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Added doxygen comments to new and modified procedures
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
