### PR TITLE
Revert "fix(prt): use exclusive lower bound when solving usertimes (#2760)"

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -33,8 +33,3 @@ description = "When a MVR connection was included as part of an exchange between
 section = "fixes"
 subsection = "model"
 description = "The Flow Model Interface (FMI) package for transport and tracking models conducts TDIS compatibility checks during each stress period to ensure that the model's time discretization is compatible with that of the flow model. In particular, if a flow model stress period has just one time step, the transport or tracking model may have any number of time steps. However, if a flow model stress period has more than one time step, the transport or tracking model must have the same number of time steps. Simulations would previously stop with an error if the transport or tracking model violated this rule for any stress periods up to the simulation's last, but would not raise an error for the last stress period. The compatibility check was updated to include the last stress period. Simulations will now stop with an error if the transport or tracking model violates this rule for any stress period in the simulation."
-
-[[items]]
-section = "fixes"
-subsection = "model"
-description = "Fixed an issue with PRT which could cause double-reporting of user-defined tracking time events."

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -1029,7 +1029,7 @@ contains
     ! dummy
     class(PrtModelType) :: this
     ! local
-    integer(I4B) :: np, ip, i
+    integer(I4B) :: np, ip
     class(BndType), pointer :: packobj
     type(ParticleType), pointer :: particle
     real(DP) :: tmax
@@ -1063,20 +1063,7 @@ contains
           if (particle%istatus > ACTIVE) cycle ! Skip terminated particles
           particle%istatus = ACTIVE ! Set active status in case of release
           ! If the particle was released this time step, emit a release event
-          if (particle%trelease >= totimc) then
-            call this%method%release(particle)
-            ! Emit a usertime event if a user time coincides with release time
-            call this%method%tracktimes%advance()
-            if (this%method%tracktimes%any()) then
-              do i = this%method%tracktimes%selection(1), &
-                this%method%tracktimes%selection(2)
-                if (this%method%tracktimes%times(i) == particle%trelease) then
-                  call this%method%usertime(particle)
-                  exit
-                end if
-              end do
-            end if
-          end if
+          if (particle%trelease >= totimc) call this%method%release(particle)
           ! Maximum time is the end of the time step or the particle
           ! stop time, whichever comes first, unless it's the final
           ! time step and the extend option is on, in which case

--- a/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
@@ -155,7 +155,7 @@ contains
     if (this%tracktimes%any()) then
       do i = this%tracktimes%selection(1), this%tracktimes%selection(2)
         t = this%tracktimes%times(i)
-        if (t <= t0) cycle
+        if (t < particle%ttrack) cycle
         if (t > texit .or. t > tmax) exit
         dt = t - t0
         x = new_x(exit_x%v, exit_x%dvdx, subcell%vx1, subcell%vx2, &

--- a/src/Solution/ParticleTracker/Method/MethodSubcellTernary.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellTernary.f90
@@ -144,7 +144,7 @@ contains
     if (this%tracktimes%any()) then
       do i = this%tracktimes%selection(1), this%tracktimes%selection(2)
         t = this%tracktimes%times(i)
-        if (t <= t0) cycle
+        if (t < t0) cycle
         if (t > texit .or. t > tmax) exit
         dt = t - t0
         call calculate_xyz_position(dt, &


### PR DESCRIPTION
Revert 7ea75ae82b6bfcbb5a09d185b9694e2f45073cd8, misguided attempt to set up for a separate fix. Needs further consideration.