### PR TITLE
fix(disu): use nodesuser for CELLID range check in get_nodenumber_idx1

### DIFF
--- a/autotest/test_gwf_disu_hfb_idomain.py
+++ b/autotest/test_gwf_disu_hfb_idomain.py
@@ -1,0 +1,86 @@
+"""
+Regression test for issue #2772.
+
+Build a 3x3x3 DISU model, deactivate one cell via IDOMAIN, then add an
+HFB barrier whose CELLIDs use user (full-grid) node numbers that exceed
+the active-cell count. Both endpoints of the barrier are active and
+adjacent. The HFB IO guide documents CELLID for DISU as a user node
+number, so this should run cleanly.
+
+Prior to the fix in `Disu.f90:get_nodenumber_idx1`, the range check used
+`this%nodes` (reduced/active count) rather than `this%nodesuser`,
+inconsistent with the equivalent checks in DISV/DISV2D. Reading the HFB
+file then failed with:
+
+    Node number (N) is less than 1 or greater than nodes (n_active).
+"""
+
+from pathlib import Path
+
+import flopy
+import numpy as np
+import pytest
+from flopy.utils.gridutil import get_disu_kwargs
+from framework import TestFramework
+
+cases = ["disuhfb"]
+
+
+def build_models(idx, test):
+    name = cases[idx]
+    ws = test.workspace
+    nlay, nrow, ncol = 3, 3, 3
+    delr = 10.0 * np.ones(ncol)
+    delc = 10.0 * np.ones(nrow)
+    top = 0.0
+    botm = [-10.0, -20.0, -30.0]
+    disukwargs = get_disu_kwargs(nlay, nrow, ncol, delr, delc, top, botm)
+    # Deactivate user node 2 so n_active = 26 < n_user = 27
+    idomain = np.ones((nlay, nrow * ncol), dtype=int)
+    idomain[0, 1] = 0
+    disukwargs["idomain"] = idomain
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    flopy.mf6.ModflowTdis(sim)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
+    flopy.mf6.ModflowIms(sim, print_option="SUMMARY")
+    flopy.mf6.ModflowGwfdisu(gwf, **disukwargs)
+    flopy.mf6.ModflowGwfic(gwf, strt=0.0)
+    flopy.mf6.ModflowGwfnpf(gwf)
+    # CHD on first and last user cells (both active)
+    flopy.mf6.ModflowGwfchd(
+        gwf, stress_period_data=[[(0,), 1.0], [(nlay * nrow * ncol - 1), 0.0]]
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf, head_filerecord=f"{name}.hds", saverecord=[("HEAD", "ALL")]
+    )
+
+    # HFB pair (26, 27): user IDs that span the active/inactive threshold.
+    # Both cells are active and laterally adjacent in the bottom layer.
+    hfb_data = [[(25,), (26,), 1.0e-6]]
+    flopy.mf6.ModflowGwfhfb(gwf, stress_period_data={0: hfb_data})
+
+    return sim, None
+
+
+def check_output(idx, test):
+    name = cases[idx]
+    sim = flopy.mf6.MFSimulation.load(sim_ws=test.workspace)
+    gwf = sim.get_model(name)
+    head = gwf.output.head().get_data()
+    assert np.all(np.isfinite(head)), "head should be finite everywhere active"
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        compare=None,
+    )
+    test.run()

