### PR TITLE
feat(fmi) Expose the cell saturated fraction to the other models

### DIFF
--- a/src/Exchange/exg-gwfgwe.f90
+++ b/src/Exchange/exg-gwfgwe.f90
@@ -265,6 +265,10 @@ contains
     call mem_checkin(gwemodel%fmi%gwfsat, &
                      'GWFSAT', gwemodel%fmi%memoryPath, &
                      'SAT', gwfmodel%npf%memoryPath)
+    gwemodel%fmi%gwfsat_old => gwfmodel%npf%sat_old
+    call mem_checkin(gwemodel%fmi%gwfsat_old, &
+                     'GWFSAT_OLD', gwemodel%fmi%memoryPath, &
+                     'SAT_OLD', gwfmodel%npf%memoryPath)
     gwemodel%fmi%gwfspdis => gwfmodel%npf%spdis
     call mem_checkin(gwemodel%fmi%gwfspdis, &
                      'GWFSPDIS', gwemodel%fmi%memoryPath, &

--- a/src/Exchange/exg-gwfgwt.f90
+++ b/src/Exchange/exg-gwfgwt.f90
@@ -268,6 +268,10 @@ contains
     call mem_checkin(gwtmodel%fmi%gwfsat, &
                      'GWFSAT', gwtmodel%fmi%memoryPath, &
                      'SAT', gwfmodel%npf%memoryPath)
+    gwtmodel%fmi%gwfsat_old => gwfmodel%npf%sat_old
+    call mem_checkin(gwtmodel%fmi%gwfsat_old, &
+                     'GWFSAT_OLD', gwtmodel%fmi%memoryPath, &
+                     'SAT_OLD', gwfmodel%npf%memoryPath)
     gwtmodel%fmi%gwfspdis => gwfmodel%npf%spdis
     call mem_checkin(gwtmodel%fmi%gwfspdis, &
                      'GWFSPDIS', gwtmodel%fmi%memoryPath, &

--- a/src/Model/Connection/GwtInterfaceModel.f90
+++ b/src/Model/Connection/GwtInterfaceModel.f90
@@ -118,6 +118,8 @@ contains
                       this%fmi%memoryPath)
     call mem_allocate(this%fmi%gwfsat, this%neq, 'GWFSAT', &
                       this%fmi%memoryPath)
+    call mem_allocate(this%fmi%gwfsat_old, this%neq, 'GWFSAT_OLD', &
+                      this%fmi%memoryPath)
     call mem_allocate(this%fmi%gwfspdis, 3, this%neq, 'GWFSPDIS', &
                       this%fmi%memoryPath)
   end subroutine allocate_fmi

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -227,11 +227,10 @@ contains
       !
       ! -- calculate new and old water volumes and solid volume
       vcell = this%dis%area(n) * (this%dis%top(n) - this%dis%bot(n))
-      vnew = vcell * this%fmi%gwfsat(n) * this%porosity(n)
-      vold = vnew
-      if (this%fmi%igwfstrgss /= 0) vold = vold + this%fmi%gwfstrgss(n) * delt
-      if (this%fmi%igwfstrgsy /= 0) vold = vold + this%fmi%gwfstrgsy(n) * delt
       vsolid = vcell * (DONE - this%porosity(n))
+
+      vnew = vcell * this%fmi%gwfsat(n) * this%porosity(n)
+      vold = vcell * this%fmi%gwfsat_old(n) * this%porosity(n)
       !
       ! -- add terms to diagonal and rhs accumulators
       term = (this%rhos(n) * this%cps(n)) * vsolid
@@ -400,13 +399,9 @@ contains
       !
       ! -- calculate new and old water volumes and solid volume
       vcell = this%dis%area(n) * (this%dis%top(n) - this%dis%bot(n))
-      vwatnew = vcell * this%fmi%gwfsat(n) * this%porosity(n)
-      vwatold = vwatnew
-      if (this%fmi%igwfstrgss /= 0) vwatold = vwatold + this%fmi%gwfstrgss(n) &
-                                              * delt
-      if (this%fmi%igwfstrgsy /= 0) vwatold = vwatold + this%fmi%gwfstrgsy(n) &
-                                              * delt
       vsolid = vcell * (DONE - this%porosity(n))
+      vwatnew = vcell * this%fmi%gwfsat(n) * this%porosity(n)
+      vwatold = vcell * this%fmi%gwfsat_old(n) * this%porosity(n)
       !
       ! -- calculate rate
       term = (this%rhos(n) * this%cps(n)) * vsolid

--- a/src/Model/GroundWaterFlow/gwf-npf.f90
+++ b/src/Model/GroundWaterFlow/gwf-npf.f90
@@ -38,6 +38,7 @@ module GwfNpfModule
     type(Xt3dType), pointer :: xt3d => null() !< xt3d pointer
     integer(I4B), pointer :: iname => null() !< length of variable names
     character(len=24), dimension(:), pointer :: aname => null() !< variable names
+    integer(I4B), pointer :: iss => null() !< steady state flag: 1 = steady, 0 = transient
     integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !< pointer to model ibound
     real(DP), dimension(:), pointer, contiguous :: hnew => null() !< pointer to model xnew
     integer(I4B), pointer :: ixt3d => null() !< xt3d flag (0 is off, 1 is lhs, 2 is rhs)
@@ -84,6 +85,7 @@ module GwfNpfModule
     integer(I4B), pointer :: iwetdry => null() !< flag to indicate angle1 was read
     real(DP), dimension(:), pointer, contiguous :: wetdry => null() !< wetdry array
     real(DP), dimension(:), pointer, contiguous :: sat => null() !< saturation (0. to 1.) for each cell
+    real(DP), dimension(:), pointer, contiguous :: sat_old => null() !< saturation (0. to 1.) for each cell
     real(DP), dimension(:), pointer, contiguous :: condsat => null() !< saturated conductance (symmetric array)
     integer(I4B), dimension(:), pointer, contiguous :: ibotnode => null() !< bottom node used if igwfnewtonur /= 0
     ! spdis machinery:
@@ -286,6 +288,7 @@ contains
   subroutine npf_ar(this, ic, vsc, ibound, hnew)
     ! -- modules
     use MemoryManagerModule, only: mem_reallocate
+    use MemoryHelperModule, only: create_mem_path
     ! -- dummy
     class(GwfNpftype) :: this !< instance of the NPF package
     type(GwfIcType), pointer, intent(in) :: ic !< initial conditions
@@ -299,6 +302,9 @@ contains
     this%ic => ic
     this%ibound => ibound
     this%hnew => hnew
+    !
+    ! -- set pointer to gwf iss
+    call mem_setptr(this%iss, 'ISS', create_mem_path(this%name_model))
     !
     if (this%icalcspdis == 1) then
       call mem_reallocate(this%spdis, 3, this%dis%nodes, 'SPDIS', this%memoryPath)
@@ -391,6 +397,7 @@ contains
     integer(I4B), intent(in) :: irestore
     ! -- local
     integer(I4B) :: n
+    real(DP) :: satn
     !
     ! -- loop through all cells and set hold=bot if wettable cell is dry
     if (this%irewet > 0) then
@@ -407,6 +414,20 @@ contains
         hnew(n) = DHDRY
       end do
     end if
+    !
+    ! -- store old saturation
+    do n = 1, this%dis%nodes
+      if (this%icelltype(n) /= 0) then
+        if (this%ibound(n) == 0) then
+          satn = DZERO
+        else
+          call this%thksat(n, hold(n), satn)
+        end if
+      else
+        satn = DONE
+      end if
+      this%sat_old(n) = satn
+    end do
     !
     ! -- TVK
     if (this%intvk /= 0) then
@@ -814,6 +835,13 @@ contains
       end do
       !
     end if
+
+    ! -- for steady state, sat_old = sat
+    if (this%iss == 1) then
+      do n = 1, this%dis%nodes
+        this%sat_old(n) = this%sat(n)
+      end do
+    end if
   end subroutine npf_cq
 
   !> @brief Fractional cell saturation
@@ -1071,6 +1099,7 @@ contains
     call mem_deallocate(this%k22input)
     call mem_deallocate(this%k33input)
     call mem_deallocate(this%sat, 'SAT', this%memoryPath)
+    call mem_deallocate(this%sat_old, 'SAT_OLD', this%memoryPath)
     call mem_deallocate(this%condsat)
     call mem_deallocate(this%wetdry)
     call mem_deallocate(this%angle1)
@@ -1229,6 +1258,7 @@ contains
     call mem_allocate(this%icelltype, ncells, 'ICELLTYPE', this%memoryPath)
     call mem_allocate(this%k11, ncells, 'K11', this%memoryPath)
     call mem_allocate(this%sat, ncells, 'SAT', this%memoryPath)
+    call mem_allocate(this%sat_old, ncells, 'SAT_OLD', this%memoryPath)
     call mem_allocate(this%condsat, njas, 'CONDSAT', this%memoryPath)
     !
     ! -- Optional arrays dimensioned to full size initially

--- a/src/Model/GroundWaterTransport/gwt-ist.f90
+++ b/src/Model/GroundWaterTransport/gwt-ist.f90
@@ -317,7 +317,7 @@ contains
       ! calculate new and old water volumes
       vcell = this%dis%area(n) * (this%dis%top(n) - this%dis%bot(n))
       swtpdt = this%fmi%gwfsat(n)
-      swt = this%fmi%gwfsatold(n, delt)
+      swt = this%fmi%gwfsat_old(n)
       thetaim = this%get_thetaim(n)
       idiag = ia(n)
 
@@ -447,7 +447,7 @@ contains
         ! calculate new and old water volumes
         vcell = this%dis%area(n) * (this%dis%top(n) - this%dis%bot(n))
         swtpdt = this%fmi%gwfsat(n)
-        swt = this%fmi%gwfsatold(n, delt)
+        swt = this%fmi%gwfsat_old(n)
         thetaim = this%get_thetaim(n)
 
         ! set exchange coefficient

--- a/src/Model/GroundWaterTransport/gwt-mst.f90
+++ b/src/Model/GroundWaterTransport/gwt-mst.f90
@@ -230,6 +230,7 @@ contains
     real(DP) :: tled
     real(DP) :: hhcof, rrhs
     real(DP) :: vnew, vold
+    real(DP) :: Vcell
     !
     ! -- set variables
     tled = DONE / delt
@@ -241,11 +242,9 @@ contains
       if (this%ibound(n) <= 0) cycle
       !
       ! -- calculate new and old water volumes
-      vnew = this%dis%area(n) * (this%dis%top(n) - this%dis%bot(n)) * &
-             this%fmi%gwfsat(n) * this%thetam(n)
-      vold = vnew
-      if (this%fmi%igwfstrgss /= 0) vold = vold + this%fmi%gwfstrgss(n) * delt
-      if (this%fmi%igwfstrgsy /= 0) vold = vold + this%fmi%gwfstrgsy(n) * delt
+      Vcell = this%dis%area(n) * (this%dis%top(n) - this%dis%bot(n))
+      vnew = Vcell * this%fmi%gwfsat(n) * this%thetam(n)
+      vold = Vcell * this%fmi%gwfsat_old(n) * this%thetam(n)
       !
       ! -- add terms to diagonal and rhs accumulators
       hhcof = -vnew * tled
@@ -356,7 +355,7 @@ contains
       volfracm = this%get_volfracm(n)
       rhobm = this%bulk_density(n)
       sat_new = this%fmi%gwfsat(n)
-      sat_old = this%fmi%gwfsatold(n, delt)
+      sat_old = this%fmi%gwfsat_old(n)
 
       ! -- Matrix contribution for sorption term
       hhcof = -volfracm * rhobm * sat_new * this%isotherm%derivative(cnew, n) &
@@ -530,6 +529,7 @@ contains
     real(DP) :: rate
     real(DP) :: tled
     real(DP) :: vnew, vold
+    real(DP) :: Vcell
     real(DP) :: hhcof, rrhs
     !
     ! -- initialize
@@ -543,11 +543,9 @@ contains
       if (this%ibound(n) <= 0) cycle
       !
       ! -- calculate new and old water volumes
-      vnew = this%dis%area(n) * (this%dis%top(n) - this%dis%bot(n)) * &
-             this%fmi%gwfsat(n) * this%thetam(n)
-      vold = vnew
-      if (this%fmi%igwfstrgss /= 0) vold = vold + this%fmi%gwfstrgss(n) * delt
-      if (this%fmi%igwfstrgsy /= 0) vold = vold + this%fmi%gwfstrgsy(n) * delt
+      Vcell = this%dis%area(n) * (this%dis%top(n) - this%dis%bot(n))
+      vnew = Vcell * this%fmi%gwfsat(n) * this%thetam(n)
+      vold = Vcell * this%fmi%gwfsat_old(n) * this%thetam(n)
       !
       ! -- calculate rate
       hhcof = -vnew * tled
@@ -658,7 +656,7 @@ contains
       rhobm = this%bulk_density(n)
       volfracm = this%get_volfracm(n)
       sat_new = this%fmi%gwfsat(n)
-      sat_old = this%fmi%gwfsatold(n, delt)
+      sat_old = this%fmi%gwfsat_old(n)
 
       ! -- Matrix contribution for sorption term
       contribution = -volfracm * rhobm * sat_new &

--- a/src/Model/ModelUtilities/FlowModelInterface.f90
+++ b/src/Model/ModelUtilities/FlowModelInterface.f90
@@ -31,6 +31,7 @@ module FlowModelInterfaceModule
     real(DP), dimension(:, :), pointer, contiguous :: gwfspdis => null() !< pointer to npf specific discharge array
     real(DP), dimension(:), pointer, contiguous :: gwfhead => null() !< pointer to the GWF head array
     real(DP), dimension(:), pointer, contiguous :: gwfsat => null() !< pointer to the GWF saturation array
+    real(DP), dimension(:), pointer, contiguous :: gwfsat_old => null() !< pointer to the GWF saturation array
     integer(I4B), dimension(:), pointer, contiguous :: ibdgwfsat0 => null() !< mark cells with saturation = 0 to exclude from dispersion
     integer(I4B), pointer :: idryinactive => null() !< mark cells with an additional flag to exclude from deactivation (gwe will simulate conduction through dry cells)
     real(DP), dimension(:), pointer, contiguous :: gwfstrgss => null() !< pointer to flow model QSTOSS
@@ -178,6 +179,7 @@ contains
     ! -- special treatment, these could be from mem_checkin
     call mem_deallocate(this%gwfhead, 'GWFHEAD', this%memoryPath)
     call mem_deallocate(this%gwfsat, 'GWFSAT', this%memoryPath)
+    call mem_deallocate(this%gwfsat_old, 'GWFSAT_OLD', this%memoryPath)
     call mem_deallocate(this%gwfspdis, 'GWFSPDIS', this%memoryPath)
     call mem_deallocate(this%gwfflowja, 'GWFFLOWJA', this%memoryPath)
     !
@@ -267,10 +269,12 @@ contains
       call mem_allocate(this%gwfflowja, this%dis%con%nja, &
                         'GWFFLOWJA', this%memoryPath)
       call mem_allocate(this%gwfsat, nodes, 'GWFSAT', this%memoryPath)
+      call mem_allocate(this%gwfsat_old, nodes, 'GWFSAT_OLD', this%memoryPath)
       call mem_allocate(this%gwfhead, nodes, 'GWFHEAD', this%memoryPath)
       call mem_allocate(this%gwfspdis, 3, nodes, 'GWFSPDIS', this%memoryPath)
       do n = 1, nodes
         this%gwfsat(n) = DONE
+        this%gwfsat_old(n) = DONE
         this%gwfhead(n) = DZERO
         this%gwfspdis(:, n) = DZERO
       end do
@@ -698,6 +702,7 @@ contains
               nr = this%dis%get_nodenumber(nu, 0)
               if (nr <= 0) cycle
               this%gwfsat(nr) = this%bfr%auxvar(1, i)
+              this%gwfsat_old(nr) = this%bfr%auxvar(1, i)
             end do
           case ('STO-SS')
             do nu = 1, this%dis%nodesuser

--- a/src/Model/TransportModel/tsp-fmi.f90
+++ b/src/Model/TransportModel/tsp-fmi.f90
@@ -57,7 +57,6 @@ module TspFmiModule
     procedure :: fmi_bd
     procedure :: fmi_ot_flow
     procedure :: fmi_da => gwtfmi_da
-    procedure :: gwfsatold
     procedure :: initialize_gwfterms_from_bfr
     procedure :: initialize_gwfterms_from_gwfbndlist
     procedure :: source_options => gwtfmi_source_options
@@ -494,33 +493,6 @@ contains
       end if
     end do
   end subroutine set_active_status
-
-  !> @brief Calculate the previous saturation level
-  !!
-  !! Calculate the groundwater cell head saturation for the end of
-  !! the last time step
-  !<
-  function gwfsatold(this, n, delt) result(satold)
-    ! -- modules
-    ! -- dummy
-    class(TspFmiType) :: this
-    integer(I4B), intent(in) :: n
-    real(DP), intent(in) :: delt
-    ! -- result
-    real(DP) :: satold
-    ! -- local
-    real(DP) :: vcell
-    real(DP) :: vnew
-    real(DP) :: vold
-    !
-    ! -- calculate the value
-    vcell = this%dis%area(n) * (this%dis%top(n) - this%dis%bot(n))
-    vnew = vcell * this%gwfsat(n)
-    vold = vnew
-    if (this%igwfstrgss /= 0) vold = vold + this%gwfstrgss(n) * delt
-    if (this%igwfstrgsy /= 0) vold = vold + this%gwfstrgsy(n) * delt
-    satold = vold / vcell
-  end function gwfsatold
 
   !> @ brief Source input options for package
   !<


### PR DESCRIPTION
In the Transport and Energy models the saturation, $S_w$, is required in the mst and est packages.
However these values aren't exposed through the FMI. 
Instead they are computed using the gwfstrgss and gwfstrgsy rates.

mst:
 $f_{storage} = \frac{ \partial \left(S_w \theta C\right)}{\partial t}$

There are several reasons to switch to using the saturation directly:
- The code becomes clearer. We can now recognize the equation as is stated in the documentation
- The computation from rate to cell saturation works fine for confined cases, but when we are working with unconfined cases their is an additional requirement that needs to be fulfilled i.e. Sy = theta
- My main motive for this change is In preparation of the higher order time integration. For that i need to store saturation for multiple older timesteps (or compute it using gwfstrgss  and gwfstrgsy but that means that i have to store those for multiple time steps). This change makes it possible to do.

**Note**
After this change we can almost entirely get rid of gwfstrgss and gwfstrgsy in the FMI. It only being used in 1 place in the prt-fmi file.


Checklist of items for pull request

- [ ] Replaced section above with description of pull request
- [ ] Closed issue #xxxx
- [ ] Referenced issue or pull request #xxxx
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
