### PR TITLE
ci: drop intel mac builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,10 +330,6 @@ jobs:
           - os: macos-14
             debug: true
             xcode-version: '15.1.0'
-          # intel mac, release mode
-          - os: macos-15-intel
-            debug: false
-            xcode-version: '16.1.0'
           # ubuntu, release mode
           - os: ubuntu-22.04
             debug: false

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -27,7 +27,6 @@ jobs:
           - {os: macos-14, compiler: gcc, version: 12, xcode-version: '15.1.0'}
           - {os: macos-14, compiler: gcc, version: 13, xcode-version: '15.1.0'}
           - {os: macos-14, compiler: gcc, version: 14, xcode-version: '15.1.0'}
-          - {os: macos-15-intel, compiler: gcc, version: 13, xcode-version: '16.1.0'}
           - {os: windows-2022, compiler: gcc, version: 11}
           - {os: windows-2022, compiler: gcc, version: 12}
           - {os: windows-2022, compiler: gcc, version: 13}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,12 +70,6 @@ jobs:
             optimization: 1
             extended: false
             xcode-version: '15.1.0'
-          - os: macos-15-intel
-            compiler: gcc
-            version: 13
-            optimization: 1
-            extended: false
-            xcode-version: '16.1.0'
           - os: windows-2022
             compiler: ${{ inputs.compiler_toolchain }}
             version: ${{ inputs.compiler_version }}
@@ -609,9 +603,6 @@ jobs:
             compiler: ${{ inputs.compiler_toolchain }}
             version: ${{ inputs.compiler_version }}
           - os: macos-14
-            compiler: gcc
-            version: 13
-          - os: macos-15-intel
             compiler: gcc
             version: 13
           - os: windows-2022


### PR DESCRIPTION
The recently added gfortran builds for Intel Macs are more trouble than they're worth to maintain. Statically linking gcc/gfortran libs does not work reliably on the `macos-15-intel` runner. Users can build from source if needed. See related PRs on other MODFLOW-ORG repositories.