### PR TITLE
fix(wel): fix for flow_reduction_length with Newton-Raphson

### DIFF
--- a/autotest/test_gwf_wel02.py
+++ b/autotest/test_gwf_wel02.py
@@ -8,14 +8,14 @@ AFR enabled.  Because cell thickness (10 m) differs from the AFR unit length
   Fraction mode: tp = botm + flowred * (top - botm) = 0 + 0.5 * 10 = 5.0 m
   Length  mode:  tp = botm + flowred * 1.0           = 0 + 0.5       = 0.5 m
 
-Each case runs Newton (main workspace) and non-Newton (mf6/ subdirectory).
-The TestFramework's automatic head comparison verifies Newton ≈ non-Newton.
-check_output() additionally verifies that the two AFR modes produce heads on
-opposite sides of a 1.0 m threshold after 4 days of pumping.
+Each case runs Newton (wel02-frac or wel02-len) and non-Newton (wel02-frac/mf6 or
+wel02-len/mf6 subdirectory). The TestFramework's automatic head comparison
+verifies Newton ≈ non-Newton. check_output() additionally verifies that the two AFR
+modes produce heads on opposite sides of a 1.0 m threshold after 4 days of pumping.
 
 Analytical estimates (smoothstep saturation, Euler forward, dt=0.1 d):
-  fraction: full pumping for ~2 d (h: 10→5), then reduced → h(4d) ≈ 1.7 m
-  length:   full pumping for ~3.8 d (h: 10→0.5), then near-zero → h(4d) ≈ 0.1 m
+  fraction: full pumping for ~2 d (h: 10 to 5), then reduced to h(4d) ≈ 1.8 m
+  length:   full pumping for ~3.8 d (h: 10 to 0.5), then near-zero to h(4d) ≈ 0.2 m
 The 1.0 m threshold separates them with > 0.7 m margin on each side.
 """
 

--- a/autotest/test_gwf_wel02.py
+++ b/autotest/test_gwf_wel02.py
@@ -1,52 +1,69 @@
 """
