### PR TITLE
test(tsp-mve): new autotest for parallel mve package

### DIFF
--- a/autotest/test_gwe_mve03.py
+++ b/autotest/test_gwe_mve03.py
@@ -2,9 +2,9 @@
 Test problem for GWE with MVE active.  Another autotest will check this autotest
 in parallel.
 
-Test that MVE successfully transfers thermal energy from an SFE reach in one model to its 
-neighbor in another model.  It is expected that this will work fine in serial, the check 
-is will it work in parallel.
+Test that MVE successfully transfers thermal energy from an SFE reach in one
+model to its neighbor in another model.  It is expected that this will work fine
+in serial, the bigger check is whether it works in parallel.
 
  Model configuration
 
@@ -115,7 +115,7 @@ def build_gwf_model(sim, gwfname, mod_num):
         save_flows=True,
         model_nam_file=f"{gwfname}.nam",
     )
-    
+
     # Instantiating MODFLOW 6 discretization package
     flopy.mf6.ModflowGwfdis(
         gwf,
@@ -131,7 +131,7 @@ def build_gwf_model(sim, gwfname, mod_num):
         pname="DIS-" + str(mod_num),
         filename=f"{gwfname}.dis",
     )
-    
+
     # Instantiating MODFLOW 6 storage package
     flopy.mf6.ModflowGwfsto(
         gwf,
@@ -143,7 +143,7 @@ def build_gwf_model(sim, gwfname, mod_num):
         pname="STO-" + str(mod_num),
         filename=f"{gwfname}.sto",
     )
-    
+
     # Instantiating node-property flow package
     flopy.mf6.ModflowGwfnpf(
         gwf,
@@ -155,7 +155,7 @@ def build_gwf_model(sim, gwfname, mod_num):
         pname="NPF-" + str(mod_num),
         filename=f"{gwfname}.npf",
     )
-    
+
     # Instantiating initial conditions package for flow model
     flopy.mf6.ModflowGwfic(
         gwf,
@@ -163,10 +163,10 @@ def build_gwf_model(sim, gwfname, mod_num):
         pname="IC-" + str(mod_num),
         filename=f"{gwfname}.ic",
     )
-    
+
     # Instantiate streamflow routing
     packagedata = []
-    
+
     for i in np.arange(ncol):
         ncon = 2
         if i in [0, ncol - 1]:
@@ -187,7 +187,7 @@ def build_gwf_model(sim, gwfname, mod_num):
                 ndv,  # number of diversions
             ]
         )
-    
+
     con_data = []
     for irno in range(ncol):
         if irno == 0:
@@ -197,14 +197,14 @@ def build_gwf_model(sim, gwfname, mod_num):
         else:
             t = (irno, irno - 1, -(irno + 1))
         con_data.append(t)
-    
+
     sfrbndx = []
     for i in np.arange(len(packagedata)):
         if i == 0:
             sfrbndx.append([i, "INFLOW", surf_Q_in])
-    
+
     sfr_perioddata = {0: sfrbndx}
-    
+
     flopy.mf6.ModflowGwfsfr(
         gwf,
         save_flows=True,
@@ -221,7 +221,7 @@ def build_gwf_model(sim, gwfname, mod_num):
         pname="SFR-" + str(mod_num),
         filename=f"{gwfname}.sfr",
     )
-    
+
     # Instantiating output control package for flow model
     flopy.mf6.ModflowGwfoc(
         gwf,
@@ -232,16 +232,16 @@ def build_gwf_model(sim, gwfname, mod_num):
         saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
     )
-    
+
     return sim, gwf
 
 
 def build_gwe_model(sim, gwename, mod_num):
     # Instantiating GWE model
     gwe = flopy.mf6.ModflowGwe(sim, modelname=gwename, model_nam_file=f"{gwename}.nam")
-    
+
     gwe.name_file.save_flows = True
-    
+
     # Instantiating discretization package
     flopy.mf6.ModflowGwedis(
         gwe,
@@ -257,7 +257,7 @@ def build_gwe_model(sim, gwename, mod_num):
         pname="DIS-" + str(mod_num),
         filename=f"{gwename}.dis",
     )
