### PR TITLE
Petsc 3.25 upgrade

### DIFF
--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -93,3 +93,4 @@ runs:
         set PKG_CONFIG_PATH=%PKG_CONFIG_PATH%;%GITHUB_WORKSPACE%\petsc\install\lib\pkgconfig
         echo PKG_CONFIG_PATH=%PKG_CONFIG_PATH%>>%GITHUB_ENV%
         echo %GITHUB_WORKSPACE%\petsc\install\bin>>%GITHUB_PATH%
+        echo %GITHUB_WORKSPACE%\petsc\install\lib>>%GITHUB_PATH%

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -37,9 +37,9 @@ runs:
       if: steps.petsc-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        curl https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.20.5.tar.gz -O -J
+        curl https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.25.0.tar.gz -O -J
         mkdir petsc
-        tar -xzf petsc-3.20.5.tar.gz -C petsc --strip-components=1
+        tar -xzf petsc-3.25.0.tar.gz -C petsc --strip-components=1
 
     - name: Setup Cygwin
       if: steps.petsc-cache.outputs.cache-hit != 'true'
@@ -64,6 +64,20 @@ runs:
       run: |
         "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "C:\tools\cygwin\bin\bash.exe" --login --norc -eo pipefail -o igncr "%TEMP%\compile_petsc.sh"
 
+    - name: Fix PETSc.pc paths
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        PETSC_PC="$GITHUB_WORKSPACE/petsc/install/lib/pkgconfig/PETSc.pc"
+        if [ -f "$PETSC_PC" ]; then
+          # Convert cygwin paths to Windows paths
+          sed -i 's|/cygdrive/\([a-z]\)/|\U\1:/|g' "$PETSC_PC"
+          echo "Fixed PETSc.pc paths:"
+          cat "$PETSC_PC"
+        else
+          echo "Warning: PETSc.pc not found at $PETSC_PC"
+        fi
+
     - name: Save PETSc cache
       if: steps.petsc-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3
@@ -74,8 +88,6 @@ runs:
     - name: Setup PETSC environment
       shell: cmd
       run: |
-        set PETSC_DIR=%GITHUB_WORKSPACE%\petsc
-        set PETSC_ARCH=arch-mswin-c-opt
-        echo PETSC_DIR=%PETSC_DIR%>>%GITHUB_ENV%
-        echo PETSC_ARCH=%PETSC_ARCH%>>%GITHUB_ENV%
-        echo %PETSC_DIR%\%PETSC_ARCH%\lib>>%GITHUB_PATH%
+        set PKG_CONFIG_PATH=%PKG_CONFIG_PATH%;%GITHUB_WORKSPACE%\petsc\install\lib\pkgconfig
+        echo PKG_CONFIG_PATH=%PKG_CONFIG_PATH%>>%GITHUB_ENV%
+        echo %GITHUB_WORKSPACE%\petsc\install\bin>>%GITHUB_PATH%

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -66,13 +66,14 @@ runs:
 
     - name: Fix PETSc.pc paths
       if: steps.petsc-cache.outputs.cache-hit != 'true'
-      shell: bash
+      shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
       run: |
         PETSC_PC="$GITHUB_WORKSPACE/petsc/install/lib/pkgconfig/PETSc.pc"
         if [ -f "$PETSC_PC" ]; then
-          # Convert cygwin paths to Windows paths (/cygdrive/c/ -> C:/)
-          # Git bash sed doesn't support \U, so handle common drive letters explicitly
-          sed -i 's|/cygdrive/c/|C:/|g; s|/cygdrive/d/|D:/|g; s|/cygdrive/e/|E:/|g' "$PETSC_PC"
+          # Convert cygwin paths to Windows paths
+          sed -i 's|/cygdrive/c/|C:/|g' "$PETSC_PC"
+          sed -i 's|/cygdrive/d/|D:/|g' "$PETSC_PC"
+          sed -i 's|/cygdrive/e/|E:/|g' "$PETSC_PC"
           echo "Fixed PETSc.pc paths:"
           cat "$PETSC_PC"
         else

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -26,12 +26,12 @@ runs:
     - name: Setup oneAPI
       uses: ./modflow6/.github/actions/setup-par-oneapi
 
-    # - name: Restore PETSc cache
-    #   id: petsc-cache
-    #   uses: actions/cache/restore@v3
-    #   with:
-    #     path: petsc
-    #     key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+    - name: Restore PETSc cache
+      id: petsc-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: petsc
+        key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
     - name: Download PETSc
       if: steps.petsc-cache.outputs.cache-hit != 'true'
@@ -80,12 +80,12 @@ runs:
           echo "Warning: PETSc.pc not found at $PETSC_PC"
         fi
 
-    # - name: Save PETSc cache
-    #   if: steps.petsc-cache.outputs.cache-hit != 'true'
-    #   uses: actions/cache/save@v3
-    #   with:
-    #     path: petsc
-    #     key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+    - name: Save PETSc cache
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: petsc
+        key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
     - name: Setup PETSC environment
       shell: cmd

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -10,11 +10,13 @@ runs:
         unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\configure_petsc.sh" "%TEMP%\configure_petsc.sh"
         unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\compile_petsc.sh" "%TEMP%\compile_petsc.sh"
 
-    - name: Hide Strawberry gmake
+    - name: Hide Strawberry programs
       shell: bash
       run: |
         mkdir "$RUNNER_TEMP/strawberry"
         mv /c/Strawberry/c/bin/gmake "$RUNNER_TEMP/strawberry/gmake"
+        mv /c/Strawberry/perl/bin/pkg-config "$RUNNER_TEMP/strawberry/pkg-config"
+        mv /c/Strawberry/perl/bin/pkg-config.bat "$RUNNER_TEMP/strawberry/pkg-config.bat"
 
     - name: Get date
       id: get-date
@@ -24,12 +26,12 @@ runs:
     - name: Setup oneAPI
       uses: ./modflow6/.github/actions/setup-par-oneapi
 
-    - name: Restore PETSc cache
-      id: petsc-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: petsc
-        key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+    # - name: Restore PETSc cache
+    #   id: petsc-cache
+    #   uses: actions/cache/restore@v3
+    #   with:
+    #     path: petsc
+    #     key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
     - name: Download PETSc
       if: steps.petsc-cache.outputs.cache-hit != 'true'
@@ -78,12 +80,12 @@ runs:
           echo "Warning: PETSc.pc not found at $PETSC_PC"
         fi
 
-    - name: Save PETSc cache
-      if: steps.petsc-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
-      with:
-        path: petsc
-        key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+    # - name: Save PETSc cache
+    #   if: steps.petsc-cache.outputs.cache-hit != 'true'
+    #   uses: actions/cache/save@v3
+    #   with:
+    #     path: petsc
+    #     key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
     - name: Setup PETSC environment
       shell: cmd

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -85,6 +85,12 @@ runs:
         path: petsc
         key: petsc-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
+    - name: Restore Strawberry pkg-config
+      shell: bash
+      run: |
+        mv "$RUNNER_TEMP/strawberry/pkg-config" /c/Strawberry/perl/bin/pkg-config
+        mv "$RUNNER_TEMP/strawberry/pkg-config.bat" /c/Strawberry/perl/bin/pkg-config.bat
+
     - name: Setup PETSC environment
       shell: cmd
       run: |

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -10,13 +10,11 @@ runs:
         unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\configure_petsc.sh" "%TEMP%\configure_petsc.sh"
         unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\compile_petsc.sh" "%TEMP%\compile_petsc.sh"
 
-    - name: Hide Strawberry programs
+    - name: Hide Strawberry gmake
       shell: bash
       run: |
         mkdir "$RUNNER_TEMP/strawberry"
         mv /c/Strawberry/c/bin/gmake "$RUNNER_TEMP/strawberry/gmake"
-        mv /c/Strawberry/perl/bin/pkg-config "$RUNNER_TEMP/strawberry/pkg-config"
-        mv /c/Strawberry/perl/bin/pkg-config.bat "$RUNNER_TEMP/strawberry/pkg-config.bat"
 
     - name: Get date
       id: get-date
@@ -86,12 +84,6 @@ runs:
       with:
         path: petsc
         key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
-
-    - name: Restore Strawberry pkg-config
-      shell: bash
-      run: |
-        mv "$RUNNER_TEMP/strawberry/pkg-config" /c/Strawberry/perl/bin/pkg-config
-        mv "$RUNNER_TEMP/strawberry/pkg-config.bat" /c/Strawberry/perl/bin/pkg-config.bat
 
     - name: Setup PETSC environment
       shell: cmd

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -31,7 +31,7 @@ runs:
       uses: actions/cache/restore@v3
       with:
         path: petsc
