### PR TITLE
fix: improve error message when dis package missing

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -63,3 +63,8 @@ description = "Avoids an unhandled and unnecessary exception in cases where a GW
 section = "fixes"
 subsection = "netcdf"
 description = "Fix an indexing issue in structured NetCDF export where READASARRAYS packages (RCHA, EVTA) with time-varying per-period arrays would crash with a NetCDF edge-exceeds-bound error when writing any stress period after the first."
+
+[[items]]
+section = "fixes"
+subsection = "basic"
+description = "Stop with an informative error if a discretization package is missing after loading the model input file's PACKAGES block."

--- a/src/Utilities/Idm/ModelPackageInputs.f90
+++ b/src/Utilities/Idm/ModelPackageInputs.f90
@@ -289,9 +289,8 @@ contains
       ftype = ftypes(n)
       found = .false.
 
-      ! check for discretization package
-      if (trim(ftype) == 'DIS6' .or. trim(ftype) == 'DISV6' .or. &
-          trim(ftype) == 'DISU6') has_dis = .true.
+      ! check for discretization package (any type starting with 'DIS')
+      if (ftype(1:3) == 'DIS') has_dis = .true.
 
       ! search supported types for this filetype
       do m = 1, this%niunit
@@ -322,20 +321,13 @@ contains
       end if
     end do
 
-    ! check that a discretization package is specified when required
+    ! check that a discretization package is specified
     if (.not. has_dis) then
-      do m = 1, this%niunit
-        if (trim(this%cunit(m)) == 'DIS6' .or. &
-            trim(this%cunit(m)) == 'DISV6' .or. &
-            trim(this%cunit(m)) == 'DISU6') then
-          write (errmsg, '(3a)') &
-            'Discretization package (DIS6, DISV6, or DISU6) not specified &
-            &for model "', trim(this%modelname), '".'
-          call store_error(errmsg)
-          call store_error_filename(this%modelfname)
-          exit
-        end if
-      end do
+      write (errmsg, '(3a)') &
+        'Discretization package not specified for model "', &
+        trim(this%modelname), '".'
+      call store_error(errmsg)
+      call store_error_filename(this%modelfname)
     end if
 
     ! allocate the pkglist

--- a/src/Utilities/Idm/ModelPackageInputs.f90
+++ b/src/Utilities/Idm/ModelPackageInputs.f90
@@ -277,16 +277,21 @@ contains
     integer(I4B), dimension(:), allocatable :: cunit_idxs, indx
     character(len=LENPACKAGETYPE) :: ftype
     integer(I4B) :: n, m
-    logical(LGP) :: found
+    logical(LGP) :: found, has_dis
 
     ! allocate
     allocate (cunit_idxs(0))
+    has_dis = .false.
 
     ! identify input packages and check that each is supported
     do n = 1, size(ftypes)
       ! type from model nam file packages block
       ftype = ftypes(n)
       found = .false.
+
+      ! check for discretization package
+      if (trim(ftype) == 'DIS6' .or. trim(ftype) == 'DISV6' .or. &
+          trim(ftype) == 'DISU6') has_dis = .true.
 
       ! search supported types for this filetype
       do m = 1, this%niunit
@@ -316,6 +321,22 @@ contains
         call store_error_filename(this%modelfname)
       end if
     end do
+
+    ! check that a discretization package is specified when required
+    if (.not. has_dis) then
+      do m = 1, this%niunit
+        if (trim(this%cunit(m)) == 'DIS6' .or. &
+            trim(this%cunit(m)) == 'DISV6' .or. &
+            trim(this%cunit(m)) == 'DISU6') then
+          write (errmsg, '(3a)') &
+            'Discretization package (DIS6, DISV6, or DISU6) not specified &
+            &for model "', trim(this%modelname), '".'
+          call store_error(errmsg)
+          call store_error_filename(this%modelfname)
+          exit
+        end if
+      end do
+    end if
 
     ! allocate the pkglist
     allocate (this%pkglist(size(cunit_idxs)))

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -9,7 +9,7 @@ module LoadMf6FileModule
 
   use KindModule, only: DP, I4B, LGP
   use SimVariablesModule, only: errmsg