-Variation of test_gwf_wel01 that compares head and flow results for MODFLOW 6
-simulations with and without the FLOW_REDUCTION_LENGTH option.
+Tests AUTO_FLOW_REDUCE (AFR) behavior in the WEL package.
+
+Scenario: single isolated unconfined cell, 10 m tall, drained by a well with
+AFR enabled.  Because cell thickness (10 m) differs from the AFR unit length
+(1 m), fraction mode and length mode produce clearly distinct turnoff thresholds:
+
+  Fraction mode: tp = botm + flowred * (top - botm) = 0 + 0.5 * 10 = 5.0 m
+  Length  mode:  tp = botm + flowred * 1.0           = 0 + 0.5       = 0.5 m
+
+Each case runs Newton (main workspace) and non-Newton (mf6/ subdirectory).
+The TestFramework's automatic head comparison verifies Newton ≈ non-Newton.
+check_output() additionally verifies that the two AFR modes produce heads on
+opposite sides of a 1.0 m threshold after 4 days of pumping.
+
+Analytical estimates (smoothstep saturation, Euler forward, dt=0.1 d):
+  fraction: full pumping for ~2 d (h: 10→5), then reduced → h(4d) ≈ 1.7 m
+  length:   full pumping for ~3.8 d (h: 10→0.5), then near-zero → h(4d) ≈ 0.1 m
+The 1.0 m threshold separates them with > 0.7 m margin on each side.
 """
 
 import flopy
+import numpy as np
 import pytest
 from framework import TestFramework
 
-cases = ["wel02"]
+# Two AFR-mode cases; each case compares Newton vs non-Newton.
+cases = ["wel02-frac", "wel02-len"]
 
-# set static data
-nper = 1
-tdis_rc = [
-    (50.0, 50, 1.05),
-]
+# --- Grid: single isolated cell, 10 m thick ---
+nlay, nrow, ncol = 1, 1, 1
+top = 10.0
+botm = [0.0]
+delr = delc = 1.0
 
-nlay, nrow, ncol = 2, 1, 1
-delr = delc = 10.0
-top, botm = 10.0, [9.0, 8.0]
-strt = top
+# --- Hydraulic properties ---
 hk = 1.0
 sy = 0.1
-wellq = 0.25
+strt = 10.0
 
-nouter, ninner = 100, 300
-hclose, rclose, relax = 1e-9, 1e-6, 1.0
+# --- WEL parameters ---
+wellq = -0.25  # m³/d, pumping
+flowred = 0.5
+# Turnoff thresholds (gwf-wel.f90 formulas):
+_tp_frac = botm[0] + flowred * (top - botm[0])  # 5.0 m  (fraction mode)
+_tp_len = botm[0] + flowred * 1.0  # 0.5 m  (length  mode)
+# Head threshold that fraction mode exceeds and length mode falls below.
+_h_threshold = 1.0  # m
+
+# --- Time: 4 days, 40 equal steps of 0.1 d ---
+nper = 1
+tdis_rc = [(4.0, 40, 1.0)]
+
+# --- Solver ---
+nouter, ninner = 500, 300
+hclose = 1e-9
+rcloserecord = 1e-3  # m3/d; framework uses 5x this for comparison
+relax = 1.0
 
 
-def build_model(ws, idx, reduce_length=None):
-    name = cases[idx]
-
-    # build MODFLOW 6 files
+def _build_sim(ws, name, *, use_length, use_newton):
     sim = flopy.mf6.MFSimulation(
-        sim_name=name,
-        version="mf6",
-        exe_name="mf6",
-        sim_ws=ws,
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
-    # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim,
-        time_units="DAYS",
-        nper=nper,
-        perioddata=tdis_rc,
-    )
-
-    # create iterative model solution and register the gwf model with it
-    ims = flopy.mf6.ModflowIms(
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
+    flopy.mf6.ModflowIms(
         sim,
         print_option="SUMMARY",
         outer_dvclose=hclose,
@@ -54,22 +71,19 @@ def build_model(ws, idx, reduce_length=None):
         under_relaxation="NONE",
         inner_maximum=ninner,
         inner_dvclose=hclose,
-        rcloserecord=rclose,
+        rcloserecord=rcloserecord,
         linear_acceleration="BICGSTAB",
         scaling_method="NONE",
         reordering_method="NONE",
         relaxation_factor=relax,
     )
-
-    # create gwf model
     gwf = flopy.mf6.ModflowGwf(
         sim,
         modelname=name,
-        newtonoptions="NEWTON UNDER_RELAXATION",
+        newtonoptions="NEWTON UNDER_RELAXATION" if use_newton else None,
         save_flows=True,
     )
-
-    dis = flopy.mf6.ModflowGwfdis(
+    flopy.mf6.ModflowGwfdis(
         gwf,
         nlay=nlay,
         nrow=nrow,
@@ -79,70 +93,75 @@ def build_model(ws, idx, reduce_length=None):
         top=top,
         botm=botm,
     )
-
-    # initial conditions
-    ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
-
-    # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf,
-        save_flows=True,
-        icelltype=1,
-        k=hk,
-        k33=hk,
-    )
-    # storage
-    sto = flopy.mf6.ModflowGwfsto(
+    flopy.mf6.ModflowGwfic(gwf, strt=strt)
+    flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=1, k=hk, k33=hk)
+    flopy.mf6.ModflowGwfsto(
         gwf,
         save_flows=True,
         iconvert=1,
         ss=0.0,
         sy=sy,
-        steady_state={0: False},
-        transient={0: False},
+        transient={0: True},
     )
-
-    wel_spd = {0: [[0, 0, 0, -wellq]]}
-    wel = flopy.mf6.ModflowGwfwel(
+    flopy.mf6.ModflowGwfwel(
         gwf,
         print_input=True,
         print_flows=True,
-        auto_flow_reduce="auto_flow_reduce 0.5",
-        flow_reduction_length=reduce_length,
-        stress_period_data=wel_spd,
+        auto_flow_reduce=flowred,
+        flow_reduction_length=True if use_length else None,
+        stress_period_data={0: [[0, 0, 0, wellq]]},
         afrcsv_filerecord=f"{name}.afr.csv",
     )
-
-    # output control
-    oc = flopy.mf6.ModflowGwfoc(
+    flopy.mf6.ModflowGwfoc(
         gwf,
         head_filerecord=f"{name}.hds",
         budget_filerecord=f"{name}.cbc",
-        printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        printrecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
     )
-
     return sim
 
 
 def build_models(idx, test):
-    ws = test.workspace
-    sim = build_model(ws, idx, reduce_length=True)
-    mc = build_model(ws / "mf6", idx)
+    name = cases[idx]
+    use_length = name.endswith("-len")
+    sim = _build_sim(test.workspace, name, use_length=use_length, use_newton=True)
+    mc = _build_sim(
+        test.workspace / "mf6", name, use_length=use_length, use_newton=False
+    )
     return sim, mc
 
 
 def check_output(idx, test):
-    fpth0 = test.workspace / f"{test.name}.cbc"
-    fpth1 = test.workspace / "mf6" / f"{test.name}.cbc"
-    outfile = test.workspace / f"{test.name}.cbc.cmp.out"
-    success = flopy.utils.compare.compare_cell_budget(
-        fpth0,
-        fpth1,
-        outfile=outfile,
-        rclose=rclose,
+    name = cases[idx]
+
+    # Read all-time heads from Newton (main) and non-Newton (mf6/) runs.
+    h_nwt = flopy.utils.HeadFile(test.workspace / f"{name}.hds").get_alldata()
+    h_std = flopy.utils.HeadFile(test.workspace / "mf6" / f"{name}.hds").get_alldata()
+
+    # Newton and non-Newton must agree at every time step.
+    # 1 mm tolerance is orders of magnitude above cross-compiler floating-point
+    # differences for a solution converged to hclose=1e-9.
+    max_diff = float(np.max(np.abs(h_nwt - h_std)))
+    assert max_diff < 1e-3, (
+        f"{name}: max Newton vs non-Newton head difference = {max_diff:.2e} m "
+        f"(must be < 1e-3 m)"
     )
-    assert success, f"budgets do not match for {test.name}"
+
+    # After 4 days, fraction mode (tp={_tp_frac} m) retains significantly more
+    # water than length mode (tp={_tp_len} m) because pumping is curtailed much
+    # earlier.  Both sides of the 1.0 m threshold have > 0.7 m of margin.
+    h_final = float(h_nwt[-1, 0, 0, 0])
+    if name.endswith("-frac"):
+        assert h_final > _h_threshold, (
+            f"{name}: fraction-mode final head {h_final:.4f} m must be "
+            f"> {_h_threshold} m (tp_frac={_tp_frac} m reduces pumping early)"
+        )
+    else:
+        assert h_final < _h_threshold, (
+            f"{name}: length-mode final head {h_final:.4f} m must be "
+            f"< {_h_threshold} m (tp_len={_tp_len} m reduces pumping late)"
+        )
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -21,6 +21,11 @@ description = "The default values for DENSITY\\_WATER, HEAT\\_CAPACITY\\_WATER, 
 
 [[items]]
 section = "fixes"
+subsection = "stress"
+description = "For the Well (WEL) Package, when AUTO\\_FLOW\\_REDUCE is active and FLOW\\_REDUCTION\\_LENGTH is specified, the Newton-Raphson linearization incorrectly used the cell thickness instead of the unit length (1.0) when computing the turnoff threshold. This produced an incorrect Jacobian term and inconsistent behavior between the standard and Newton formulations. The thickness calculation in the Newton code path now respects the FLOW\\_REDUCTION\\_LENGTH option, consistent with the non-Newton code path."
+
+[[items]]
+section = "fixes"
 subsection = "internal"
 description = "Resolved mass-balance errors in the Central and UTVD numerical schemes caused by inconsistent interpretation of cell-to-interface distances (cl1/cl2)."
 

--- a/src/Model/GroundWaterFlow/gwf-wel.f90
+++ b/src/Model/GroundWaterFlow/gwf-wel.f90
@@ -426,7 +426,11 @@ contains
           ! -- calculate derivative for well
           tp = this%dis%top(node)
           bt = this%dis%bot(node)
-          thick = tp - bt
+          if (this%iflowredlen == 0) then
+            thick = tp - bt
+          else
+            thick = DONE
+          end if
           tp = bt + this%flowred * thick
           drterm = sQSaturationDerivative(tp, bt, this%xnew(node))
           drterm = drterm * this%q_mult(i)


### PR DESCRIPTION
Fix issue with GWF wel package when using flow_reduction_length option and Newton-Raphson option. Update existing integration test for flow_reduction_length to actually test Newton-Raphson versus non-Newton-Raphson. Bug identified and required code changes provided by @ndeeds. 

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
