### PR TITLE
fix(prt): trap subcell cycles

### DIFF
--- a/src/Solution/ParticleTracker/Method/MethodCell.f90
+++ b/src/Solution/ParticleTracker/Method/MethodCell.f90
@@ -7,6 +7,7 @@ module MethodCellModule
   use ParticleModule, only: ParticleType, ACTIVE, TERM_NO_EXITS, TERM_BOUNDARY
   use ParticleEventModule, only: ParticleEventType
   use CellExitEventModule, only: CellExitEventType
+  use SubCellExitEventModule, only: SubCellExitEventType
   use CellDefnModule, only: CellDefnType, SATURATION_DRY
   use IteratorModule, only: IteratorType
   implicit none
@@ -279,6 +280,22 @@ contains
           end if
         end select
       end do
+    type is (SubCellExitEventType)
+      itr = particle%history%Iterator()
+      do while (itr%has_next())
+        call itr%next()
+        select type (prev => itr%value())
+        class is (SubCellExitEventType)
+          if (event%icu == prev%icu .and. &
+              event%ilay == prev%ilay .and. &
+              event%isc == prev%isc .and. &
+              event%exit_face == prev%exit_face .and. &
+              event%exit_face /= 0) then
+            found_cycle = .true.
+            exit
+          end if
+        end select
+      end do
     end select
   end function forms_cycle
 
@@ -295,6 +312,11 @@ contains
 
     select type (event)
     type is (CellExitEventType)
+      p => event
+      call particle%history%Add(p)
+      if (particle%history%Count() > particle%icycwin) &
+        call particle%history%RemoveNode(1, .true.)
+    type is (SubCellExitEventType)
       p => event
       call particle%history%Add(p)
       if (particle%history%Count() > particle%icycwin) &

--- a/src/Solution/ParticleTracker/Method/MethodSubcell.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcell.f90
@@ -1,5 +1,6 @@
 module MethodSubcellModule
   use KindModule, only: DP, I4B
+  use ErrorUtilModule, only: pstop
   use MethodModule, only: LEVEL_SUBFEATURE
   use MethodCellModule, only: MethodCellType
   use ParticleModule, only: ParticleType
@@ -35,6 +36,9 @@ contains
     class(MethodSubcellType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
     class(ParticleEventType), pointer :: event
+    ! local
+    integer(I4B) :: i, nhist
+    class(*), pointer :: prev
 
     allocate (SubCellExitEventType :: event)
     select type (event)
@@ -43,6 +47,25 @@ contains
       event%exit_face = particle%iboundary(LEVEL_SUBFEATURE)
     end select
     call this%events%broadcast(particle, event)
+    if (particle%icycwin == 0) then
+      deallocate (event)
+      return
+    end if
+    if (this%forms_cycle(particle, event)) then
+      print *, "Cyclic subcell pathline detected"
+      nhist = particle%history%Count()
+      do i = 1, nhist
+        prev => particle%history%GetItem(i)
+        select type (prev)
+        class is (ParticleEventType)
+          print *, "Back ", nhist - i + 1, ": ", prev%get_text()
+        end select
+      end do
+      print *, "Current :", event%get_text()
+      call pstop(1, 'Cyclic subcell pathline detected, aborting')
+    else
+      call this%store_event(particle, event)
+    end if
   end subroutine subcellexit
 
   !> @brief Get the subcell method's level.


### PR DESCRIPTION
#2435 added a cycle detection option to PRT, where a cycle is defined as a particle exiting through the same cell face more than once in the same solve. This did not catch cycles between subcells, though. Expand the mechanism to trap subcell cycles too.

No release note since cycle detection is currently a dev option. Though I wonder if at some point we should make it user-facing, since cycles have proven not particularly rare.