-        key: petsc-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+        key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
     - name: Download PETSc
       if: steps.petsc-cache.outputs.cache-hit != 'true'
@@ -83,7 +83,7 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: petsc
-        key: petsc-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+        key: petsc-3.25.0-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
     - name: Restore Strawberry pkg-config
       shell: bash

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -68,7 +68,7 @@ runs:
       if: steps.petsc-cache.outputs.cache-hit != 'true'
       shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
       run: |
-        PETSC_PC="$GITHUB_WORKSPACE/petsc/install/lib/pkgconfig/PETSc.pc"
+        PETSC_PC="$(cygpath -u "$GITHUB_WORKSPACE")/petsc/install/lib/pkgconfig/PETSc.pc"
         if [ -f "$PETSC_PC" ]; then
           # Convert cygwin paths to Windows paths
           sed -i 's|/cygdrive/c/|C:/|g' "$PETSC_PC"

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -70,8 +70,9 @@ runs:
       run: |
         PETSC_PC="$GITHUB_WORKSPACE/petsc/install/lib/pkgconfig/PETSc.pc"
         if [ -f "$PETSC_PC" ]; then
-          # Convert cygwin paths to Windows paths
-          sed -i 's|/cygdrive/\([a-z]\)/|\U\1:/|g' "$PETSC_PC"
+          # Convert cygwin paths to Windows paths (/cygdrive/c/ -> C:/)
+          # Git bash sed doesn't support \U, so handle common drive letters explicitly
+          sed -i 's|/cygdrive/c/|C:/|g; s|/cygdrive/d/|D:/|g; s|/cygdrive/e/|E:/|g' "$PETSC_PC"
           echo "Fixed PETSc.pc paths:"
           cat "$PETSC_PC"
         else

--- a/.github/actions/test-extended/action.yml
+++ b/.github/actions/test-extended/action.yml
@@ -52,7 +52,7 @@ runs:
       with:
         repository: petsc/petsc
         path: petsc
-        ref: v3.22.5
+        ref: v3.25.0
 
     - name: Configure environment
       shell: bash

--- a/.github/common/compile_petsc.sh
+++ b/.github/common/compile_petsc.sh
@@ -2,4 +2,5 @@ cd "$GITHUB_WORKSPACE/petsc"
 PETSC_PREFIX=$(cygpath -u "$GITHUB_WORKSPACE/petsc")
 make all
 make check
+rm -rf "$PETSC_PREFIX/install"
 make PETSC_DIR=$PETSC_PREFIX PETSC_ARCH=arch-mswin-c-opt install

--- a/.github/common/compile_petsc.sh
+++ b/.github/common/compile_petsc.sh
@@ -1,3 +1,4 @@
 cd "$GITHUB_WORKSPACE/petsc"
 make all
 make check
+make install

--- a/.github/common/compile_petsc.sh
+++ b/.github/common/compile_petsc.sh
@@ -1,4 +1,5 @@
 cd "$GITHUB_WORKSPACE/petsc"
+PETSC_PREFIX=$(cygpath -u "$GITHUB_WORKSPACE/petsc")
 make all
 make check
-make install
+make PETSC_DIR=$PETSC_PREFIX PETSC_ARCH=arch-mswin-c-opt install

--- a/.github/common/compile_petsc.sh
+++ b/.github/common/compile_petsc.sh
@@ -2,5 +2,7 @@ cd "$GITHUB_WORKSPACE/petsc"
 PETSC_PREFIX=$(cygpath -u "$GITHUB_WORKSPACE/petsc")
 make all
 make check
+
+# We need to make sure this folder doesn't exist otherwise the install target does nothing.
 rm -rf "$PETSC_PREFIX/install"
-make PETSC_DIR=$PETSC_PREFIX PETSC_ARCH=arch-mswin-c-opt install
+make install

--- a/.github/common/configure_petsc.sh
+++ b/.github/common/configure_petsc.sh
@@ -17,6 +17,7 @@ env -i \
     --with-cc='cl' \
     --with-fc='ifort' \
     --with-cxx='cl' \
+    FPPFLAGS='-I/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/include/mpi' \
     --with-blaslapack-lib='-L/cygdrive/c/PROGRA~2/Intel/oneAPI/mkl/latest/lib mkl_intel_lp64_dll.lib mkl_sequential_dll.lib mkl_core_dll.lib' \
     --with-mpi-include='/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/include' \
     --with-mpi-lib='/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/lib/impi.lib' \

--- a/.github/common/configure_petsc.sh
+++ b/.github/common/configure_petsc.sh
@@ -1,5 +1,7 @@
 cd "$GITHUB_WORKSPACE/petsc"
+PETSC_PREFIX=$(cygpath -u "$GITHUB_WORKSPACE/petsc")/install
 ./configure \
+    --prefix="$PETSC_PREFIX" \
     --with-debugging=0 \
     --with-shared-libraries=1 \
     --with-cc='cl' \
@@ -9,4 +11,5 @@ cd "$GITHUB_WORKSPACE/petsc"
     --with-mpi-include='/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/include' \
     --with-mpi-lib='/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/lib/impi.lib' \
     --with-mpiexec='/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/bin/mpiexec -localonly' \
-    --with-python-exec='/usr/bin/PYTHON~1.EXE'
+    --with-python-exec='/usr/bin/PYTHON~1.EXE' \
+    --with-fortran-bindings='1'

--- a/.github/common/configure_petsc.sh
+++ b/.github/common/configure_petsc.sh
@@ -1,6 +1,16 @@
+# Strip down environment to prevent "xargs: environment is too large for exec" error
+# Use env -i to start with minimal environment, preserving only essentials
 cd "$GITHUB_WORKSPACE/petsc"
 PETSC_PREFIX=$(cygpath -u "$GITHUB_WORKSPACE/petsc")/install
-./configure \
+
+env -i \
+    PATH="$PATH" \
+    TEMP="$TEMP" \
+    TMP="$TMP" \
+    HOME="$HOME" \
+    INCLUDE="$INCLUDE" \
+    LIB="$LIB" \
+    ./configure \
     --prefix="$PETSC_PREFIX" \
     --with-debugging=0 \
     --with-shared-libraries=1 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,7 @@ jobs:
           copy "C:\Program Files (x86)\Intel\oneAPI\mpi\latest\bin\hydra_bstrap_proxy.exe" .
           copy "C:\Program Files (x86)\Intel\oneAPI\mpi\latest\bin\hydra_pmi_proxy.exe" .
           copy "C:\Program Files (x86)\Intel\oneAPI\mpi\latest\bin\hydra_service.exe" .
-          copy "%GITHUB_WORKSPACE%\petsc\arch-mswin-c-opt\lib\libpetsc.dll" .
+          copy "%GITHUB_WORKSPACE%\petsc\install\bin\libpetsc.dll" .
           copy "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\hdf5.dll" .
           copy "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\hdf5_hl.dll" .
           copy "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\libcurl.dll" .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,7 @@ jobs:
           copy "C:\Program Files (x86)\Intel\oneAPI\mpi\latest\bin\hydra_bstrap_proxy.exe" .
           copy "C:\Program Files (x86)\Intel\oneAPI\mpi\latest\bin\hydra_pmi_proxy.exe" .
           copy "C:\Program Files (x86)\Intel\oneAPI\mpi\latest\bin\hydra_service.exe" .
-          copy "%GITHUB_WORKSPACE%\petsc\install\bin\libpetsc.dll" .
+          copy "%GITHUB_WORKSPACE%\petsc\install\lib\libpetsc.dll" .
           copy "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\hdf5.dll" .
           copy "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\hdf5_hl.dll" .
           copy "%GITHUB_WORKSPACE%\netcdf\netCDF4.9.3-NC4-64\bin\libcurl.dll" .

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -1,5 +1,5 @@
 test_drive = dependency('test-drive', required : false)