-  use SimModule, only: store_error, store_error_filename, ustop
+  use SimModule, only: store_error
   use ConstantsModule, only: LINELENGTH, LENVARNAME
   use BlockParserModule, only: BlockParserType
   use LayeredArrayReaderModule, only: read_dbl1d_layered, &
@@ -824,14 +824,6 @@ contains
     ! Check if it is a full grid sized array (NODES), otherwise use
     ! idt%shape to construct shape from variables in memoryPath
     if (idt%shape == 'NODES') then
-      if (.not. associated(mshape)) then
-        write (errmsg, '(3a)') &
-          'Grid shape unknown when loading "', trim(idt%tagname), &
-          '". Check that a discretization package is specified for this model.'
-        call store_error(errmsg)
-        call store_error_filename(input_fname)
-        call ustop()
-      end if
       nvals = product(mshape)
     else
       call get_shape_from_string(idt%shape, array_shape, mf6_input%mempath)
@@ -1020,14 +1012,6 @@ contains
 
     ! Check if it is a full grid sized array (NODES)
     if (idt%shape == 'NODES') then
-      if (.not. associated(mshape)) then
-        write (errmsg, '(3a)') &
-          'Grid shape unknown when loading "', trim(idt%tagname), &
-          '". Check that a discretization package is specified for this model.'
-        call store_error(errmsg)
-        call store_error_filename(input_fname)
-        call ustop()
-      end if
       nvals = product(mshape)
     else
       call get_shape_from_string(idt%shape, array_shape, mf6_input%mempath)

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -9,7 +9,7 @@ module LoadMf6FileModule
 
   use KindModule, only: DP, I4B, LGP
   use SimVariablesModule, only: errmsg
-  use SimModule, only: store_error
+  use SimModule, only: store_error, store_error_filename, ustop
   use ConstantsModule, only: LINELENGTH, LENVARNAME
   use BlockParserModule, only: BlockParserType
   use LayeredArrayReaderModule, only: read_dbl1d_layered, &
@@ -824,6 +824,14 @@ contains
     ! Check if it is a full grid sized array (NODES), otherwise use
     ! idt%shape to construct shape from variables in memoryPath
     if (idt%shape == 'NODES') then
+      if (.not. associated(mshape)) then
+        write (errmsg, '(3a)') &
+          'Grid shape unknown when loading "', trim(idt%tagname), &
+          '". Check that a discretization package is specified for this model.'
+        call store_error(errmsg)
+        call store_error_filename(input_fname)
+        call ustop()
+      end if
       nvals = product(mshape)
     else
       call get_shape_from_string(idt%shape, array_shape, mf6_input%mempath)
@@ -1012,6 +1020,14 @@ contains
 
     ! Check if it is a full grid sized array (NODES)
     if (idt%shape == 'NODES') then
+      if (.not. associated(mshape)) then
+        write (errmsg, '(3a)') &
+          'Grid shape unknown when loading "', trim(idt%tagname), &
+          '". Check that a discretization package is specified for this model.'
+        call store_error(errmsg)
+        call store_error_filename(input_fname)
+        call ustop()
+      end if
       nvals = product(mshape)
     else
       call get_shape_from_string(idt%shape, array_shape, mf6_input%mempath)


### PR DESCRIPTION
<details>
<summary>First draft, superseded</summary>

If `mshape` is not associated when package data loads, it likely means the model doesn't have a discretization package. Calling `product(mshape)` is then undefined behavior,  on Windows / Intel Fortran as reported in #2806 it continues into an invalid state until the parser breaks, on Mac / gfortran I found it crashes immediately.

Stop with an informative error suggesting a discretization may be missing if `mshape` is not associated at package data load time. This seems a bit ad hoc, but I'm not sure where to trap for a missing dis otherwise. Maybe you have a better idea @mjreno ?
</details>

Stop with an informative error if grid discretization is missing after loading the model input file's `packages` block.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request