### PR TITLE
ci(release): include dfns in distributions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -721,6 +721,7 @@ jobs:
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             zip -r $distname.zip \
               $distname/bin \
+              $distname/dfns \
               $distname/src \
               $distname/srcbmi \
               $distname/doc \
@@ -739,6 +740,7 @@ jobs:
           else
             zip -r $distname.zip \
               $distname/bin/* \
+              $distname/dfns \
               $distname/doc/mf6io.pdf \
               $distname/doc/release.pdf \
               $distname/code.json \
@@ -756,6 +758,7 @@ jobs:
           if [[ "${{ inputs.releasemode }}" == "true" ]]; then
             7z a -tzip $distname.zip \
               $distname/bin \
+              $distname/dfns \
               $distname/src \
               $distname/srcbmi \
               $distname/doc \
@@ -773,6 +776,7 @@ jobs:
           else
             7z a -tzip $distname.zip \
               $distname/bin/* \
+              $distname/dfns \
               $distname/doc/mf6io.pdf \
               $distname/doc/release.pdf \
               $distname/code.json \
@@ -787,6 +791,20 @@ jobs:
         with:
           name: "${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
           path: "${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}.zip"
+
+      - name: Create DFN asset
+        if: runner.os == 'Linux'
+        run: |
+          distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
+          cd "$distname/dfns"
+          zip -r "../../${{ needs.build.outputs.distname }}_dfns.zip" .
+
+      - name: Upload DFN asset
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v7
+        with:
+          name: "${{ needs.build.outputs.distname }}_dfns"
+          path: "${{ needs.build.outputs.distname }}_dfns.zip"
 
       - name: Upload release notes
         if: runner.os == 'Linux'

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -39,6 +39,21 @@ FC = environ.get("FC", "gfortran")
 CC = environ.get("CC", "gcc")
 
 
+def copy_dfns(output_path: PathLike):
+    output_path = Path(output_path).expanduser().absolute()
+    src = PROJ_ROOT_PATH / "doc/mf6io/mf6ivar/dfn"
+    dst = output_path / "dfns"
+    print(f"Copying {src} to {dst}")
+    copytree(src, dst, ignore=ignore_patterns(".DS_Store"))
+
+
+@no_parallel
+def test_copy_dfns(tmp_path):
+    copy_dfns(tmp_path)
+    assert (tmp_path / "dfns").is_dir()
+    assert any((tmp_path / "dfns").glob("*.dfn"))
+
+
 def copy_sources(output_path: PathLike):
     output_path = Path(output_path).expanduser().absolute()
 
@@ -308,6 +323,9 @@ def build_distribution(
 
     # code.json metadata
     copy(PROJ_ROOT_PATH / "code.json", output_path)
+
+    # copy DFN files (included in all distributions)
+    copy_dfns(output_path=output_path)
 
     # full releases include examples, source code, makefiles and docs
     if developmode:

--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -21,10 +21,12 @@ FC = environ.get("FC", None)
 DIST_DIRS = {
     "develop": [
         "bin",
+        "dfns",
         "doc",
     ],
     "release": [
         "bin",
+        "dfns",
         "doc",
         "examples",
         "src",
@@ -61,6 +63,15 @@ def dist_dir_path(request):
 def test_directories(dist_dir_path, releasemode):
     for dir_path in DIST_DIRS["release" if releasemode else "develop"]:
         assert (dist_dir_path / dir_path).is_dir()
+
+
+@no_parallel
+def test_dfns(dist_dir_path):
+    dfns_path = dist_dir_path / "dfns"
+    assert dfns_path.is_dir()
+    assert any(dfns_path.glob("*.dfn"))
+    assert (dfns_path / "sim-nam.dfn").is_file()
+    assert (dfns_path / "gwf-nam.dfn").is_file()
 
 
 @no_parallel


### PR DESCRIPTION
Add `dfns/` folder to both develop and release mode distributions. And add a separate release asset with DFNs for devtools to consume more easily. Close #2349