-if test_drive.found()
+if test_drive.found() and not fc_id.contains('intel')
   tests = [
     'ArrayHandlers',
     'FeatureFlags',

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -1,5 +1,5 @@
 test_drive = dependency('test-drive', required : false)
-if test_drive.found() and not fc_id.contains('intel')
+if test_drive.found()
   tests = [
     'ArrayHandlers',
     'FeatureFlags',

--- a/meson.build
+++ b/meson.build
@@ -155,13 +155,6 @@ if is_parallel_build or is_extended_build
   dependencies += petsc
   
   with_petsc = true
-  if host_machine.system() == 'windows'
-    user32 = fc.find_library('user32', required: true)
-    gdi32 = fc.find_library('gdi32', required: true)
-    advapi32 = fc.find_library('advapi32', required: true)
-    mkl = dependency('mkl', required: true)
-    dependencies += [mkl, user32, gdi32, advapi32]
-  endif
 
   # find mpi
   if is_mpich

--- a/meson.build
+++ b/meson.build
@@ -125,13 +125,6 @@ elif is_netcdf_build
   message('NetCDF build:', is_netcdf_build)
 endif
 
-# windows options for petsc
-petsc_dir_rel = '..' /'petsc'
-petsc_dir_abs = meson.project_source_root() / '..' /'petsc'
-petsc_arch = 'arch-mswin-c-opt'
-petsc_compiled_rel = petsc_dir_rel / petsc_arch
-petsc_compiled_abs = petsc_dir_abs / petsc_arch
-
 # windows options for netcdf
 netcdf_dir_rel = '..' /'netcdf'
 netcdf_dir_abs = meson.project_source_root() / '..' / 'netcdf'
@@ -144,7 +137,7 @@ netcdff_compiled_abs = netcdf_dir_abs / netcdff_build
 
 # on windows only with intel
 if build_machine.system() == 'windows' and is_parallel_build
-  if fc_id != 'intel-cl'
+  if fc_id != 'intel-cl' and fc_id != 'intel-llvm-cl'
     error('Parallel build on Windows only with intel compiler. Terminating...')
   endif
 endif
@@ -157,15 +150,18 @@ extended_incdir = [ ]
 # load petsc, mpi, and netcdf dependencies/libraries
 if is_parallel_build or is_extended_build
   # find petsc
-  if build_machine.system() != 'windows'
-    petsc = dependency('PETSc', required : true)
-  else
-    # directly look for petsc
-    petsc = fc.find_library('libpetsc', dirs: petsc_compiled_abs / 'lib', required : true)
-  endif
+  petsc = dependency('PETSc', required : true)
   extra_cmp_args += [ '-D__WITH_PETSC__' ]
   dependencies += petsc
+  
   with_petsc = true
+  if host_machine.system() == 'windows'
+    user32 = fc.find_library('user32', required: true)
+    gdi32 = fc.find_library('gdi32', required: true)
+    advapi32 = fc.find_library('advapi32', required: true)
+    mkl = dependency('mkl', required: true)
+    dependencies += [mkl, user32, gdi32, advapi32]
+  endif
 
   # find mpi
   if is_mpich
@@ -259,31 +255,6 @@ compile_args += extra_cmp_args
 
 add_project_arguments(fc.get_supported_arguments(compile_args), language: 'fortran')
 add_project_link_arguments(fc.get_supported_arguments(link_args), language: 'fortran')
-
-if is_parallel_build and build_machine.system() == 'windows'
-  message('Compiling PETSc Fortran modules')
-  petsc_incdir = include_directories([petsc_dir_rel / 'include', petsc_compiled_rel / 'include'])
-  extended_incdir += ['..' / petsc_dir_rel / 'include', '..' / petsc_compiled_rel / 'include']
-  petsc_src = petsc_dir_abs / 'src'
-  sources_petsc = [petsc_src / 'dm/f90-mod/petscdmdamod.F90',
-                  petsc_src / 'dm/f90-mod/petscdmmod.F90',
-                  petsc_src / 'dm/f90-mod/petscdmplexmod.F90',
-                  petsc_src / 'dm/f90-mod/petscdmswarmmod.F90',
-                  petsc_src / 'ksp/f90-mod/petsckspdefmod.F90',
-                  petsc_src / 'ksp/f90-mod/petsckspmod.F90',
-                  petsc_src / 'ksp/f90-mod/petscpcmod.F90',
-                  petsc_src / 'mat/f90-mod/petscmatmod.F90',
-                  petsc_src / 'snes/f90-mod/petscsnesmod.F90',
-                  petsc_src / 'sys/f90-mod/petscsysmod.F90',
-                  petsc_src / 'sys/mpiuni/f90-mod/mpiunimod.F90',
-                  petsc_src / 'tao/f90-mod/petsctaomod.F90',
-                  petsc_src / 'ts/f90-mod/petsctsmod.F90',
-                  petsc_src / 'vec/f90-mod/petscvecmod.F90',]
-  petsc_modules = static_library('petsc_modules', 
-                                sources_petsc,
-                                dependencies: dependencies,
-                                include_directories: petsc_incdir)  
-endif
 
 # build mf6 and libmf6
 buildname = get_option('buildname')

--- a/pixi.lock
+++ b/pixi.lock
@@ -254,7 +254,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py310h6557065_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -620,7 +619,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-11.3.0-py310h35255db_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -951,7 +949,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py310h566a92c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -1256,7 +1253,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py310h5de80a5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -1934,7 +1930,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py310h6557065_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -2354,7 +2349,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-11.3.0-py310h35255db_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -2740,7 +2734,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py310h566a92c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -3100,7 +3093,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py310h5de80a5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -17157,51 +17149,6 @@ packages:
   purls: []
   size: 542795
   timestamp: 1754665193489
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
-  sha256: c9601efb1af5391317e04eca77c6fe4d716bf1ca1ad8da2a05d15cb7c28d7d4e
-  md5: 1bee70681f504ea424fb07cdb090c001
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 115175
-  timestamp: 1720805894943
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
-  sha256: 6468cbfaf1d3140be46dd315ec383d373dbbafd770ce2efe77c3f0cdbc4576c1
-  md5: 05eda637f6465f7e8c5ab7e341341ea9
-  depends:
-  - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 54834
-  timestamp: 1720806008171
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
-  sha256: 636122606556b651ad4d0ac60c7ab6b379e98f390359a1f0c05ad6ba6fb3837f
-  md5: 0b1b9f9e420e4a0e40879b61f94ae646
-  depends:
-  - __osx >=10.13
-  - libiconv >=1.17,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 239818
-  timestamp: 1720806136579
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
-  sha256: d82f4655b2d67fe12eefe1a3eea4cd27d33fa41dbc5e9aeab5fd6d3d2c26f18a
-  md5: b4f41e19a8c20184eec3aaf0f0953293
-  depends:
-  - __osx >=11.0
-  - libglib >=2.80.3,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 49724
-  timestamp: 1720806128118
 - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
   sha256: 86b0c40c8b569dbc164cb1de098ddabf4c240a5e8f38547aab00493891fa67f3
   md5: 122d6514d415fbe02c9b58aee9f6b53e

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -252,6 +254,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py310h6557065_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -617,6 +620,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-11.3.0-py310h35255db_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -947,6 +951,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py310h566a92c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -1251,6 +1256,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py310h5de80a5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -1541,6 +1547,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py310hb3a2f59_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.4-h5112557_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -1654,6 +1661,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1925,6 +1934,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py310h6557065_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -2344,6 +2354,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-11.3.0-py310h35255db_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -2729,6 +2740,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py310h566a92c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.46.4-ha059160_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -3088,6 +3100,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py310h5de80a5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -3431,6 +3444,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py310hb3a2f59_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.4-h5112557_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
@@ -17143,6 +17157,64 @@ packages:
   purls: []
   size: 542795
   timestamp: 1754665193489
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
+  sha256: c9601efb1af5391317e04eca77c6fe4d716bf1ca1ad8da2a05d15cb7c28d7d4e
+  md5: 1bee70681f504ea424fb07cdb090c001
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 115175
+  timestamp: 1720805894943
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
+  sha256: 6468cbfaf1d3140be46dd315ec383d373dbbafd770ce2efe77c3f0cdbc4576c1
+  md5: 05eda637f6465f7e8c5ab7e341341ea9
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 54834
+  timestamp: 1720806008171
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
+  sha256: 636122606556b651ad4d0ac60c7ab6b379e98f390359a1f0c05ad6ba6fb3837f
+  md5: 0b1b9f9e420e4a0e40879b61f94ae646
+  depends:
+  - __osx >=10.13
+  - libiconv >=1.17,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 239818
+  timestamp: 1720806136579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
+  sha256: d82f4655b2d67fe12eefe1a3eea4cd27d33fa41dbc5e9aeab5fd6d3d2c26f18a
+  md5: b4f41e19a8c20184eec3aaf0f0953293
+  depends:
+  - __osx >=11.0
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 49724
+  timestamp: 1720806128118
+- conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
+  sha256: 86b0c40c8b569dbc164cb1de098ddabf4c240a5e8f38547aab00493891fa67f3
+  md5: 122d6514d415fbe02c9b58aee9f6b53e
+  depends:
+  - libglib >=2.80.3,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 36118
+  timestamp: 1720806338740
 - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.4.0-pyhcf101f3_0.conda
   sha256: dfe0fa6e351d2b0cef95ac1a1533d4f960d3992f9e0f82aeb5ec3623a699896b
   md5: cc9d9a3929503785403dbfad9f707145

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ version = "6.8.0.dev0"
 
 [activation.env]
 PKG_CONFIG_PATH = """
-C:\\dev\\externals\\test-drive\\install\\icx\\lib\\pkgconfig;C:\\Program Files (x86)\\Intel\\oneAPI\\mpi\\latest\\lib\\pkgconfig;C:\\dev\\externals\\petsc\\arch-mswin-icx\\lib\\pkgconfig;
+C:\\dev\\externals\\test-drive\\install\\icx\\lib\\pkgconfig;C:\\Program Files (x86)\\Intel\\oneAPI\\mpi\\latest\\lib\\pkgconfig;C:\\dev\\externals\\petsc\\install\\arch-mswin-icx\\lib\\pkgconfig;
 """
 
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,12 +4,6 @@ channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "linux-aarch64", "osx-arm64", "osx-64"]
 version = "6.8.0.dev0"
 
-[activation.env]
-PKG_CONFIG_PATH = """
-C:\\dev\\externals\\test-drive\\install\\icx\\lib\\pkgconfig;C:\\Program Files (x86)\\Intel\\oneAPI\\mpi\\latest\\lib\\pkgconfig;C:\\dev\\externals\\petsc\\install\\arch-mswin-icx\\lib\\pkgconfig;
-"""
-
-
 [dependencies]
 appdirs = "*"
 cffconvert = "*"
@@ -101,7 +95,7 @@ fix-python-style = { cmd = "pixi run check-python-lint --fix; pixi run fix-pytho
 
 # meson build/test for mf6 and zbud6
 builddir = "echo _builddir"
-setup = { cmd = "meson setup --prefix=$(pwd) --libdir=bin --bindir=bin" }
+setup = { cmd = "meson setup --prefix=$(pwd) --libdir=bin --bindir=bin", env = { PKG_CONFIG_PATH = "$CONDA_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" } }
 build = "meson install -C"
 test = "meson test --verbose --no-rebuild -C"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,6 +4,12 @@ channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "linux-aarch64", "osx-arm64", "osx-64"]
 version = "6.8.0.dev0"
 
+[activation.env]
+PKG_CONFIG_PATH = """
+C:\\dev\\externals\\test-drive\\install\\icx\\lib\\pkgconfig;C:\\Program Files (x86)\\Intel\\oneAPI\\mpi\\latest\\lib\\pkgconfig;C:\\dev\\externals\\petsc\\arch-mswin-icx\\lib\\pkgconfig;
+"""
+
+
 [dependencies]
 appdirs = "*"
 cffconvert = "*"
@@ -95,7 +101,7 @@ fix-python-style = { cmd = "pixi run check-python-lint --fix; pixi run fix-pytho
 
 # meson build/test for mf6 and zbud6
 builddir = "echo _builddir"
-setup = { cmd = "meson setup --prefix=$(pwd) --libdir=bin --bindir=bin", env = { PKG_CONFIG_PATH = "$CONDA_PREFIX/lib/pkgconfig" } }
+setup = { cmd = "meson setup --prefix=$(pwd) --libdir=bin --bindir=bin" }
 build = "meson install -C"
 test = "meson test --verbose --no-rebuild -C"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,7 +24,6 @@ ninja = "*"
 numpy = "<2.0.0"    # modflowapi has a resriction on the numpy version
 pandas = "*"
 pip = "*"
-pkg-config = "*"
 pooch = "*"
 pydotplus = "*"
 pyshp = "*"
@@ -141,6 +140,9 @@ builddir = "echo _builddir_osx-64"
 
 [target.osx-arm64.tasks]
 builddir = "echo _builddir_osx-arm64"
+
+[target.win-64.dependencies]
+pkg-config = "*"
 
 [target.win-64.tasks]
 builddir = "echo _builddir_win-64"

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,6 +24,7 @@ ninja = "*"
 numpy = "<2.0.0"    # modflowapi has a resriction on the numpy version
 pandas = "*"
 pip = "*"
+pkg-config = "*"
 pooch = "*"
 pydotplus = "*"
 pyshp = "*"

--- a/src/Solution/PETSc/PetscConvergence.F90
+++ b/src/Solution/PETSc/PetscConvergence.F90
@@ -153,7 +153,9 @@ contains
       flag = apply_check(context, n, xnorm_inf, rnorm_inf_ims, rnorm_L2_ims)
     end if
 
-    if (flag == KSP_CONVERGED_ITERATING) then
+    ! For some reason `KSPConvergedReasonequals` isn't exported by petscksp when compiled with ifx, 
+    ! so we need to compare the integer values directly
+    if (flag%v == KSP_CONVERGED_ITERATING%v) then
       ! not yet converged, max. iters reached? Then stop.
       if (n == context%max_its) then
         flag = KSP_DIVERGED_ITS
@@ -283,7 +285,9 @@ contains
       end if
     end if
 
-    if (flag == KSP_CONVERGED_ITERATING) then
+    ! For some reason `KSPConvergedReasonequals` isn't exported by petscksp when compiled with ifx, 
+    ! so we need to compare the integer values directly
+    if (flag%v == KSP_CONVERGED_ITERATING%v) then
       ! not yet converged, max. iters reached? Then stop.
       if (n == context%max_its) then
         flag = KSP_DIVERGED_ITS

--- a/src/Solution/PETSc/PetscConvergence.F90
+++ b/src/Solution/PETSc/PetscConvergence.F90
@@ -12,6 +12,7 @@ module PetscConvergenceModule
   private
 
   public :: petsc_cnvg_check, petsc_cnvg_check_internal
+  public :: petsc_ctx_create, petsc_ctx_destroy
   public :: KSPSetConvergenceTest
 
   ! TODO_MJR: this could be smaller, find a bound
@@ -31,45 +32,12 @@ module PetscConvergenceModule
     real(DP) :: rnorm_L2_init !< the initial L2 norm for (b - Ax)
     type(ConvergenceSummaryType), pointer :: cnvg_summary => null() !< detailed convergence information
     real(DP) :: t_convergence_check !< the time spent convergence checking
-  contains
-    procedure :: create
-    procedure :: destroy
   end type PetscCnvgCtxType
-
-  ! passing our context into PETSc requires an explicit interface
-  ! on KSPSetConvergenceTest, it is defined here:
-  interface
-    subroutine CnvgCheckFunc(ksp, n, rnorm, flag, context, ierr)
-      import tKSP, PetscCnvgCtxType
-      type(tKSP) :: ksp
-      PetscInt :: n
-      PetscReal :: rnorm
-      KSPConvergedReason :: flag
-      class(PetscCnvgCtxType), pointer :: context
-      PetscErrorCode :: ierr
-    end subroutine
-
-    subroutine CnvgDestroyFunc(context, ierr)
-      import PetscCnvgCtxType
-      class(PetscCnvgCtxType), pointer :: context
-      PetscErrorCode :: ierr
-    end subroutine
-
-    subroutine KSPSetConvergenceTest(ksp, check_convergence, context, &
-                                     destroy, ierr)
-      import tKSP, CnvgCheckFunc, PetscCnvgCtxType, CnvgDestroyFunc
-      type(tKSP) :: ksp
-      procedure(CnvgCheckFunc) :: check_convergence
-      class(PetscCnvgCtxType), pointer :: context
-      procedure(CnvgDestroyFunc) :: destroy
-      PetscErrorCode :: ierr
-    end subroutine
-  end interface
 
 contains
 
-  subroutine create(this, mat, settings, summary)
-    class(PetscCnvgCtxType) :: this
+  subroutine petsc_ctx_create(this, mat, settings, summary)
+    type(PetscCnvgCtxType) :: this
     Mat, pointer :: mat
     type(ImsLinearSettingsType), pointer :: settings
     type(ConvergenceSummaryType), pointer :: summary
@@ -89,7 +57,7 @@ contains
     call MatCreateVecs(mat, this%residual, PETSC_NULL_VEC, ierr)
     CHKERRQ(ierr)
 
-  end subroutine create
+  end subroutine petsc_ctx_create
 
   !> @brief Routine to check the convergence following the configuration
   !< of IMS. (called back from the PETSc solver)
@@ -98,7 +66,7 @@ contains
     PetscInt :: n !< Iteration number
     PetscReal :: rnorm_L2 !< 2-norm (preconditioned) residual value
     KSPConvergedReason :: flag !< Converged reason
-    class(PetscCnvgCtxType), pointer :: context !< context
+    type(PetscCnvgCtxType) :: context !< context (passed by value from C wrapper)
     PetscErrorCode :: ierr !< error
     ! local
     PetscReal, parameter :: min_one = -1.0
@@ -129,6 +97,16 @@ contains
 
     ! n == 0 is before the iteration starts
     if (n == 0) then
+      ! Re-create work vectors from solution to ensure matching Vec subtype
+      call VecDestroy(context%x_old, ierr)
+      CHKERRQ(ierr)
+      call VecDuplicate(x, context%x_old, ierr)
+      CHKERRQ(ierr)
+      call VecDestroy(context%delta_x, ierr)
+      CHKERRQ(ierr)
+      call VecDuplicate(x, context%delta_x, ierr)
+      CHKERRQ(ierr)
+
       context%rnorm_L2_init = rnorm0
       if (rnorm_L2 < RNORM_L2_TOL) then
         ! exact solution found
@@ -192,7 +170,7 @@ contains
   function apply_check(ctx, nit, dvmax, rnorm_inf, rnorm_L2) result(flag)
     use TdisModule, only: kstp
     use IMSLinearBaseModule, only: ims_base_testcnvg, ims_base_epfact
-    class(PetscCnvgCtxType) :: ctx
+    type(PetscCnvgCtxType) :: ctx
     integer(I4B) :: nit !< iteration number
     real(DP) :: dvmax !< infinity norm of dep. var. change
     real(DP) :: rnorm_inf !< infinity norm of residual change
@@ -233,7 +211,7 @@ contains
     PetscInt :: n !< Iteration number
     PetscReal :: rnorm_L2 !< 2-norm (preconditioned) residual value
     KSPConvergedReason :: flag !< Converged reason
-    class(PetscCnvgCtxType), pointer :: context !< context
+    type(PetscCnvgCtxType) :: context !< context (passed by value from C wrapper)
     PetscErrorCode :: ierr !< error
     ! local
     PetscReal, parameter :: min_one = -1.0
@@ -252,6 +230,16 @@ contains
 
     ! n == 0 is before the iteration starts
     if (n == 0) then
+      ! Re-create work vectors from solution to ensure matching Vec subtype
+      call VecDestroy(context%x_old, ierr)
+      CHKERRQ(ierr)
+      call VecDuplicate(x, context%x_old, ierr)
+      CHKERRQ(ierr)
+      call VecDestroy(context%delta_x, ierr)
+      CHKERRQ(ierr)
+      call VecDuplicate(x, context%delta_x, ierr)
+      CHKERRQ(ierr)
+
       context%rnorm_L2_init = rnorm0
       if (rnorm_L2 < RNORM_L2_TOL) then
         ! exact solution found
@@ -337,9 +325,9 @@ contains
     end if
 
     ! get dv and dr per local model (readonly!)
-    call VecGetArrayReadF90(dx, local_dx, ierr)
+    call VecGetArrayRead(dx, local_dx, ierr)
     CHKERRQ(ierr)
-    call VecGetArrayReadF90(res, local_res, ierr)
+    call VecGetArrayRead(res, local_res, ierr)
     CHKERRQ(ierr)
     do i = 1, summary%convnmod
       ! reset
@@ -367,9 +355,9 @@ contains
         summary%convlocr(i, iter_cnt) = idx_r
       end if
     end do
-    call VecRestoreArrayF90(dx, local_dx, ierr)
+    call VecRestoreArray(dx, local_dx, ierr)
     CHKERRQ(ierr)
-    call VecRestoreArrayF90(res, local_res, ierr)
+    call VecRestoreArray(res, local_res, ierr)
     CHKERRQ(ierr)
 
   end subroutine fill_cnvg_summary
@@ -403,7 +391,7 @@ contains
     end if
 
     ! get dv and dr per local model (readonly!)
-    call VecGetArrayReadF90(dx, local_dx, ierr)
+    call VecGetArrayRead(dx, local_dx, ierr)
     CHKERRQ(ierr)
     do i = 1, summary%convnmod
       ! reset
@@ -423,13 +411,13 @@ contains
         summary%convlocdv(i, iter_cnt) = idx_dv
       end if
     end do
-    call VecRestoreArrayF90(dx, local_dx, ierr)
+    call VecRestoreArray(dx, local_dx, ierr)
     CHKERRQ(ierr)
 
   end subroutine fill_cnvg_summary_internal
 
-  subroutine destroy(this)
-    class(PetscCnvgCtxType) :: this
+  subroutine petsc_ctx_destroy(this)
+    type(PetscCnvgCtxType) :: this
     ! local
     integer(I4B) :: ierr
 
@@ -440,6 +428,6 @@ contains
     call VecDestroy(this%residual, ierr)
     CHKERRQ(ierr)
 
-  end subroutine destroy
+  end subroutine petsc_ctx_destroy
 
 end module PetscConvergenceModule

--- a/src/Solution/PETSc/PetscConvergence.F90
+++ b/src/Solution/PETSc/PetscConvergence.F90
@@ -153,7 +153,7 @@ contains
       flag = apply_check(context, n, xnorm_inf, rnorm_inf_ims, rnorm_L2_ims)
     end if
 
-    ! For some reason `KSPConvergedReasonequals` isn't exported by petscksp when compiled with ifx, 
+    ! For some reason `KSPConvergedReasonequals` isn't exported by petscksp when compiled with ifx,
     ! so we need to compare the integer values directly
     if (flag%v == KSP_CONVERGED_ITERATING%v) then
       ! not yet converged, max. iters reached? Then stop.
@@ -285,7 +285,7 @@ contains
       end if
     end if
 
-    ! For some reason `KSPConvergedReasonequals` isn't exported by petscksp when compiled with ifx, 
+    ! For some reason `KSPConvergedReasonequals` isn't exported by petscksp when compiled with ifx,
     ! so we need to compare the integer values directly
     if (flag%v == KSP_CONVERGED_ITERATING%v) then
       ! not yet converged, max. iters reached? Then stop.

--- a/src/Solution/PETSc/PetscImsPreconditioner.F90
+++ b/src/Solution/PETSc/PetscImsPreconditioner.F90
@@ -135,6 +135,7 @@ contains
   !< (this is not a type bound procedure)
   subroutine pcshell_apply(pc, x, y, ierr)
     use IMSLinearBaseModule, only: ims_base_ilu0a
+    use iso_c_binding, only: c_ptr, c_f_pointer
     external lusol ! from ilut.f90
     PC :: pc !< the shell preconditioner
     Vec :: x !< the input vector
@@ -142,10 +143,15 @@ contains
     PetscErrorCode :: ierr !< PETSc error code
     ! local
     type(PcShellCtxType), pointer :: pc_ctx => null()
+    type(c_ptr) :: ctx_ptr
     real(DP), dimension(:), pointer :: local_x, local_y
     integer(I4B) :: neq, nja
 
-    call PCShellGetContext(pc, pc_ctx, ierr)
+    ! Due to a missing export in the PETSc Fortran interface, we have to get the context as a C pointer and then convert it back to a Fortran pointer
+    ! call PCShellGetContext(pc, pc_ctx, ierr) -> This results in a linker error because petscFtnCtx is not exported as defined in petscsysmod.F90 
+    ! Workaround is to use the macro as defined in petscpc.h directly : #define PCShellGetContext ...
+    call PCShellGetContextCptr(pc, ctx_ptr, ierr)
+    call c_f_pointer(ctx_ptr, pc_ctx)
     CHKERRQ(ierr)
 
     call VecGetArrayRead(x, local_x, ierr)
@@ -174,18 +180,24 @@ contains
   !< (this is not a type bound procedure)
   subroutine pcshell_setup(pc, ierr)
     use IMSLinearBaseModule, only: ims_base_pcu
+    use iso_c_binding, only: c_ptr, c_f_pointer
     PC :: pc !< the shell preconditioner
     PetscErrorCode :: ierr !< PETSc error code
     ! local
     type(PcShellCtxType), pointer :: pc_ctx => null()
+    type(c_ptr) :: ctx_ptr
     integer(I4B) :: neq, nja
     integer(I4B) :: niapc, njapc, njlu, njw, nwlu
     integer(I4B), dimension(:), contiguous, pointer :: ia, ja
     real(DP), dimension(:), contiguous, pointer :: amat
 
-    call PCShellGetContext(pc, pc_ctx, ierr)
+    ! Due to a missing export in the PETSc Fortran interface, we have to get the context as a C pointer and then convert it back to a Fortran pointer
+    ! call PCShellGetContext(pc, pc_ctx, ierr) -> This results in a linker error because petscFtnCtx is not exported as defined in petscsysmod.F90 
+    ! Workaround is to use the macro as defined in petscpc.h directly : #define PCShellGetContext ...
+    call PCShellGetContextCptr(pc, ctx_ptr, ierr)
+    call c_f_pointer(ctx_ptr, pc_ctx)
     CHKERRQ(ierr)
-
+    
     ! note the two different matrix types here:
     ! bridging between PETSc and IMS
     call pc_ctx%system_matrix%get_aij_local(ia, ja, amat)

--- a/src/Solution/PETSc/PetscImsPreconditioner.F90
+++ b/src/Solution/PETSc/PetscImsPreconditioner.F90
@@ -14,6 +14,7 @@ module PetscImsPreconditionerModule
   public :: PcShellCtxType
   public :: pcshell_apply
   public :: pcshell_setup
+  public :: pctx_create, pctx_destroy
 
   character(len=9), dimension(4) :: IMS_PC_TYPE = ["IMS ILU0 ", &
                                                    "IMS MILU0", &
@@ -36,20 +37,7 @@ module PetscImsPreconditionerModule
     integer(I4B), dimension(:), contiguous, pointer :: JLU => null() !< (M)ILUT work array
     integer(I4B), dimension(:), contiguous, pointer :: JW => null() !< (M)ILUT work array
     real(DP), dimension(:), contiguous, pointer :: WLU => null() !< (M)ILUT work array
-  contains
-    procedure :: create => pctx_create
-    procedure :: destroy => pctx_destroy
-
   end type
-
-  interface
-    subroutine PCShellGetContext(pc, ctx, ierr)
-      import PcShellCtxType, tPC
-      type(tPC) :: pc
-      type(PcShellCtxType), pointer :: ctx
-      integer :: ierr
-    end subroutine
-  end interface
 
 contains
 
@@ -58,7 +46,7 @@ contains
   subroutine pctx_create(this, matrix, lin_settings)
     use IMSLinearBaseModule, only: ims_base_pccrs, ims_calc_pcdims
     use MemoryManagerModule, only: mem_allocate
-    class(PcShellCtxType) :: this !< this instance
+    type(PcShellCtxType) :: this !< this instance
     class(PetscMatrixType), pointer :: matrix !< the linear system matrix
     type(ImsLinearSettingsType), pointer :: lin_settings !< linear settings from IMS
     ! local
@@ -125,7 +113,7 @@ contains
   !<
   subroutine pctx_destroy(this)
     use MemoryManagerModule, only: mem_deallocate
-    class(PcShellCtxType) :: this
+    type(PcShellCtxType) :: this
 
     ! matrix
     call mem_deallocate(this%IAPC)
@@ -147,6 +135,7 @@ contains
   !< (this is not a type bound procedure)
   subroutine pcshell_apply(pc, x, y, ierr)
     use IMSLinearBaseModule, only: ims_base_ilu0a
+    use iso_c_binding, only: c_ptr, c_f_pointer
     external lusol ! from ilut.f90
     PC :: pc !< the shell preconditioner
     Vec :: x !< the input vector
@@ -154,15 +143,17 @@ contains
     PetscErrorCode :: ierr !< PETSc error code
     ! local
     type(PcShellCtxType), pointer :: pc_ctx => null()
+    type(c_ptr) :: ctx_ptr
     real(DP), dimension(:), pointer :: local_x, local_y
     integer(I4B) :: neq, nja
 
-    call PCShellGetContext(pc, pc_ctx, ierr)
+    call PCShellGetContextcptr(pc, ctx_ptr, ierr)
     CHKERRQ(ierr)
+    call c_f_pointer(ctx_ptr, pc_ctx)
 
-    call VecGetArrayReadF90(x, local_x, ierr)
+    call VecGetArrayRead(x, local_x, ierr)
     CHKERRQ(ierr)
-    call VecGetArrayF90(y, local_y, ierr)
+    call VecGetArray(y, local_y, ierr)
     CHKERRQ(ierr)
 
     neq = pc_ctx%system_matrix%nrow
@@ -175,9 +166,9 @@ contains
       call lusol(neq, local_x, local_y, pc_ctx%APC, pc_ctx%JLU, pc_ctx%IW)
     end select
 
-    call VecRestoreArrayF90(x, local_x, ierr)
+    call VecRestoreArrayRead(x, local_x, ierr)
     CHKERRQ(ierr)
-    call VecRestoreArrayF90(y, local_y, ierr)
+    call VecRestoreArray(y, local_y, ierr)
     CHKERRQ(ierr)
 
   end subroutine pcshell_apply
@@ -186,17 +177,20 @@ contains
   !< (this is not a type bound procedure)
   subroutine pcshell_setup(pc, ierr)
     use IMSLinearBaseModule, only: ims_base_pcu
+    use iso_c_binding, only: c_ptr, c_f_pointer
     PC :: pc !< the shell preconditioner
     PetscErrorCode :: ierr !< PETSc error code
     ! local
     type(PcShellCtxType), pointer :: pc_ctx => null()
+    type(c_ptr) :: ctx_ptr
     integer(I4B) :: neq, nja
     integer(I4B) :: niapc, njapc, njlu, njw, nwlu
     integer(I4B), dimension(:), contiguous, pointer :: ia, ja
     real(DP), dimension(:), contiguous, pointer :: amat
 
-    call PCShellGetContext(pc, pc_ctx, ierr)
+    call PCShellGetContextcptr(pc, ctx_ptr, ierr)
     CHKERRQ(ierr)
+    call c_f_pointer(ctx_ptr, pc_ctx)
 
     ! note the two different matrix types here:
     ! bridging between PETSc and IMS

--- a/src/Solution/PETSc/PetscImsPreconditioner.F90
+++ b/src/Solution/PETSc/PetscImsPreconditioner.F90
@@ -148,7 +148,7 @@ contains
     integer(I4B) :: neq, nja
 
     ! Due to a missing export in the PETSc Fortran interface, we have to get the context as a C pointer and then convert it back to a Fortran pointer
-    ! call PCShellGetContext(pc, pc_ctx, ierr) -> This results in a linker error because petscFtnCtx is not exported as defined in petscsysmod.F90 
+    ! call PCShellGetContext(pc, pc_ctx, ierr) -> This results in a linker error because petscFtnCtx is not exported as defined in petscsysmod.F90
     ! Workaround is to use the macro as defined in petscpc.h directly : #define PCShellGetContext ...
     call PCShellGetContextCptr(pc, ctx_ptr, ierr)
     call c_f_pointer(ctx_ptr, pc_ctx)
@@ -192,12 +192,12 @@ contains
     real(DP), dimension(:), contiguous, pointer :: amat
 
     ! Due to a missing export in the PETSc Fortran interface, we have to get the context as a C pointer and then convert it back to a Fortran pointer
-    ! call PCShellGetContext(pc, pc_ctx, ierr) -> This results in a linker error because petscFtnCtx is not exported as defined in petscsysmod.F90 
+    ! call PCShellGetContext(pc, pc_ctx, ierr) -> This results in a linker error because petscFtnCtx is not exported as defined in petscsysmod.F90
     ! Workaround is to use the macro as defined in petscpc.h directly : #define PCShellGetContext ...
     call PCShellGetContextCptr(pc, ctx_ptr, ierr)
     call c_f_pointer(ctx_ptr, pc_ctx)
     CHKERRQ(ierr)
-    
+
     ! note the two different matrix types here:
     ! bridging between PETSc and IMS
     call pc_ctx%system_matrix%get_aij_local(ia, ja, amat)

--- a/src/Solution/PETSc/PetscImsPreconditioner.F90
+++ b/src/Solution/PETSc/PetscImsPreconditioner.F90
@@ -135,7 +135,6 @@ contains
   !< (this is not a type bound procedure)
   subroutine pcshell_apply(pc, x, y, ierr)
     use IMSLinearBaseModule, only: ims_base_ilu0a
-    use iso_c_binding, only: c_ptr, c_f_pointer
     external lusol ! from ilut.f90
     PC :: pc !< the shell preconditioner
     Vec :: x !< the input vector
@@ -143,13 +142,11 @@ contains
     PetscErrorCode :: ierr !< PETSc error code
     ! local
     type(PcShellCtxType), pointer :: pc_ctx => null()
-    type(c_ptr) :: ctx_ptr
     real(DP), dimension(:), pointer :: local_x, local_y
     integer(I4B) :: neq, nja
 
-    call PCShellGetContextcptr(pc, ctx_ptr, ierr)
+    call PCShellGetContext(pc, pc_ctx, ierr)
     CHKERRQ(ierr)
-    call c_f_pointer(ctx_ptr, pc_ctx)
 
     call VecGetArrayRead(x, local_x, ierr)
     CHKERRQ(ierr)
@@ -177,20 +174,17 @@ contains
   !< (this is not a type bound procedure)
   subroutine pcshell_setup(pc, ierr)
     use IMSLinearBaseModule, only: ims_base_pcu
-    use iso_c_binding, only: c_ptr, c_f_pointer
     PC :: pc !< the shell preconditioner
     PetscErrorCode :: ierr !< PETSc error code
     ! local
     type(PcShellCtxType), pointer :: pc_ctx => null()
-    type(c_ptr) :: ctx_ptr
     integer(I4B) :: neq, nja
     integer(I4B) :: niapc, njapc, njlu, njw, nwlu
     integer(I4B), dimension(:), contiguous, pointer :: ia, ja
     real(DP), dimension(:), contiguous, pointer :: amat
 
-    call PCShellGetContextcptr(pc, ctx_ptr, ierr)
+    call PCShellGetContext(pc, pc_ctx, ierr)
     CHKERRQ(ierr)
-    call c_f_pointer(ctx_ptr, pc_ctx)
 
     ! note the two different matrix types here:
     ! bridging between PETSc and IMS

--- a/src/Solution/PETSc/PetscSolver.F90
+++ b/src/Solution/PETSc/PetscSolver.F90
@@ -368,9 +368,11 @@ contains
       end if
     end if
 
+    ! For some reason `KSPConvergedReasonequals` isn't exported by petscksp when compiled with ifx, 
+    ! so we need to compare the integer values directly
     if (cnvg_reason%v < 0) then
-      if (cnvg_reason == KSP_DIVERGED_BREAKDOWN .or. &
-          cnvg_reason == KSP_DIVERGED_ITS) then
+      if (cnvg_reason%v == KSP_DIVERGED_BREAKDOWN%v .or. &
+          cnvg_reason%v == KSP_DIVERGED_ITS%v) then
         ! out of iterations, or rho/eta became zero,
         ! move to next Picard iteration and try again
         this%is_converged = 0

--- a/src/Solution/PETSc/PetscSolver.F90
+++ b/src/Solution/PETSc/PetscSolver.F90
@@ -263,7 +263,7 @@ contains
     class(PetscSolverType) :: this !< This solver instance
     ! local
     PC :: pc, sub_pc
-    KSP, pointer :: sub_ksp(:)  => null()
+    KSP, pointer :: sub_ksp(:) => null()
     PetscInt :: n_local, n_first
     PetscErrorCode :: ierr
 
@@ -298,7 +298,7 @@ contains
     PetscErrorCode :: ierr
 
     call petsc_ctx_create(this%petsc_ctx, this%mat_petsc, this%linear_settings, &
-                               convergence_summary)
+                          convergence_summary)
 
     if (.not. this%use_ims_cnvgopt) then
       ! use PETSc residual L2 norm for convergence
@@ -368,7 +368,7 @@ contains
       end if
     end if
 
-    ! For some reason `KSPConvergedReasonequals` isn't exported by petscksp when compiled with ifx, 
+    ! For some reason `KSPConvergedReasonequals` isn't exported by petscksp when compiled with ifx,
     ! so we need to compare the integer values directly
     if (cnvg_reason%v < 0) then
       if (cnvg_reason%v == KSP_DIVERGED_BREAKDOWN%v .or. &

--- a/src/Solution/PETSc/PetscSolver.F90
+++ b/src/Solution/PETSc/PetscSolver.F90
@@ -1,6 +1,8 @@
 module PetscSolverModule
+#include <petsc/finclude/petscsys.h>
 #include <petsc/finclude/petscksp.h>
   use petscksp
+  use petscsys
   use KindModule, only: I4B, DP, LGP
   use ConstantsModule, only: LINELENGTH, LENSOLUTIONNAME, DZERO
   use ListsModule, only: basesolutionlist
@@ -32,7 +34,7 @@ module PetscSolverModule
     logical(LGP) :: use_ims_pc !< when true, use custom IMS-style preconditioning
     logical(LGP) :: use_ims_cnvgopt !< when true, use IMS convergence check in PETSc solve
     KSPType :: ksp_type !< the KSP solver type (CG, BCGS, ...)
-    class(PetscCnvgCtxType), pointer :: petsc_ctx => null() !< context for the PETSc custom convergence check
+    type(PetscCnvgCtxType), pointer :: petsc_ctx => null() !< context for the PETSc custom convergence check
     type(PcShellCtxType), pointer :: pc_context => null() !< context for the custom (IMS) precondioner
     type(ConvergenceSummaryType), pointer :: convergence_summary => null() !< data structure wrapping the convergence data
     character(len=LENSOLUTIONNAME + 1) :: option_prefix !< prefix for keys in petscrc database in case there are multiple solutions
@@ -106,7 +108,7 @@ contains
     this%use_ims_cnvgopt = .true. ! use IMS convergence check, override with .petscrc
     this%use_ims_pc = .true. ! use IMS preconditioning, override with .petscrc
     allocate (this%pc_context)
-    call this%pc_context%create(this%matrix, linear_settings)
+    call pctx_create(this%pc_context, this%matrix, linear_settings)
 
     if (linear_settings%ilinmeth == CG_METHOD) then
       this%ksp_type = KSPCG
@@ -188,16 +190,16 @@ contains
     class(PetscSolverType) :: this
     ! local
     PetscErrorCode :: ierr
-    logical(LGP) :: found
-    logical(LGP) :: use_petsc_pc, use_petsc_cnvg
+    PetscBool :: found
+    PetscBool :: use_petsc_pc, use_petsc_cnvg
 
-    use_petsc_pc = .false.
+    use_petsc_pc = PETSC_FALSE
     call PetscOptionsGetBool(PETSC_NULL_OPTIONS, trim(this%option_prefix), &
                              '-use_petsc_pc', use_petsc_pc, found, ierr)
     CHKERRQ(ierr)
     this%use_ims_pc = .not. use_petsc_pc
 
-    use_petsc_cnvg = .false.
+    use_petsc_cnvg = PETSC_FALSE
     call PetscOptionsGetBool(PETSC_NULL_OPTIONS, trim(this%option_prefix), &
                              '-use_petsc_cnvg', use_petsc_cnvg, found, ierr)
     CHKERRQ(ierr)
@@ -223,7 +225,7 @@ contains
     call KSPSetOperators(this%ksp_petsc, this%mat_petsc, this%mat_petsc, ierr)
     CHKERRQ(ierr)
 
-    call KSPSetInitialGuessNonzero(this%ksp_petsc, .true., ierr)
+    call KSPSetInitialGuessNonzero(this%ksp_petsc, PETSC_TRUE, ierr)
     CHKERRQ(ierr)
 
     call KSPSetType(this%ksp_petsc, this%ksp_type, ierr)
@@ -242,7 +244,7 @@ contains
       CHKERRQ(ierr)
     end if
 
-    call KSPSetErrorIfNotConverged(this%ksp_petsc, .false., ierr)
+    call KSPSetErrorIfNotConverged(this%ksp_petsc, PETSC_FALSE, ierr)
     CHKERRQ(ierr)
 
     ! finally override these options from the
@@ -261,7 +263,7 @@ contains
     class(PetscSolverType) :: this !< This solver instance
     ! local
     PC :: pc, sub_pc
-    KSP, dimension(1) :: sub_ksp
+    KSP, pointer :: sub_ksp(:)  => null()
     PetscInt :: n_local, n_first
     PetscErrorCode :: ierr
 
@@ -295,7 +297,7 @@ contains
     ! local
     PetscErrorCode :: ierr
 
-    call this%petsc_ctx%create(this%mat_petsc, this%linear_settings, &
+    call petsc_ctx_create(this%petsc_ctx, this%mat_petsc, this%linear_settings, &
                                convergence_summary)
 
     if (.not. this%use_ims_cnvgopt) then
@@ -314,6 +316,7 @@ contains
   end subroutine create_convergence_check
 
   subroutine petsc_solve(this, kiter, rhs, x, cnvg_summary)
+    use iso_c_binding
     class(PetscSolverType) :: this
     integer(I4B) :: kiter
     class(VectorBaseType), pointer :: rhs
@@ -355,7 +358,7 @@ contains
 
     call KSPGetConvergedReason(this%ksp_petsc, cnvg_reason, ierr)
     CHKERRQ(ierr)
-    if (cnvg_reason > 0) then
+    if (cnvg_reason%v > 0) then
       if (this%petsc_ctx%icnvg_ims == -1) then
         ! move to next Picard iteration (e.g. with 'STRICT' option)
         this%is_converged = 0
@@ -365,7 +368,7 @@ contains
       end if
     end if
 
-    if (cnvg_reason < 0) then
+    if (cnvg_reason%v < 0) then
       if (cnvg_reason == KSP_DIVERGED_BREAKDOWN .or. &
           cnvg_reason == KSP_DIVERGED_ITS) then
         ! out of iterations, or rho/eta became zero,
@@ -457,10 +460,10 @@ contains
     CHKERRQ(ierr)
 
     ! delete context
-    call this%petsc_ctx%destroy()
+    call petsc_ctx_destroy(this%petsc_ctx)
     deallocate (this%petsc_ctx)
 
-    call this%pc_context%destroy()
+    call pctx_destroy(this%pc_context)
     deallocate (this%pc_context)
 
   end subroutine petsc_destroy

--- a/src/Utilities/Matrix/PetscMatrix.F90
+++ b/src/Utilities/Matrix/PetscMatrix.F90
@@ -127,8 +127,8 @@ contains
     CHKERRQ(ierr)
 
     call MatGetRowIJ(local_mat, 1, PETSC_FALSE, PETSC_FALSE, &
-                        nrows_local, ia_tmp, ja_tmp, &
-                        done, ierr)
+                     nrows_local, ia_tmp, ja_tmp, &
+                     done, ierr)
     CHKERRQ(ierr)
 
     do i = 1, size(ia_tmp)
@@ -139,7 +139,7 @@ contains
     end do
 
     call MatRestoreRowIJ(local_mat, 1, PETSC_FALSE, PETSC_FALSE, &
-                            nrows_local, ia_tmp, ja_tmp, done, ierr)
+                         nrows_local, ia_tmp, ja_tmp, done, ierr)
     CHKERRQ(ierr)
 
   end subroutine pm_init

--- a/src/Utilities/Matrix/PetscMatrix.F90
+++ b/src/Utilities/Matrix/PetscMatrix.F90
@@ -126,7 +126,7 @@ contains
     call MatGetDiagonalBlock(this%mat, local_mat, ierr)
     CHKERRQ(ierr)
 
-    call MatGetRowIJF90(local_mat, 1, PETSC_FALSE, PETSC_FALSE, &
+    call MatGetRowIJ(local_mat, 1, PETSC_FALSE, PETSC_FALSE, &
                         nrows_local, ia_tmp, ja_tmp, &
                         done, ierr)
     CHKERRQ(ierr)
@@ -138,7 +138,7 @@ contains
       this%ja_local(i) = ja_tmp(i)
     end do
 
-    call MatRestoreRowIJF90(local_mat, 1, PETSC_FALSE, PETSC_FALSE, &
+    call MatRestoreRowIJ(local_mat, 1, PETSC_FALSE, PETSC_FALSE, &
                             nrows_local, ia_tmp, ja_tmp, done, ierr)
     CHKERRQ(ierr)
 

--- a/src/Utilities/Matrix/PetscMatrix.F90
+++ b/src/Utilities/Matrix/PetscMatrix.F90
@@ -72,7 +72,7 @@ contains
     Mat :: local_mat
     integer(I4B), dimension(:), pointer :: ia_tmp, ja_tmp
     integer(I4B) :: nrows_local
-    logical(LGP) :: done
+    PetscBool :: done
 
     this%memory_path = mem_path
     this%nrow = sparse%nrow

--- a/src/meson.build
+++ b/src/meson.build
@@ -547,12 +547,10 @@ mf6_external = static_library('mf6_external', external_libraries)
 
 message('MODFLOW 6 executable name: ' + buildname)
 
-if build_machine.system() == 'windows' and (with_petsc or with_netcdf)
+if build_machine.system() == 'windows' and with_netcdf
   if is_extended_build
     incdir = include_directories(extended_incdir)
-  elif with_petsc
-    incdir = petsc_incdir
-  elif with_netcdf
+  else
     incdir = netcdf_incdir
   endif
   mf6core = static_library('mf6core',


### PR DESCRIPTION
This PR contains the changes needed to get MODFLOW working with the latest petsc version.

**How to build**
To build petsc i used the following build.py

```
#!/usr/bin/python3
if __name__ == '__main__':
  import sys
  import os
  sys.path.insert(0, os.path.abspath('config'))
  import configure
  configure_options = [
    '--with-blaslapack-lib=-L/cygdrive/c/PROGRA~2/Intel/oneAPI/mkl/latest/lib mkl_intel_lp64_dll.lib mkl_sequential_dll.lib mkl_core_dll.lib',
    '--with-cc=icx',
    '--with-cxx=icx',
    '--with-fc=ifx',
    '--with-shared-libraries=1',
    'FPPFLAGS=-I/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/include/mpi',
    '--debugging=0',
    '--with-mpi-include=/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/include',
    '--with-mpi-lib=/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/lib/impi.lib',
    '--with-mpiexec=/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/bin/mpiexec -localonly',
    '--with-fortran-bindings=1',
    '--with-fortran-bindings-inplace=0',
    '--prefix=/cygdrive/c/dev/externals/petsc/install/arch-mswin-icx',
    'PETSC_ARCH=arch-mswin-icx'
  ]
  configure.petsc_configure(configure_options)
```

The commands to build are:
```
python build.py
make PETSC_DIR=/cygdrive/c/dev/externals/petsc PETSC_ARCH=arch-mswin-icx all
make PETSC_DIR=/cygdrive/c/dev/externals/petsc PETSC_ARCH=arch-mswin-icx install
```
This will create an out of build install at  `c/dev/externals/petsc/install/arch-mswin-icx`

**Get it working with PKG CONFIG**
After running the make install command the files are placed at what you have defined at `prefix`.
The pkg config configuration file is located at  ${prefix}\lib\pkgconfig\PETSc.pc.
For the windows build this needs to be updated. The reason for this is that the windows build uses cygwin to build petsc.
- In the PETSc.pc file replace all occurrences of `/cygdrive/c/`  by `C:/`


**At the PETSc.pc location to the PKG_CONFIG_PATH environment variable**
For pkg config to be able to find petsc the location of the PETSc.pc file needs to be added to PKG_CONFIG_PATH environment variable. On windows this can be done at System Properties ->Advanced->Environment Variables
Then create or update the PKG_CONFIG_PATH  with the location


An overview of the changes are:
_pixi.toml_
- Updated the hardcoded PKG_CONFIG_PATH to also include the system PKG_CONFIG_PATH

_meson_
- Removed compiling the mod files ourselves. Petsc now automatically generates them so their is no need anymore
- Find the petsc library using pkg config. This will automatically set all correct linker and include arguments

_Fortran_
- The ifx compiler produced errors when passing context classes to petsc. The error stated that type-bound-procedures couldn't be passed along. To fix this i moved the create and destroy methods out of the class, making the classes pure data classes
- The new version of petsc now adds enums. However for some reason not all methods are exported/available in the library. This most likely is a petsc bug due the way the exports are defined.  The workaround applied is to compare the integer values behind the enums directly e.g. `flag%v == KSP_CONVERGED_ITERATING%v`
-Some of the methods have been renamed e.g. `VecGetArrayReadF90` -> `VecGetArrayRead`
- Due to a missing export one of the `PCShellGetContext`  arguments is not available. The solution is to use the petsc macro directly and call it's c counterpart
- In the new version of petsc a new type for a boolean is introduced: `PetscBool`
- To Fix a runtime error I recreate the context%x_old and context%delta_x when they are first accesed

Things that still need to be figures out:
- The runtime error where i recreate the x_old and delta_x vectors shouldn't be nececarry. For some reason they are intialized with an incorrect size. We need to figure out why this is happening
- ~~The pipeline needs to be updated. To work with the new meson pkg_config approach this also means that the PETSc.px need to be updated and added to the PKG_CONFIG_PATH variable~~
- ~~This PR has only be tested on a windows system with the IFX compiler. More work may be needed on other systems/compilers~~



Checklist of items for pull request

- [ ] Replaced section above with description of pull request
- [ ] Closed issue #xxxx
- [ ] Referenced issue or pull request #xxxx
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
