### PR TITLE
fix(exg): optional mvt in gwtgwt exchange

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -48,3 +48,8 @@ description = "The adaptive time stepping algorithm (ATS) was not working correc
 section = "fixes"
 subsection = "parallel"
 description = "Mover (MVR) Package connections across two or more models running in parallel were previously supported for flow but not for solute or energy transport.  GWT-GWT or GWE-GWE exchanges that also include MVT or MVE connections, respectively, is now supported for simulations run in parallel mode."
+
+[[items]]
+section = "fixes"
+subsection = "exchanges"
+description = "Avoids an unhandled and unnecessary exception in cases where a GWF-GWF exchange is configured with a MVR package, but the corresponding GWT-GWT exchange does not have a MVT package enabled."

--- a/src/Exchange/exg-gwfgwt.f90
+++ b/src/Exchange/exg-gwfgwt.f90
@@ -421,8 +421,8 @@ contains
               !
               !cdl link up mvt to mvr
               if (gwfExg%inmvr > 0) then
-                if (gwtConn%owns_exchange) then
-                  !cdl todo: check and make sure gwtEx has mvt active
+                if (gwtConn%owns_exchange .and. &
+                    gwtConn%gwtExchange%inmvt > 0) then
                   call gwtExg%mvt%set_pointer_mvrbudobj(gwfExg%mvr%budobj)
                 end if
               end if
@@ -475,8 +475,7 @@ contains
     !
     !cdl link up mvt to mvr
     if (gwfConn%gwfExchange%inmvr > 0) then
-      if (gwtConn%owns_exchange) then
-        !cdl todo: check and make sure gwtEx has mvt active
+      if (gwtConn%owns_exchange .and. gwtConn%gwtExchange%inmvt > 0) then
         call gwtConn%gwtExchange%mvt%set_pointer_mvrbudobj( &
           gwfConn%gwfExchange%mvr%budobj)
       end if


### PR DESCRIPTION
The MVT need not be configured in GWTGWT exchanges, even though the matching GWFGWF exchange has a MVR package enabled. This was marked as a todo but causing problems now.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