-    
+
     # Instantiating initial temperatures
     flopy.mf6.ModflowGweic(
         gwe,
@@ -265,12 +265,12 @@ def build_gwe_model(sim, gwename, mod_num):
         pname="IC-" + str(mod_num),
         filename=f"{gwename}.ic",
     )
-    
+
     # Instantiating advection package
     flopy.mf6.ModflowGweadv(
         gwe, scheme=scheme, pname="ADV-" + str(mod_num), filename=f"{gwename}.adv"
     )
-    
+
     # Instantiating conduction package
     flopy.mf6.ModflowGwecnd(
         gwe,
@@ -282,7 +282,7 @@ def build_gwe_model(sim, gwename, mod_num):
         pname="CND-" + str(mod_num),
         filename=f"{gwename}.cnd",
     )
-    
+
     # Instantiating mass storage package
     flopy.mf6.ModflowGweest(
         gwe,
@@ -296,24 +296,30 @@ def build_gwe_model(sim, gwename, mod_num):
         pname="EST-" + str(mod_num),
         filename=f"{gwename}.est",
     )
-    
+
     # Instantiate source-sink mixing package
     flopy.mf6.ModflowGwessm(
         gwe, sources=[[]], pname="SSM-" + str(mod_num), filename=f"{gwename}.ssm"
     )
-    
+
     # Instantiate streamflow transport package
     sfepackagedata = []
     for irno in range(ncol):
-        t = (irno, strt_temp - ((mod_num - 1) * strt_temp * 0.5), ktf, rbthcnd, f"myreach{irno + 1}")
+        t = (
+            irno,
+            strt_temp - ((mod_num - 1) * strt_temp * 0.5),
+            ktf,
+            rbthcnd,
+            f"myreach{irno + 1}",
+        )
         sfepackagedata.append(t)
-    
+
     sfeperioddata = [
         (0, "STATUS", "ACTIVE"),
         (1, "STATUS", "ACTIVE"),
         (0, "INFLOW", strt_temp - ((mod_num - 1) * strt_temp)),
     ]