--- a/autotest/test_gwf_disu_hfb_idomain.py
+++ b/autotest/test_gwf_disu_hfb_idomain.py
@@ -15,8 +15,6 @@ file then failed with:
     Node number (N) is less than 1 or greater than nodes (n_active).
 """
 
-from pathlib import Path
-
 import flopy
 import numpy as np
 import pytest

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -37,4 +37,4 @@ description = "The Flow Model Interface (FMI) package for transport and tracking
 [[items]]
 section = "fixes"
 subsection = "internal"
-description = "When a horizontal flow barrier is placed bewteen two cells, MODFLOW checks to ensure that the cells are adjacent.  This check did not function correctly for DISU grids, in some cases, if the IDOMAIN functionality was used to remove cells.  The check for two adjacent DISU cells was corrected to work for IDOMAIN functionality."
+description = "When a horizontal flow barrier is placed between two cells, MODFLOW checks to ensure that the cells are adjacent.  This check did not function correctly for DISU grids, in some cases, if the IDOMAIN functionality was used to remove cells.  The check for two adjacent DISU cells was corrected to work for IDOMAIN functionality."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -33,3 +33,8 @@ description = "When a MVR connection was included as part of an exchange between
 section = "fixes"
 subsection = "model"
 description = "The Flow Model Interface (FMI) package for transport and tracking models conducts TDIS compatibility checks during each stress period to ensure that the model's time discretization is compatible with that of the flow model. In particular, if a flow model stress period has just one time step, the transport or tracking model may have any number of time steps. However, if a flow model stress period has more than one time step, the transport or tracking model must have the same number of time steps. Simulations would previously stop with an error if the transport or tracking model violated this rule for any stress periods up to the simulation's last, but would not raise an error for the last stress period. The compatibility check was updated to include the last stress period. Simulations will now stop with an error if the transport or tracking model violates this rule for any stress period in the simulation."
+
+[[items]]
+section = "fixes"
+subsection = "internal"
+description = "When a horizontal flow barrier is placed bewteen two cells, MODFLOW checks to ensure that the cells are adjacent.  This check did not function correctly for DISU grids, in some cases, if the IDOMAIN functionality was used to remove cells.  The check for two adjacent DISU cells was corrected to work for IDOMAIN functionality."

--- a/src/Model/Discretization/Disu.f90
+++ b/src/Model/Discretization/Disu.f90
@@ -1064,10 +1064,10 @@ contains
     integer(I4B) :: nodenumber
     !
     if (icheck /= 0) then
-      if (nodeu < 1 .or. nodeu > this%nodes) then
+      if (nodeu < 1 .or. nodeu > this%nodesuser) then
         write (errmsg, '(a,i0,a,i0,a)') &
           'Node number (', nodeu, ') is less than 1 or greater than nodes (', &
-          this%nodes, ').'
+          this%nodesuser, ').'
         call store_error(errmsg)
       end if
     end if


### PR DESCRIPTION
## Summary

Fixes #2772.

`Disu%get_nodenumber_idx1` checked `nodeu > this%nodes` (reduced/active count) instead of `nodeu > this%nodesuser`. The equivalent checks in `Disv.f90:937` and `Disv2d.f90:878` already use `nodesuser`, and the function indexes `this%nodereduced` (sized `nodesuser`) on the next line, so the original bound was inconsistent with both the function's contract and the sibling implementations.

The bug was latent until a caller passed `icheck=1`. The HFB rewrite (now using `dis%get_nodenumber(nodeu, 1)` directly rather than going through `noder_from_cellid`, which uses `icheck=0`) exposed it: HFB `CELLID`s using user node numbers above the active-cell count are rejected with "Node number (N) is less than 1 or greater than nodes (n_active)", even when the cell is active and the user node number is valid per the MF6 IO guide.

## Changes

- `src/Model/Discretization/Disu.f90`: change the bound from `this%nodes` to `this%nodesuser` (one place, two lines).
- `autotest/test_gwf_disu_hfb_idomain.py`: regression test. Builds a 3x3x3 DISU via `get_disu_kwargs`, deactivates one cell so `n_active = 26 < n_user = 27`, then adds an HFB barrier between user cells 26 and 27 (both active, laterally adjacent in the bottom layer). Pre-fix: errors with `Node number (27) is less than 1 or greater than nodes (26)`. Post-fix: runs cleanly.

## Test plan

- [x] Regression test reproduces the failure on stock 6.7.0 (verified locally with the same model setup).
- [ ] CI runs the full autotest suite.