-    
+
     sfe_obs = {
         (gwename + ".sfe.obs.csv",): [
             (f"sfe-{i + 1}-conc", "TEMPERATURE", i + 1) for i in range(ncol)
@@ -323,7 +329,7 @@ def build_gwe_model(sim, gwename, mod_num):
     sfe_obs["digits"] = 10
     sfe_obs["print_input"] = True
     sfe_obs["filename"] = gwename + ".sfe.obs"
-    
+
     sfe = flopy.mf6.modflow.ModflowGwesfe(
         gwe,
         boundnames=True,
@@ -339,7 +345,7 @@ def build_gwe_model(sim, gwename, mod_num):
         pname="SFE-" + str(mod_num),
         filename=f"{gwename}.sfe",
     )
-    
+
     # Instantiate heat transport output control package
     flopy.mf6.ModflowGweoc(
         gwe,
@@ -350,7 +356,7 @@ def build_gwe_model(sim, gwename, mod_num):
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
     )
-    
+
     return sim, gwe
 
 
@@ -520,7 +526,7 @@ def check_output(idx, test):
     # process the last line read
     m_arr = line.strip().split()
 
-    # if mvr and mve are working correctly, the temperature of the water 
+    # if mvr and mve are working correctly, the temperature of the water
     # moved from model 1 to model 2, thestream temperature should be cut in half
     assert float(m_arr[-1]) == strt_temp / 2, (
         "SFE temperature for model2, reach 1 not equal to 50.0"

--- a/autotest/test_gwe_mve03.py
+++ b/autotest/test_gwe_mve03.py
@@ -1,0 +1,543 @@
+"""
+Test problem for GWE with MVE active.  Another autotest will check this autotest
+in parallel.
+
+Test that MVE successfully transfers thermal energy from an SFE reach in one model to its 
+neighbor in another model.  It is expected that this will work fine in serial, the check 
+is will it work in parallel.
+
+ Model configuration
+
+                      Model 1                          Model 2
+                     ---------                        ---------
+
+               +---------+---------+            +---------+---------+
+              /         /         /|           /         /         /|
+SFR/SFE -> ==/=========/=========/=> MVR/MVE ======================>|
+            /         /         /  +         /         /         /  +
+           +---------+---------+  /         +---------+---------+  /
+           |         |         | /          |         |         | /
+           |         |         |/           |         |         |/
+           +---------+---------+            +---------+---------+
+
+
+"""
+
+# Imports
+
+import os
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+# Base simulation and model name and workspace
+
+cases = ["mve"]
+
+# model units
+length_units = "meters"
+time_units = "days"
+
+# static parameters
+nrow = 1
+ncol = 2
+nlay = 1
+top = 1.0
+botm = 0.0
+delr = 1.0  # Column width ($m$)
+delc = 1.0  # Row width ($m$)
+k11 = 1.0  # Horizontal hydraulic conductivity ($m/d$)
+ss = 1e-6  # Specific storage
+sy = 0.20  # Specific Yield
+prsity = 0.20  # Porosity
+nper = 1  # Number of periods
+perlen = [1000.0]  # Simulation time ($days$)
+nstp = [1]  # 10 day transient time steps
+steady = {0: False}
+transient = {0: True}
+strthd = 0.8
+scheme = "UPSTREAM"
+
+# GWE related parameters
+strt_temp = 10.0
+rhow = 1000.0
+cpw = 4183.0
+lhv = 2454.0
+cps = 760.0
+rhos = 1500.0
+ktf = 0.0
+rbthcnd = 1e-4
+
+# Set some static model parameter values
+
+k33 = k11  # Vertical hydraulic conductivity ($m/d$)
+idomain = 1  # All cells included in the simulation
+iconvert = 1  # All cells are convertible
+icelltype = 1  # Cell conversion type (>1: unconfined)
+
+# Set some static transport related model parameter values
+dispersivity = 0.0  # dispersion (remember, 1D model)
+
+# SFR related parameters
+surf_Q_in = 1.0
+nreaches = ncol
+rlen = delr
+rwid = 9.0
+roughness = 0.035
+rbth = 0.1
+rhk = 0.0
+ustrf = 1.0
+ndv = 0
+strm_incision = 0.1
+
+# Set solver parameter values (and related)
+nouter, ninner = 100, 300
+hclose, rclose, relax = 1e-10, 1e-10, 1.0
+ttsmult = 1.0
+
+# Set up temporal data used by TDIS file
+tdis_rc = []
+for i in np.arange(nper):
+    tdis_rc.append((perlen[i], nstp[i], ttsmult))
+
+
+# Functions for creating MODFLOW 6 GWF/GWE models with an SFR/SFE &
+# MVR/MVE connection
+
+
+def build_gwf_model(sim, gwfname, mod_num):
+    # Instantiating MODFLOW 6 groundwater flow model
+    gwf = flopy.mf6.ModflowGwf(
+        sim,
+        modelname=gwfname,
+        save_flows=True,
+        model_nam_file=f"{gwfname}.nam",
+    )
+    
+    # Instantiating MODFLOW 6 discretization package
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        length_units=length_units,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        idomain=idomain,
+        pname="DIS-" + str(mod_num),
+        filename=f"{gwfname}.dis",
+    )
+    
+    # Instantiating MODFLOW 6 storage package
+    flopy.mf6.ModflowGwfsto(
+        gwf,
+        ss=ss,
+        sy=sy,
+        iconvert=iconvert,
+        steady_state=steady,
+        transient=transient,
+        pname="STO-" + str(mod_num),
+        filename=f"{gwfname}.sto",
+    )
+    
+    # Instantiating node-property flow package
+    flopy.mf6.ModflowGwfnpf(
+        gwf,
+        save_flows=True,
+        icelltype=icelltype,
+        k=k11,
+        k33=k33,
+        save_specific_discharge=True,
+        pname="NPF-" + str(mod_num),
+        filename=f"{gwfname}.npf",
+    )
+    
+    # Instantiating initial conditions package for flow model
+    flopy.mf6.ModflowGwfic(
+        gwf,
+        strt=strthd,
+        pname="IC-" + str(mod_num),
+        filename=f"{gwfname}.ic",
+    )
+    
+    # Instantiate streamflow routing
+    packagedata = []
+    
+    for i in np.arange(ncol):
+        ncon = 2
+        if i in [0, ncol - 1]:
+            ncon = 1
+        packagedata.append(
+            [
+                i,  # irch
+                (0, 0, i),  # lay, row, col
+                delr,  # reach length
+                rwid,  # reach width
+                0.001,  # slope
+                top - (i * strm_incision),  # streambed elevation
+                rbth,  # streambed thickness
+                rhk,  # streambed K
+                roughness,  # Manning's "n"
+                ncon,  # number of connections
+                ustrf,  # no idea
+                ndv,  # number of diversions
+            ]
+        )
+    
+    con_data = []
+    for irno in range(ncol):
+        if irno == 0:
+            t = (irno, -(irno + 1))
+        elif irno == ncol - 1:
+            t = (irno, irno - 1)
+        else:
+            t = (irno, irno - 1, -(irno + 1))
+        con_data.append(t)
+    
+    sfrbndx = []
+    for i in np.arange(len(packagedata)):
+        if i == 0:
+            sfrbndx.append([i, "INFLOW", surf_Q_in])
+    
+    sfr_perioddata = {0: sfrbndx}
+    
+    flopy.mf6.ModflowGwfsfr(
+        gwf,
+        save_flows=True,
+        print_stage=True,
+        print_flows=True,
+        print_input=True,
+        length_conversion=1.0,
+        time_conversion=86400.0,
+        mover=True,
+        nreaches=len(packagedata),
+        packagedata=packagedata,
+        connectiondata=con_data,
+        perioddata=sfr_perioddata,
+        pname="SFR-" + str(mod_num),
+        filename=f"{gwfname}.sfr",
+    )
+    
+    # Instantiating output control package for flow model
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        pname="OC-" + str(mod_num),
+        head_filerecord=f"{gwfname}.hds",
+        budget_filerecord=f"{gwfname}.cbc",
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+    
+    return sim, gwf
+
+
+def build_gwe_model(sim, gwename, mod_num):
+    # Instantiating GWE model
+    gwe = flopy.mf6.ModflowGwe(sim, modelname=gwename, model_nam_file=f"{gwename}.nam")
+    
+    gwe.name_file.save_flows = True
+    
+    # Instantiating discretization package
+    flopy.mf6.ModflowGwedis(
+        gwe,
+        nogrb=True,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        idomain=idomain,
+        pname="DIS-" + str(mod_num),
+        filename=f"{gwename}.dis",
+    )
+    
+    # Instantiating initial temperatures
+    flopy.mf6.ModflowGweic(
+        gwe,
+        strt=strt_temp - ((mod_num - 1) * strt_temp),
+        pname="IC-" + str(mod_num),
+        filename=f"{gwename}.ic",
+    )
+    
+    # Instantiating advection package
+    flopy.mf6.ModflowGweadv(
+        gwe, scheme=scheme, pname="ADV-" + str(mod_num), filename=f"{gwename}.adv"
+    )
+    
+    # Instantiating conduction package
+    flopy.mf6.ModflowGwecnd(
+        gwe,
+        xt3d_off=True,
+        alh=dispersivity,
+        ath1=dispersivity,
+        ktw=0.5918 * 86400,
+        kts=0.2700 * 86400,
+        pname="CND-" + str(mod_num),
+        filename=f"{gwename}.cnd",
+    )
+    
+    # Instantiating mass storage package
+    flopy.mf6.ModflowGweest(
+        gwe,
+        save_flows=True,
+        porosity=prsity,
+        heat_capacity_water=cpw,
+        density_water=rhow,
+        latent_heat_vaporization=lhv,
+        heat_capacity_solid=cps,
+        density_solid=rhos,
+        pname="EST-" + str(mod_num),
+        filename=f"{gwename}.est",
+    )
+    
+    # Instantiate source-sink mixing package
+    flopy.mf6.ModflowGwessm(
+        gwe, sources=[[]], pname="SSM-" + str(mod_num), filename=f"{gwename}.ssm"
+    )
+    
+    # Instantiate streamflow transport package
+    sfepackagedata = []
+    for irno in range(ncol):
+        t = (irno, strt_temp - ((mod_num - 1) * strt_temp * 0.5), ktf, rbthcnd, f"myreach{irno + 1}")
+        sfepackagedata.append(t)
+    
+    sfeperioddata = [
+        (0, "STATUS", "ACTIVE"),
+        (1, "STATUS", "ACTIVE"),
+        (0, "INFLOW", strt_temp - ((mod_num - 1) * strt_temp)),
+    ]
+    
+    sfe_obs = {
+        (gwename + ".sfe.obs.csv",): [
+            (f"sfe-{i + 1}-conc", "TEMPERATURE", i + 1) for i in range(ncol)
+        ]
+        + [(f"sfe-{i + 1}-extinfq", "EXT-INFLOW", i + 1) for i in range(ncol)],
+    }
+    sfe_obs["digits"] = 10
+    sfe_obs["print_input"] = True
+    sfe_obs["filename"] = gwename + ".sfe.obs"
+    
+    sfe = flopy.mf6.modflow.ModflowGwesfe(
+        gwe,
+        boundnames=True,
+        save_flows=True,
+        print_input=True,
+        print_flows=True,
+        print_temperature=True,
+        temperature_filerecord=gwename + ".sfe.bin",
+        packagedata=sfepackagedata,
+        reachperioddata=sfeperioddata,
+        observations=sfe_obs,
+        flow_package_name="SFR-" + str(mod_num),
+        pname="SFE-" + str(mod_num),
+        filename=f"{gwename}.sfe",
+    )
+    
+    # Instantiate heat transport output control package
+    flopy.mf6.ModflowGweoc(
+        gwe,
+        pname="OC",
+        budget_filerecord=f"{gwename}.cbc",
+        temperature_filerecord=f"{gwename}.ucn",
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
+        printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
+    )
+    
+    return sim, gwe
+
+
+def build_models(idx, test):
+    # Base MF6 GWF model type
+    ws = test.workspace
+    name = cases[idx]
+
+    print(f"Building MF6 model...{name}")
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=ws, exe_name="mf6", version="mf6"
+    )
+
+    # Instantiating time discretization
+    flopy.mf6.ModflowTdis(
+        sim,
+        nper=nper,
+        perioddata=tdis_rc,
+        time_units=time_units,
+        filename=f"{name}.tdis",
+    )
+
+    gwf_models = []
+    gwe_models = []
+
+    for i in [1, 2]:
+        # generate names for each model
+        gwfname = "gwf" + str(i) + "-" + name
+        gwename = "gwe" + str(i) + "-" + name
+
+        # gwf
+        sim, gwf = build_gwf_model(sim, gwfname, i)
+        # gwe
+        sim, gwe = build_gwe_model(sim, gwename, i)
+
+        gwf_models.append(gwf.name)
+        gwe_models.append(gwe.name)
+
+        # Instantiating flow-transport exchange mechanism
+        flopy.mf6.ModflowGwfgwe(
+            sim,
+            exgtype="GWF6-GWE6",
+            exgmnamea=gwfname,
+            exgmnameb=gwename,
+            pname="gwfgwe-" + str(i),
+            filename=f"{gwename}.gwfgwe" + str(i),
+        )
+
+    # Instantiating solver for both flow models
+    imsgwf = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="CG",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename=f"{gwfname}.ims",
+    )
+    sim.register_ims_package(imsgwf, [gwf_models[0]])
+    sim.register_ims_package(imsgwf, [gwf_models[1]])
+
+    imsgwe = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename=f"{gwename}.ims",
+    )
+    sim.register_ims_package(imsgwe, [gwe_models[0]])
+    sim.register_ims_package(imsgwe, [gwe_models[1]])
+
+    # now the simulation-level GWF-GWF and GWE-GWE movers
+    # GWF-GWF
+
+    # add a gwf-gwf exchange
+    gwfgwf_data = [
+        ((0, 0, ncol - 1), (0, 0, 0), 1, delr / 2.0, delr / 2.0, delc, 0.0, delr)
+    ]
+
+    mvr_filerecord = f"{gwf_models[0]}-{gwf_models[1]}.exg.mvr"
+    gwfgwf = flopy.mf6.ModflowGwfgwf(
+        sim,
+        exgtype="GWF6-GWF6",
+        nexg=len(gwfgwf_data),
+        exgmnamea=gwf_models[0],
+        exgmnameb=gwf_models[1],
+        exchangedata=gwfgwf_data,
+        auxiliary=["ANGLDEGX", "CDIST"],
+        mvr_filerecord=mvr_filerecord,
+        filename=f"{gwf_models[0]}-{gwf_models[1]}.exg",
+    )
+
+    # simulation GWF-GWF Mover
+    maxmvr, maxpackages = 1, 2
+    mvrpack_sim = [[gwf_models[0], "SFR-1"], [gwf_models[1], "SFR-2"]]
+    mvrspd = [
+        [gwf_models[0], "SFR-1", ncol - 1, gwf_models[1], "SFR-2", 0, "FACTOR", 1.00]
+    ]
+    gwfgwf.mvr.initialize(
+        modelnames=True,
+        maxmvr=maxmvr,
+        print_flows=True,
+        maxpackages=maxpackages,
+        packages=mvrpack_sim,
+        perioddata=mvrspd,
+        filename=mvr_filerecord,
+    )
+
+    # GWE-GWE
+    mve_filerecord = f"{gwe_models[0]}-{gwe_models[1]}.exg.mve"
+    gwegwe = flopy.mf6.ModflowGwegwe(
+        sim,
+        exgtype="GWE6-GWE6",
+        nexg=len(gwfgwf_data),
+        exgmnamea=gwe_models[0],
+        exgmnameb=gwe_models[1],
+        gwfmodelname1=gwf_models[0],
+        gwfmodelname2=gwf_models[1],
+        exchangedata=gwfgwf_data,
+        auxiliary=["ANGLDEGX", "CDIST"],
+        mve_filerecord=mve_filerecord,
+        filename=f"{gwe_models[0]}-{gwe_models[1]}.exg",
+    )
+
+    # simulation GWE-GWE Mover
+    gwegwe.mve.initialize(filename=mve_filerecord)
+
+    return sim, None
+
+
+def check_output(idx, test):
+    print("evaluating results...")
+
+    # read transport results from GWE model
+    name = cases[idx]
+    gwename = "gwe" + str(2) + "-" + name
+
+    ws = test.workspace
+    fname = os.path.join(ws, gwename + ".lst")
+    assert os.path.isfile(fname), "File not found: " + fname
+
+    srch_str1 = "SFE PACKAGE (SFE-2) TEMPERATURE FOR EACH CONTROL VOLUME"
+    srch_str2 = " MYREACH1 "
+
+    with open(fname, "r") as f:
+        for line in f:
+            if srch_str1 in line:
+                while srch_str2 not in line:
+                    line = next(f)
+                break
+
+    # process the last line read
+    m_arr = line.strip().split()
+
+    # if mvr and mve are working correctly, the temperature of the water 
+    # moved from model 1 to model 2, thestream temperature should be cut in half
+    assert float(m_arr[-1]) == strt_temp / 2, (
+        "SFE temperature for model2, reach 1 not equal to 50.0"
+    )
+
+
+# - No need to change any code below
+@pytest.mark.parametrize(
+    "idx, name",
+    list(enumerate(cases)),
+)
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+    )
+    test.run()


### PR DESCRIPTION
In support of PR #2774, which adds support for parallel `MVT` and `MVE`, an autotest that confirms MVE works correctly when it is used to connect two SFE reaches across models, for example, was needed.  This PR provides such a test.  

- [x] Replaced section above with description of pull request
- [x] Related to a number of other pull requests: 
        #2774 
        #2715
        Additionally, this test needs [#2750](https://github.com/modflowpy/flopy/pull/2750) in flopy to pass.
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.