### PR TITLE
feat(wel): add auto_flow_reduce_auxname option

### DIFF
--- a/autotest/test_gwf_wel03.py
+++ b/autotest/test_gwf_wel03.py
@@ -1,9 +1,9 @@
 """
-Tests the AUXLENGTHNAME option for the WEL package AUTO_FLOW_REDUCE feature.
+Tests the AUTO_FLOW_REDUCE_AUXNAME option for the WEL package AUTO_FLOW_REDUCE feature.
 
 Two unconfined cells (10 m thick) separated by an inactive cell -- so they are
 truly independent 1-cell problems -- are each pumped at -0.25 m³/d with
-FLOW_REDUCTION_LENGTH and AUXLENGTHNAME active. The per-well LENGTH auxiliary
+FLOW_REDUCTION_LENGTH and AUTO_FLOW_REDUCE_AUXNAME active. The per-well LENGTH auxiliary
 variable assigns different thresholds:
   Cell 0 (col 0): LENGTH = 2.0 m  →  tp = 0 + 2.0 = 2.0 m
   Cell 1 (col 2): LENGTH = 5.0 m  →  tp = 0 + 5.0 = 5.0 m
@@ -11,22 +11,22 @@ variable assigns different thresholds:
 Cell 1 starts reducing pumping earlier (when h ≤ 5 m, at t ≈ 2 d), retaining more
 water, so h_cell1 > h_cell0 at t = 4 d.
 
-Main model: Newton + AUXLENGTHNAME (per-well threshold via aux variable)
+Main model: Newton + AUTO_FLOW_REDUCE_AUXNAME (per-well threshold via aux variable)
 Reference  (mf6/): Newton + two separate WEL packages (one per cell), each with
   an explicit global AUTO_FLOW_REDUCE value equal to the per-well aux value.
-Standard   (std/): standard formulation + AUXLENGTHNAME (otherwise identical to
-  the main model).
+Standard   (std/): standard formulation + AUTO_FLOW_REDUCE_AUXNAME (otherwise
+  identical to the main model).
 
-The TestFramework compare="mf6" verifies that the AUXLENGTHNAME model gives
+The TestFramework compare="mf6" verifies that the AUTO_FLOW_REDUCE_AUXNAME model gives
 identical results (within 1 mm) to the explicit two-package reference, proving
-that AUXLENGTHNAME correctly overrides the global threshold per well.
+that AUTO_FLOW_REDUCE_AUXNAME correctly overrides the global threshold per well.
 check_output() additionally:
   - checks that the standard and Newton formulations give identical results
     (the AUTO_FLOW_REDUCE reduction is applied in wel_cf for both); and
   - checks the physics: h_cell1 > h_cell0.
 
-test_auxlengthname_messages() separately exercises the option's warning and
-error paths (AUXLENGTHNAME without AUTO_FLOW_REDUCE or FLOW_REDUCTION_LENGTH,
+test_afr_auxname_messages() separately exercises the option's warning and
+error paths (AUTO_FLOW_REDUCE_AUXNAME without AUTO_FLOW_REDUCE or FLOW_REDUCTION_LENGTH,
 a missing aux name, and no aux variables at all).
 """
 
@@ -66,7 +66,7 @@ strt = 10.0
 
 # --- WEL parameters ---
 wellq = -0.25  # m³/d
-# Per-well FLOW_REDUCTION_LENGTH values (via AUXLENGTHNAME aux variable):
+# Per-well FLOW_REDUCTION_LENGTH values (via AUTO_FLOW_REDUCE_AUXNAME aux variable):
 _len_cell0 = 2.0  # tp = botm + 2.0 = 2.0 m for cell 0
 _len_cell1 = 5.0  # tp = botm + 5.0 = 5.0 m for cell 1
 
@@ -144,12 +144,12 @@ def _build_tdis_ims(sim, name):
     )
 
 
-def _add_auxlengthname(wel_file, aux_name):
-    """Inject AUXLENGTHNAME keyword into an already-written .wel OPTIONS block."""
+def _add_afr_auxname(wel_file, aux_name):
+    """Inject AUTO_FLOW_REDUCE_AUXNAME into an already-written .wel OPTIONS block."""
     content = wel_file.read_text()
     content = content.replace(
         "END options",
-        f"  AUXLENGTHNAME {aux_name}\nEND options",
+        f"  AUTO_FLOW_REDUCE_AUXNAME {aux_name}\nEND options",
         1,
     )
     wel_file.write_text(content)
@@ -161,10 +161,11 @@ def _run_mf6(exe, ws):
 
 
 def _build_auxlength_sim(ws, name, newton):
-    """Build the per-well AUXLENGTHNAME model (DIS/IC/NPF/STO/OC + WEL) in ws.
+    """Build the per-well AUTO_FLOW_REDUCE_AUXNAME model (DIS/IC/NPF/STO/OC + WEL).
 
     The global AUTO_FLOW_REDUCE value is a placeholder (1.0); it is overridden
-    per-well by AUXLENGTHNAME once the keyword is injected into the .wel file.
+    per-well by AUTO_FLOW_REDUCE_AUXNAME once the keyword is injected into the
+    .wel file.
     """
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=str(ws)
@@ -190,37 +191,37 @@ def _build_auxlength_sim(ws, name, newton):
 def build_models(idx, test):
     name = cases[idx]
 
-    # --- Main model: Newton + AUXLENGTHNAME ---
-    # Flopy does not yet know about AUXLENGTHNAME, so we write the model and
+    # --- Main model: Newton + AUTO_FLOW_REDUCE_AUXNAME ---
+    # Flopy does not yet know about AUTO_FLOW_REDUCE_AUXNAME, so we write the model and
     # then inject the new keyword into the OPTIONS block of the .wel file.
     sim_main = _build_auxlength_sim(test.workspace, name, newton=True)
     sim_main.write_simulation(silent=True)
-    # Inject AUXLENGTHNAME into the written .wel file
-    _add_auxlengthname(pathlib.Path(test.workspace) / f"{name}.wel", "LENGTH")
+    # Inject AUTO_FLOW_REDUCE_AUXNAME into the written .wel file
+    _add_afr_auxname(pathlib.Path(test.workspace) / f"{name}.wel", "LENGTH")
 
     # Run the main model now; the framework never runs it because we return None.
     result = _run_mf6(test.targets["mf6"], test.workspace)
     assert result.returncode == 0, (
-        f"Main AUXLENGTHNAME model failed:\n{result.stdout}\n{result.stderr}"
+        f"Main AUTO_FLOW_REDUCE_AUXNAME model failed:\n{result.stdout}\n{result.stderr}"
     )
 
-    # --- Standard-formulation AUXLENGTHNAME model (std/) ---
+    # --- Standard-formulation AUTO_FLOW_REDUCE_AUXNAME model (std/) ---
     # Identical to the main model but without the Newton-Raphson formulation.
     # The pumping reduction is applied in wel_cf regardless of formulation, so
     # this must converge to the same heads as the Newton main model.
     std_ws = pathlib.Path(test.workspace) / "std"
     sim_std = _build_auxlength_sim(std_ws, name, newton=False)
     sim_std.write_simulation(silent=True)
-    _add_auxlengthname(std_ws / f"{name}.wel", "LENGTH")
+    _add_afr_auxname(std_ws / f"{name}.wel", "LENGTH")
     result = _run_mf6(test.targets["mf6"], std_ws)
     assert result.returncode == 0, (
-        f"Standard-formulation AUXLENGTHNAME model failed:"
+        f"Standard-formulation AUTO_FLOW_REDUCE_AUXNAME model failed:"
         f"\n{result.stdout}\n{result.stderr}"
     )
 
     # --- Reference model (mf6/): Newton + two explicit WEL packages ---
     # Each package covers one cell and carries its own AUTO_FLOW_REDUCE value,
-    # so the results should be bit-for-bit identical to the AUXLENGTHNAME model.
+    # so the results should be bit-for-bit identical to the per-well model.
     ref_ws = pathlib.Path(test.workspace) / "mf6"
     sim_ref = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=str(ref_ws)
@@ -267,10 +268,10 @@ def check_output(idx, test):
     # Compare only active cells (the inactive separator carries 1e30).
     active = h_main < 1e29
 
-    # AUXLENGTHNAME model and explicit two-package reference must agree within 1 mm.
+    # Per-well model and explicit two-package reference must agree within 1 mm.
     max_diff = float(np.max(np.abs(h_main[active] - h_ref[active])))
     assert max_diff < 1e-3, (
-        f"{name}: max head difference between AUXLENGTHNAME and "
+        f"{name}: max head difference between AUTO_FLOW_REDUCE_AUXNAME and "
         f"two-package reference = {max_diff:.2e} m (must be < 1e-3 m)"
     )
 
@@ -309,11 +310,11 @@ def test_mf6model(idx, name, function_tmpdir, targets):
 
 def _run_message_case(exe, ws, afr, frl, aux, inject):
     """Build a minimal one-cell WEL model with the given options, inject an
-    AUXLENGTHNAME keyword, run it, and return (returncode, normalized_stdout).
+    AUTO_FLOW_REDUCE_AUXNAME keyword, run it, and return (rc, normalized stdout).
 
     Parameters control whether AUTO_FLOW_REDUCE (afr) and FLOW_REDUCTION_LENGTH
     (frl) are written and whether an AUX variable (aux) is declared. The
-    AUXLENGTHNAME value injected into the OPTIONS block is given by inject.
+    AUTO_FLOW_REDUCE_AUXNAME value injected into the OPTIONS block is given by inject.
     """
     ws = pathlib.Path(ws)
     ws.mkdir(parents=True, exist_ok=True)
@@ -343,7 +344,7 @@ def _run_message_case(exe, ws, afr, frl, aux, inject):
     flopy.mf6.ModflowGwfwel(gwf, stress_period_data={0: spd}, **kw)
 
     sim.write_simulation(silent=True)
-    _add_auxlengthname(ws / "m.wel", inject)
+    _add_afr_auxname(ws / "m.wel", inject)
     result = _run_mf6(exe, ws)
     # Collapse whitespace so wrapped warning/error lines can be matched.
     return result.returncode, " ".join(result.stdout.split())
@@ -358,8 +359,10 @@ _MESSAGE_CASES = [
         "LENGTH",
         True,
         [
-            "AUXLENGTHNAME is specified but AUTO_FLOW_REDUCE is not specified",
-            "AUXLENGTHNAME is specified but FLOW_REDUCTION_LENGTH is not specified",
+            "AUTO_FLOW_REDUCE_AUXNAME is specified but AUTO_FLOW_REDUCE is "
+            "not specified",
+            "AUTO_FLOW_REDUCE_AUXNAME is specified but FLOW_REDUCTION_LENGTH "
+            "is not specified",
         ],
         id="no_afr_no_frl_warns",
     ),
@@ -370,7 +373,8 @@ _MESSAGE_CASES = [
         "LENGTH",
         True,
         [
-            "AUXLENGTHNAME is specified but FLOW_REDUCTION_LENGTH is not specified",
+            "AUTO_FLOW_REDUCE_AUXNAME is specified but FLOW_REDUCTION_LENGTH "
+            "is not specified",
             "interpreted as a fraction of the cell thickness",
         ],
         id="no_frl_fraction_warns",
@@ -381,7 +385,10 @@ _MESSAGE_CASES = [
         None,
         "LENGTH",
         False,
-        ["AUXLENGTHNAME was specified as LENGTH but no AUX variables specified"],
+        [
+            "AUTO_FLOW_REDUCE_AUXNAME was specified as LENGTH but no AUX "
+            "variables specified"
+        ],
         id="no_aux_errors",
     ),
     pytest.param(
@@ -391,8 +398,8 @@ _MESSAGE_CASES = [
         "BADNAME",
         False,
         [
-            "AUXLENGTHNAME was specified as BADNAME but no AUX variable found "
-            "with this name"
+            "AUTO_FLOW_REDUCE_AUXNAME was specified as BADNAME but no AUX "
+            "variable found with this name"
         ],
         id="bad_aux_name_errors",
     ),
@@ -402,13 +409,113 @@ _MESSAGE_CASES = [
 @pytest.mark.parametrize(
     "afr, frl, aux, inject, expect_success, required", _MESSAGE_CASES
 )
-def test_auxlengthname_messages(
+def test_afr_auxname_messages(
     afr, frl, aux, inject, expect_success, required, function_tmpdir, targets
 ):
-    """Exercise the AUXLENGTHNAME warning and error paths."""
+    """Exercise the AUTO_FLOW_REDUCE_AUXNAME warning and error paths."""
     returncode, out = _run_message_case(
         targets["mf6"], function_tmpdir, afr, frl, aux, inject
     )
+    if expect_success:
+        assert returncode == 0, f"expected success but mf6 failed:\n{out}"
+    else:
+        assert returncode != 0, f"expected failure but mf6 succeeded:\n{out}"
+    for substring in required:
+        assert substring in out, (
+            f"expected message not found:\n  {substring!r}\nin output:\n{out}"
+        )
+
+
+# Cell thickness used by the bounds-check model below (top - botm).
+_BOUNDS_THICK = 10.0
+
+
+def _run_bounds_case(exe, ws, frl, aux_values):
+    """Build a one-cell WEL model whose AUTO_FLOW_REDUCE_AUXNAME aux variable
+    takes the given per-period values, run it, and return (rc, normalized
+    stdout).
+
+    aux_values is a list with one value per stress period, so a multi-period
+    list exercises the per-period bounds check (the value may change between
+    periods). The cell is _BOUNDS_THICK thick.
+    """
+    ws = pathlib.Path(ws)
+    ws.mkdir(parents=True, exist_ok=True)
+    nper = len(aux_values)
+    sim = flopy.mf6.MFSimulation(
+        sim_name="m", version="mf6", exe_name="mf6", sim_ws=str(ws)
+    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=[(1.0, 1, 1.0)] * nper)
+    flopy.mf6.ModflowIms(sim)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="m", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=1,
+        nrow=1,
+        ncol=1,
+        delr=1.0,
+        delc=1.0,
+        top=_BOUNDS_THICK,
+        botm=[0.0],
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=_BOUNDS_THICK)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=1, k=1.0)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=0.0, sy=0.1, transient={0: True})
+
+    kw = {"auxiliary": ["LENGTH"], "auto_flow_reduce": 1.0}
+    if frl:
+        kw["flow_reduction_length"] = True
+    spd = {p: [[(0, 0, 0), -0.1, av]] for p, av in enumerate(aux_values)}
+    flopy.mf6.ModflowGwfwel(gwf, stress_period_data=spd, **kw)
+
+    sim.write_simulation(silent=True)
+    _add_afr_auxname(ws / "m.wel", "LENGTH")
+    result = _run_mf6(exe, ws)
+    return result.returncode, " ".join(result.stdout.split())
+
+
+_FRAC_ERR = (
+    "must be greater than 0 and less than or equal to 1 when "
+    "FLOW_REDUCTION_LENGTH is not specified"
+)
+_LEN_ERR = "must be greater than 0 and less than or equal to the cell thickness"
+
+# (frl, aux_values, expect_success, required substrings)
+_BOUNDS_CASES = [
+    # Fraction mode: valid range is (0, 1].
+    pytest.param(False, [-0.5], False, [_FRAC_ERR], id="frac_negative"),
+    pytest.param(False, [0.0], False, [_FRAC_ERR], id="frac_zero"),
+    pytest.param(False, [1.5], False, [_FRAC_ERR], id="frac_above_one"),
+    pytest.param(False, [0.5], True, [], id="frac_valid"),
+    # Length mode: valid range is (0, cell thickness].
+    pytest.param(True, [-1.0], False, [_LEN_ERR], id="length_negative"),
+    pytest.param(True, [0.0], False, [_LEN_ERR], id="length_zero"),
+    pytest.param(
+        True,
+        [_BOUNDS_THICK + 5.0],
+        False,
+        [_LEN_ERR],
+        id="length_above_thick",
+    ),
+    pytest.param(True, [5.0], True, [], id="length_valid"),
+    # A value valid in period 1 but invalid in period 2 must still be caught,
+    # confirming the check runs every stress period.
+    pytest.param(
+        True,
+        [5.0, _BOUNDS_THICK + 5.0],
+        False,
+        [_LEN_ERR],
+        id="transient_becomes_invalid",
+    ),
+]
+
+
+@pytest.mark.parametrize("frl, aux_values, expect_success, required", _BOUNDS_CASES)
+def test_afr_auxname_bounds(
+    frl, aux_values, expect_success, required, function_tmpdir, targets
+):
+    """Per-well AUTO_FLOW_REDUCE_AUXNAME values out of range must error."""
+    returncode, out = _run_bounds_case(targets["mf6"], function_tmpdir, frl, aux_values)
     if expect_success:
         assert returncode == 0, f"expected success but mf6 failed:\n{out}"
     else:

--- a/autotest/test_gwf_wel03.py
+++ b/autotest/test_gwf_wel03.py
@@ -1,23 +1,33 @@
 """
 Tests the AUXLENGTHNAME option for the WEL package AUTO_FLOW_REDUCE feature.
 
-Two adjacent unconfined cells (10 m thick, hk=1e-4 m/d so effectively isolated)
-are each pumped at -0.25 m³/d with FLOW_REDUCTION_LENGTH and AUXLENGTHNAME active.
-The per-well LENGTH auxiliary variable assigns different thresholds:
-  Cell 1 (col 0): LENGTH = 2.0 m  →  tp = 0 + 2.0 = 2.0 m
-  Cell 2 (col 1): LENGTH = 5.0 m  →  tp = 0 + 5.0 = 5.0 m
+Two unconfined cells (10 m thick) separated by an inactive cell -- so they are
+truly independent 1-cell problems -- are each pumped at -0.25 m³/d with
+FLOW_REDUCTION_LENGTH and AUXLENGTHNAME active. The per-well LENGTH auxiliary
+variable assigns different thresholds:
+  Cell 0 (col 0): LENGTH = 2.0 m  →  tp = 0 + 2.0 = 2.0 m
+  Cell 1 (col 2): LENGTH = 5.0 m  →  tp = 0 + 5.0 = 5.0 m
 
-Cell 2 starts reducing pumping earlier (when h ≤ 5 m, at t ≈ 2 d), retaining more
-water, so h_cell2 > h_cell1 at t = 4 d.
+Cell 1 starts reducing pumping earlier (when h ≤ 5 m, at t ≈ 2 d), retaining more
+water, so h_cell1 > h_cell0 at t = 4 d.
 
 Main model: Newton + AUXLENGTHNAME (per-well threshold via aux variable)
 Reference  (mf6/): Newton + two separate WEL packages (one per cell), each with
   an explicit global AUTO_FLOW_REDUCE value equal to the per-well aux value.
+Standard   (std/): standard formulation + AUXLENGTHNAME (otherwise identical to
+  the main model).
 
 The TestFramework compare="mf6" verifies that the AUXLENGTHNAME model gives
 identical results (within 1 mm) to the explicit two-package reference, proving
 that AUXLENGTHNAME correctly overrides the global threshold per well.
-check_output() additionally checks the physics: h_cell2 > h_cell1.
+check_output() additionally:
+  - checks that the standard and Newton formulations give identical results
+    (the AUTO_FLOW_REDUCE reduction is applied in wel_cf for both); and
+  - checks the physics: h_cell1 > h_cell0.
+
+test_auxlengthname_messages() separately exercises the option's warning and
+error paths (AUXLENGTHNAME without AUTO_FLOW_REDUCE or FLOW_REDUCTION_LENGTH,
+a missing aux name, and no aux variables at all).
 """
 
 import pathlib
@@ -30,15 +40,27 @@ from framework import TestFramework
 
 cases = ["wel03"]
 
-# --- Grid: two adjacent effectively-isolated cells, 10 m thick ---
-nlay, nrow, ncol = 1, 1, 2
+# --- Grid: two pumped cells separated by an inactive cell, 10 m thick ---
+# The two pumped cells (col 0 and col 2) share no cell face, so they are truly
+# independent 1-cell problems. This structural isolation (rather than a very
+# low K between adjacent cells) is important: with only a near-zero coupling the
+# iterative solver can transiently overshoot one cell below its bottom, and the
+# standard formulation then irreversibly converts it to dry (HDRY) -- which
+# cell depends on the linear accelerator. With a fully inactive separator the
+# Newton and standard formulations converge to identical heads.
+nlay, nrow, ncol = 1, 1, 3
 top = 10.0
 botm = [0.0]
-delr = [1.0, 1.0]
+delr = [1.0, 1.0, 1.0]
 delc = 1.0
+idomain = [[[1, 0, 1]]]  # middle cell inactive
+
+# --- Cell indices of the two pumped cells ---
+_col_cell0 = 0
+_col_cell1 = 2
 
 # --- Hydraulic properties ---
-hk = 1e-4  # very low: isolates the two cells
+hk = 1.0  # isolation is structural (inactive separator), so K is immaterial
 sy = 0.1
 strt = 10.0
 
@@ -59,12 +81,18 @@ rcloserecord = 1e-3
 relax = 1.0
 
 
-def _build_gwf_base(sim, name):
-    """Create the GWF model with DIS, IC, NPF, STO, OC; no WEL."""
+def _build_gwf_base(sim, name, newton=True):
+    """Create the GWF model with DIS, IC, NPF, STO, OC; no WEL.
+
+    When newton is True the model uses the Newton-Raphson formulation;
+    when False it uses the standard formulation. The AUTO_FLOW_REDUCE
+    pumping reduction is applied in wel_cf regardless of formulation, so
+    both should converge to the same heads.
+    """
     gwf = flopy.mf6.ModflowGwf(
         sim,
         modelname=name,
-        newtonoptions="NEWTON UNDER_RELAXATION",
+        newtonoptions="NEWTON UNDER_RELAXATION" if newton else None,
         save_flows=True,
     )
     flopy.mf6.ModflowGwfdis(
@@ -76,6 +104,7 @@ def _build_gwf_base(sim, name):
         delc=delc,
         top=top,
         botm=botm,
+        idomain=idomain,
     )
     flopy.mf6.ModflowGwfic(gwf, strt=strt)
     flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=1, k=hk, k33=hk)
@@ -126,48 +155,67 @@ def _add_auxlengthname(wel_file, aux_name):
     wel_file.write_text(content)
 
 
-def build_models(idx, test):
-    name = cases[idx]
+def _run_mf6(exe, ws):
+    """Run the mf6 executable in ws and return the CompletedProcess."""
+    return subprocess.run([str(exe)], cwd=str(ws), capture_output=True, text=True)
 
-    # --- Main model: Newton + AUXLENGTHNAME ---
-    # Flopy does not yet know about AUXLENGTHNAME, so we write the model and
-    # then inject the new keyword into the OPTIONS block of the .wel file.
-    sim_main = flopy.mf6.MFSimulation(
-        sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
+
+def _build_auxlength_sim(ws, name, newton):
+    """Build the per-well AUXLENGTHNAME model (DIS/IC/NPF/STO/OC + WEL) in ws.
+
+    The global AUTO_FLOW_REDUCE value is a placeholder (1.0); it is overridden
+    per-well by AUXLENGTHNAME once the keyword is injected into the .wel file.
+    """
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=str(ws)
     )
-    _build_tdis_ims(sim_main, name)
-    gwf_main = _build_gwf_base(sim_main, name)
-
-    # WEL with AUXILIARY LENGTH and AUTO_FLOW_REDUCE + FLOW_REDUCTION_LENGTH.
-    # The global AUTO_FLOW_REDUCE value is a placeholder (1.0); it is overridden
-    # per-well by AUXLENGTHNAME once the keyword is injected below.
+    _build_tdis_ims(sim, name)
+    gwf = _build_gwf_base(sim, name, newton=newton)
     flopy.mf6.ModflowGwfwel(
-        gwf_main,
+        gwf,
         auxiliary=["LENGTH"],
         auto_flow_reduce=1.0,
         flow_reduction_length=True,
         print_flows=True,
         stress_period_data={
             0: [
-                [(0, 0, 0), wellq, _len_cell0],
-                [(0, 0, 1), wellq, _len_cell1],
+                [(0, 0, _col_cell0), wellq, _len_cell0],
+                [(0, 0, _col_cell1), wellq, _len_cell1],
             ]
         },
     )
+    return sim
 
+
+def build_models(idx, test):
+    name = cases[idx]
+
+    # --- Main model: Newton + AUXLENGTHNAME ---
+    # Flopy does not yet know about AUXLENGTHNAME, so we write the model and
+    # then inject the new keyword into the OPTIONS block of the .wel file.
+    sim_main = _build_auxlength_sim(test.workspace, name, newton=True)
     sim_main.write_simulation(silent=True)
     # Inject AUXLENGTHNAME into the written .wel file
     _add_auxlengthname(pathlib.Path(test.workspace) / f"{name}.wel", "LENGTH")
 
     # Run the main model now; the framework never runs it because we return None.
-    result = subprocess.run(
-        [str(test.targets["mf6"])],
-        cwd=test.workspace,
-        capture_output=True,
-        text=True,
-    )
+    result = _run_mf6(test.targets["mf6"], test.workspace)
     assert result.returncode == 0, (
         f"Main AUXLENGTHNAME model failed:\n{result.stdout}\n{result.stderr}"
+    )
+
+    # --- Standard-formulation AUXLENGTHNAME model (std/) ---
+    # Identical to the main model but without the Newton-Raphson formulation.
+    # The pumping reduction is applied in wel_cf regardless of formulation, so
+    # this must converge to the same heads as the Newton main model.
+    std_ws = pathlib.Path(test.workspace) / "std"
+    sim_std = _build_auxlength_sim(std_ws, name, newton=False)
+    sim_std.write_simulation(silent=True)
+    _add_auxlengthname(std_ws / f"{name}.wel", "LENGTH")
+    result = _run_mf6(test.targets["mf6"], std_ws)
+    assert result.returncode == 0, (
+        f"Standard-formulation AUXLENGTHNAME model failed:"
+        f"\n{result.stdout}\n{result.stderr}"
     )
 
     # --- Reference model (mf6/): Newton + two explicit WEL packages ---
@@ -187,7 +235,7 @@ def build_models(idx, test):
         auto_flow_reduce=_len_cell0,
         flow_reduction_length=True,
         print_flows=True,
-        stress_period_data={0: [[(0, 0, 0), wellq]]},
+        stress_period_data={0: [[(0, 0, _col_cell0), wellq]]},
     )
     flopy.mf6.ModflowGwfwel(
         gwf_ref,
@@ -196,7 +244,7 @@ def build_models(idx, test):
         auto_flow_reduce=_len_cell1,
         flow_reduction_length=True,
         print_flows=True,
-        stress_period_data={0: [[(0, 0, 1), wellq]]},
+        stress_period_data={0: [[(0, 0, _col_cell1), wellq]]},
     )
 
     # Return None for main (already written); framework writes sim_ref.
@@ -212,22 +260,37 @@ def check_output(idx, test):
     h_ref = flopy.utils.HeadFile(
         pathlib.Path(test.workspace) / "mf6" / f"{name}.hds"
     ).get_alldata()
+    h_std = flopy.utils.HeadFile(
+        pathlib.Path(test.workspace) / "std" / f"{name}.hds"
+    ).get_alldata()
+
+    # Compare only active cells (the inactive separator carries 1e30).
+    active = h_main < 1e29
 
     # AUXLENGTHNAME model and explicit two-package reference must agree within 1 mm.
-    max_diff = float(np.max(np.abs(h_main - h_ref)))
+    max_diff = float(np.max(np.abs(h_main[active] - h_ref[active])))
     assert max_diff < 1e-3, (
         f"{name}: max head difference between AUXLENGTHNAME and "
         f"two-package reference = {max_diff:.2e} m (must be < 1e-3 m)"
     )
 
-    # Physics check: cell with tp=5.0 m (col 1) reduces pumping earlier and
-    # retains more water than cell with tp=2.0 m (col 0) at t = 4 d.
+    # Standard and Newton formulations must give identical results (within 1 mm):
+    # the AUTO_FLOW_REDUCE pumping reduction is applied in wel_cf for both.
+    max_diff_form = float(np.max(np.abs(h_main[active] - h_std[active])))
+    assert max_diff_form < 1e-3, (
+        f"{name}: max head difference between Newton and standard "
+        f"formulation = {max_diff_form:.2e} m (must be < 1e-3 m)"
+    )
+
+    # Physics check: cell with tp=5.0 m reduces pumping earlier and retains
+    # more water than cell with tp=2.0 m at t = 4 d.
     h_final = h_main[-1, 0, 0, :]  # shape (ncol,)
-    h_cell0 = float(h_final[0])  # tp = 2.0 m
-    h_cell1 = float(h_final[1])  # tp = 5.0 m
+    h_cell0 = float(h_final[_col_cell0])  # tp = 2.0 m
+    h_cell1 = float(h_final[_col_cell1])  # tp = 5.0 m
     assert h_cell1 > h_cell0, (
-        f"{name}: cell with tp=5.0 m should have higher head than cell with "
-        f"tp=2.0 m, but got h_cell0={h_cell0:.4f} m, h_cell1={h_cell1:.4f} m"
+        f"{name}: cell with tp=5.0 m (col {_col_cell1}) should have higher head "
+        f"than cell with tp=2.0 m (col {_col_cell0}), but got "
+        f"h_cell0={h_cell0:.4f} m, h_cell1={h_cell1:.4f} m"
     )
 
 
@@ -242,3 +305,115 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         compare="mf6",
     )
     test.run()
+
+
+def _run_message_case(exe, ws, afr, frl, aux, inject):
+    """Build a minimal one-cell WEL model with the given options, inject an
+    AUXLENGTHNAME keyword, run it, and return (returncode, normalized_stdout).
+
+    Parameters control whether AUTO_FLOW_REDUCE (afr) and FLOW_REDUCTION_LENGTH
+    (frl) are written and whether an AUX variable (aux) is declared. The
+    AUXLENGTHNAME value injected into the OPTIONS block is given by inject.
+    """
+    ws = pathlib.Path(ws)
+    ws.mkdir(parents=True, exist_ok=True)
+    sim = flopy.mf6.MFSimulation(
+        sim_name="m", version="mf6", exe_name="mf6", sim_ws=str(ws)
+    )
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+    flopy.mf6.ModflowIms(sim)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="m", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf, nlay=1, nrow=1, ncol=1, delr=1.0, delc=1.0, top=10.0, botm=[0.0]
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=10.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=1, k=1.0)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=0.0, sy=0.1, transient={0: True})
+
+    kw = {}
+    if afr is not None:
+        kw["auto_flow_reduce"] = afr
+    if frl:
+        kw["flow_reduction_length"] = True
+    if aux:
+        kw["auxiliary"] = aux
+        spd = [[(0, 0, 0), -0.1, 1.0]]
+    else:
+        spd = [[(0, 0, 0), -0.1]]
+    flopy.mf6.ModflowGwfwel(gwf, stress_period_data={0: spd}, **kw)
+
+    sim.write_simulation(silent=True)
+    _add_auxlengthname(ws / "m.wel", inject)
+    result = _run_mf6(exe, ws)
+    # Collapse whitespace so wrapped warning/error lines can be matched.
+    return result.returncode, " ".join(result.stdout.split())
+
+
+# (afr, frl, aux, inject, expect_success, required substrings)
+_MESSAGE_CASES = [
+    pytest.param(
+        None,
+        False,
+        ["LENGTH"],
+        "LENGTH",
+        True,
+        [
+            "AUXLENGTHNAME is specified but AUTO_FLOW_REDUCE is not specified",
+            "AUXLENGTHNAME is specified but FLOW_REDUCTION_LENGTH is not specified",
+        ],
+        id="no_afr_no_frl_warns",
+    ),
+    pytest.param(
+        1.0,
+        False,
+        ["LENGTH"],
+        "LENGTH",
+        True,
+        [
+            "AUXLENGTHNAME is specified but FLOW_REDUCTION_LENGTH is not specified",
+            "interpreted as a fraction of the cell thickness",
+        ],
+        id="no_frl_fraction_warns",
+    ),
+    pytest.param(
+        1.0,
+        True,
+        None,
+        "LENGTH",
+        False,
+        ["AUXLENGTHNAME was specified as LENGTH but no AUX variables specified"],
+        id="no_aux_errors",
+    ),
+    pytest.param(
+        1.0,
+        True,
+        ["LENGTH"],
+        "BADNAME",
+        False,
+        [
+            "AUXLENGTHNAME was specified as BADNAME but no AUX variable found "
+            "with this name"
+        ],
+        id="bad_aux_name_errors",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "afr, frl, aux, inject, expect_success, required", _MESSAGE_CASES
+)
+def test_auxlengthname_messages(
+    afr, frl, aux, inject, expect_success, required, function_tmpdir, targets
+):
+    """Exercise the AUXLENGTHNAME warning and error paths."""
+    returncode, out = _run_message_case(
+        targets["mf6"], function_tmpdir, afr, frl, aux, inject
+    )
+    if expect_success:
+        assert returncode == 0, f"expected success but mf6 failed:\n{out}"
+    else:
+        assert returncode != 0, f"expected failure but mf6 succeeded:\n{out}"
+    for substring in required:
+        assert substring in out, (
+            f"expected message not found:\n  {substring!r}\nin output:\n{out}"
+        )

--- a/autotest/test_gwf_wel03.py
+++ b/autotest/test_gwf_wel03.py
@@ -1,0 +1,244 @@
+"""
+Tests the AUXLENGTHNAME option for the WEL package AUTO_FLOW_REDUCE feature.
+
+Two adjacent unconfined cells (10 m thick, hk=1e-4 m/d so effectively isolated)
+are each pumped at -0.25 m³/d with FLOW_REDUCTION_LENGTH and AUXLENGTHNAME active.
+The per-well LENGTH auxiliary variable assigns different thresholds:
+  Cell 1 (col 0): LENGTH = 2.0 m  →  tp = 0 + 2.0 = 2.0 m
+  Cell 2 (col 1): LENGTH = 5.0 m  →  tp = 0 + 5.0 = 5.0 m
+
+Cell 2 starts reducing pumping earlier (when h ≤ 5 m, at t ≈ 2 d), retaining more
+water, so h_cell2 > h_cell1 at t = 4 d.
+
+Main model: Newton + AUXLENGTHNAME (per-well threshold via aux variable)
+Reference  (mf6/): Newton + two separate WEL packages (one per cell), each with
+  an explicit global AUTO_FLOW_REDUCE value equal to the per-well aux value.
+
+The TestFramework compare="mf6" verifies that the AUXLENGTHNAME model gives
+identical results (within 1 mm) to the explicit two-package reference, proving
+that AUXLENGTHNAME correctly overrides the global threshold per well.
+check_output() additionally checks the physics: h_cell2 > h_cell1.
+"""
+
+import pathlib
+import subprocess
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = ["wel03"]
+
+# --- Grid: two adjacent effectively-isolated cells, 10 m thick ---
+nlay, nrow, ncol = 1, 1, 2
+top = 10.0
+botm = [0.0]
+delr = [1.0, 1.0]
+delc = 1.0
+
+# --- Hydraulic properties ---
+hk = 1e-4  # very low: isolates the two cells
+sy = 0.1
+strt = 10.0
+
+# --- WEL parameters ---
+wellq = -0.25  # m³/d
+# Per-well FLOW_REDUCTION_LENGTH values (via AUXLENGTHNAME aux variable):
+_len_cell0 = 2.0  # tp = botm + 2.0 = 2.0 m for cell 0
+_len_cell1 = 5.0  # tp = botm + 5.0 = 5.0 m for cell 1
+
+# --- Time: 4 days, 40 equal steps of 0.1 d ---
+nper = 1
+tdis_rc = [(4.0, 40, 1.0)]
+
+# --- Solver ---
+nouter, ninner = 500, 300
+hclose = 1e-9
+rcloserecord = 1e-3
+relax = 1.0
+
+
+def _build_gwf_base(sim, name):
+    """Create the GWF model with DIS, IC, NPF, STO, OC; no WEL."""
+    gwf = flopy.mf6.ModflowGwf(
+        sim,
+        modelname=name,
+        newtonoptions="NEWTON UNDER_RELAXATION",
+        save_flows=True,
+    )
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=strt)
+    flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=1, k=hk, k33=hk)
+    flopy.mf6.ModflowGwfsto(
+        gwf,
+        save_flows=True,
+        iconvert=1,
+        ss=0.0,
+        sy=sy,
+        transient={0: True},
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=f"{name}.hds",
+        budget_filerecord=f"{name}.cbc",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        printrecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
+    )
+    return gwf
+
+
+def _build_tdis_ims(sim, name):
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
+    flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rcloserecord,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+    )
+
+
+def _add_auxlengthname(wel_file, aux_name):
+    """Inject AUXLENGTHNAME keyword into an already-written .wel OPTIONS block."""
+    content = wel_file.read_text()
+    content = content.replace(
+        "END options",
+        f"  AUXLENGTHNAME {aux_name}\nEND options",
+        1,
+    )
+    wel_file.write_text(content)
+
+
+def build_models(idx, test):
+    name = cases[idx]
+
+    # --- Main model: Newton + AUXLENGTHNAME ---
+    # Flopy does not yet know about AUXLENGTHNAME, so we write the model and
+    # then inject the new keyword into the OPTIONS block of the .wel file.
+    sim_main = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
+    )
+    _build_tdis_ims(sim_main, name)
+    gwf_main = _build_gwf_base(sim_main, name)
+
+    # WEL with AUXILIARY LENGTH and AUTO_FLOW_REDUCE + FLOW_REDUCTION_LENGTH.
+    # The global AUTO_FLOW_REDUCE value is a placeholder (1.0); it is overridden
+    # per-well by AUXLENGTHNAME once the keyword is injected below.
+    flopy.mf6.ModflowGwfwel(
+        gwf_main,
+        auxiliary=["LENGTH"],
+        auto_flow_reduce=1.0,
+        flow_reduction_length=True,
+        print_flows=True,
+        stress_period_data={
+            0: [
+                [(0, 0, 0), wellq, _len_cell0],
+                [(0, 0, 1), wellq, _len_cell1],
+            ]
+        },
+    )
+
+    sim_main.write_simulation(silent=True)
+    # Inject AUXLENGTHNAME into the written .wel file
+    _add_auxlengthname(pathlib.Path(test.workspace) / f"{name}.wel", "LENGTH")
+
+    # Run the main model now; the framework never runs it because we return None.
+    result = subprocess.run(
+        [str(test.targets["mf6"])],
+        cwd=test.workspace,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Main AUXLENGTHNAME model failed:\n{result.stdout}\n{result.stderr}"
+    )
+
+    # --- Reference model (mf6/): Newton + two explicit WEL packages ---
+    # Each package covers one cell and carries its own AUTO_FLOW_REDUCE value,
+    # so the results should be bit-for-bit identical to the AUXLENGTHNAME model.
+    ref_ws = pathlib.Path(test.workspace) / "mf6"
+    sim_ref = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=str(ref_ws)
+    )
+    _build_tdis_ims(sim_ref, name)
+    gwf_ref = _build_gwf_base(sim_ref, name)
+
+    flopy.mf6.ModflowGwfwel(
+        gwf_ref,
+        pname="WEL-1",
+        filename="wel1.wel",
+        auto_flow_reduce=_len_cell0,
+        flow_reduction_length=True,
+        print_flows=True,
+        stress_period_data={0: [[(0, 0, 0), wellq]]},
+    )
+    flopy.mf6.ModflowGwfwel(
+        gwf_ref,
+        pname="WEL-2",
+        filename="wel2.wel",
+        auto_flow_reduce=_len_cell1,
+        flow_reduction_length=True,
+        print_flows=True,
+        stress_period_data={0: [[(0, 0, 1), wellq]]},
+    )
+
+    # Return None for main (already written); framework writes sim_ref.
+    return None, sim_ref
+
+
+def check_output(idx, test):
+    name = cases[idx]
+
+    h_main = flopy.utils.HeadFile(
+        pathlib.Path(test.workspace) / f"{name}.hds"
+    ).get_alldata()
+    h_ref = flopy.utils.HeadFile(
+        pathlib.Path(test.workspace) / "mf6" / f"{name}.hds"
+    ).get_alldata()
+
+    # AUXLENGTHNAME model and explicit two-package reference must agree within 1 mm.
+    max_diff = float(np.max(np.abs(h_main - h_ref)))
+    assert max_diff < 1e-3, (
+        f"{name}: max head difference between AUXLENGTHNAME and "
+        f"two-package reference = {max_diff:.2e} m (must be < 1e-3 m)"
+    )
+
+    # Physics check: cell with tp=5.0 m (col 1) reduces pumping earlier and
+    # retains more water than cell with tp=2.0 m (col 0) at t = 4 d.
+    h_final = h_main[-1, 0, 0, :]  # shape (ncol,)
+    h_cell0 = float(h_final[0])  # tp = 2.0 m
+    h_cell1 = float(h_final[1])  # tp = 5.0 m
+    assert h_cell1 > h_cell0, (
+        f"{name}: cell with tp=5.0 m should have higher head than cell with "
+        f"tp=2.0 m, but got h_cell0={h_cell0:.4f} m, h_cell1={h_cell1:.4f} m"
+    )
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        compare="mf6",
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -15,9 +15,14 @@ parallel = "PARALLEL"
 netcdf = "NETCDF"
 
 [[items]]
+section = "features"
+subsection = "stress"
+description = "Added a new AUTO\\_FLOW\\_REDUCE\\_AUXNAME option to the Well (WEL) Package. When AUTO\\_FLOW\\_REDUCE is active, the pumping rate of a well is smoothly reduced as the cell head drops toward the cell bottom, using a single global turnoff threshold for all wells in the package. The new AUTO\\_FLOW\\_REDUCE\\_AUXNAME option names an auxiliary variable whose value sets the turnoff threshold for each well individually, so different wells in the same package can begin reducing their pumping at different heads. The per-well auxiliary value overrides the global AUTO\\_FLOW\\_REDUCE value and is interpreted the same way: as a length above the cell bottom when FLOW\\_REDUCTION\\_LENGTH is specified, or otherwise as a fraction of the cell thickness. If AUTO\\_FLOW\\_REDUCE\\_AUXNAME is specified without AUTO\\_FLOW\\_REDUCE the option is ignored with a warning, and an error is reported if the named auxiliary variable does not exist."
+
+[[items]]
 section = "fixes"
 subsection = "stress"
-description = "The default values for DENSITY\\_WATER, HEAT\\_CAPACITY\\_WATER, LATENT\\_HEAT\\_VAPORIZATION specified in the OPTIONS block were not set as indicated in the MF6IO guide.  Defaults for these three variables now set as documented in the MF6IO guide." 
+description = "The default values for DENSITY\\_WATER, HEAT\\_CAPACITY\\_WATER, LATENT\\_HEAT\\_VAPORIZATION specified in the OPTIONS block were not set as indicated in the MF6IO guide.  Defaults for these three variables now set as documented in the MF6IO guide."
 
 [[items]]
 section = "fixes"

--- a/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
@@ -62,7 +62,7 @@ type double precision
 reader urword
 optional true
 longname cell fractional thickness for reduced pumping
-description keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\_FLOW\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.  This AUTO\_FLOW\_REDUCE option only applies to wells in model cells that are marked as ``convertible'' (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0).
+description keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\_FLOW\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. AUTO\_FLOW\_REDUCE is set to 1.0 if the specified value is greater than 1.0 and the FLOW\_REDUCTION\_LENGTH option is not specified (that is, the value is interpreted as a fraction of the cell thickness). By default, negative pumping rates are not reduced during a simulation.  This AUTO\_FLOW\_REDUCE option only applies to wells in model cells that are marked as ``convertible'' (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0).
 mf6internal flowred
 
 block options
@@ -121,13 +121,14 @@ description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length inst
 mf6internal iflowredlen
 
 block options
-name auxlengthname
+name auto_flow_reduce_auxname
 type string
 shape
 reader urword
 optional true
-longname name of auxiliary variable for per-well flow reduction length or fraction
-description name of a variable listed in AUXILIARY that defines the per-well value used to compute the flow reduction threshold for each well. When FLOW\_REDUCTION\_LENGTH is specified, the auxiliary variable is interpreted as a length; otherwise it is interpreted as a fraction of the cell thickness. When specified, the per-well auxiliary value overrides the global AUTO\_FLOW\_REDUCE value for that well. A warning will be issued if AUXLENGTHNAME is specified but AUTO\_FLOW\_REDUCE is not specified in the OPTIONS block. A warning will be issued if AUXLENGTHNAME is specified but FLOW\_REDUCTION\_LENGTH is not specified in the OPTIONS block. The program will terminate with an error if AUXLENGTHNAME is specified but no AUXILIARY variables are specified, or if the named AUXILIARY variable cannot be found.
+longname name of auxiliary variable for the per-well AUTO\_FLOW\_REDUCE value
+description name of a variable listed in AUXILIARY that defines the per-well AUTO\_FLOW\_REDUCE value used to compute the flow reduction threshold for each well. The auxiliary variable is interpreted the same way as the global AUTO\_FLOW\_REDUCE value: as a length above the cell bottom when FLOW\_REDUCTION\_LENGTH is specified, or otherwise as a fraction of the cell thickness. When specified, the per-well auxiliary value overrides the global AUTO\_FLOW\_REDUCE value for that well. A warning will be issued if AUTO\_FLOW\_REDUCE\_AUXNAME is specified but AUTO\_FLOW\_REDUCE is not specified in the OPTIONS block. A warning will be issued if AUTO\_FLOW\_REDUCE\_AUXNAME is specified but FLOW\_REDUCTION\_LENGTH is not specified in the OPTIONS block. The program will terminate with an error if AUTO\_FLOW\_REDUCE\_AUXNAME is specified but no AUXILIARY variables are specified, or if the named AUXILIARY variable cannot be found. The per-well value must be greater than zero and less than or equal to 1 when FLOW\_REDUCTION\_LENGTH is not specified, or greater than zero and less than or equal to the cell thickness when FLOW\_REDUCTION\_LENGTH is specified; the program will terminate with an error if a value is outside the valid range.
+mf6internal afrauxname
 
 block options
 name ts_filerecord

--- a/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
@@ -121,6 +121,15 @@ description keyword that indicates the AUTO\_FLOW\_REDUCE value is a length inst
 mf6internal iflowredlen
 
 block options
+name auxlengthname
+type string
+shape
+reader urword
+optional true
+longname name of auxiliary variable for per-well flow reduction length or fraction
+description name of a variable listed in AUXILIARY that defines the per-well value used to compute the flow reduction threshold for each well. When FLOW\_REDUCTION\_LENGTH is specified, the auxiliary variable is interpreted as a length; otherwise it is interpreted as a fraction of the cell thickness. When specified, the per-well auxiliary value overrides the global AUTO\_FLOW\_REDUCE value for that well. A warning will be issued if AUXLENGTHNAME is specified but AUTO\_FLOW\_REDUCE is not specified in the OPTIONS block. A warning will be issued if AUXLENGTHNAME is specified but FLOW\_REDUCTION\_LENGTH is not specified in the OPTIONS block. The program will terminate with an error if AUXLENGTHNAME is specified but no AUXILIARY variables are specified, or if the named AUXILIARY variable cannot be found.
+
+block options
 name ts_filerecord
 type record ts6 filein ts6_filename
 shape

--- a/src/Idm/gwf-welidm.f90
+++ b/src/Idm/gwf-welidm.f90
@@ -24,7 +24,7 @@ module GwfWelInputModule
     logical :: fileout = .false.
     logical :: afrcsvfile = .false.
     logical :: iflowredlen = .false.
-    logical :: auxlengthname = .false.
+    logical :: afrauxname = .false.
     logical :: ts_filerecord = .false.
     logical :: ts6 = .false.
     logical :: filein = .false.
@@ -277,17 +277,17 @@ module GwfWelInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    gwfwel_auxlengthname = InputParamDefinitionType &
+    gwfwel_afrauxname = InputParamDefinitionType &
     ( &
     'GWF', & ! component
     'WEL', & ! subcomponent
     'OPTIONS', & ! block
-    'AUXLENGTHNAME', & ! tag name
-    'AUXLENGTHNAME', & ! fortran variable
+    'AUTO_FLOW_REDUCE_AUXNAME', & ! tag name
+    'AFRAUXNAME', & ! fortran variable
     'STRING', & ! type
     '', & ! shape
-    'name of auxiliary variable for per-well flow reduction '// &
-    'length or fraction', & ! longname
+    'name of auxiliary variable for the per-well '// &
+    'AUTO\_FLOW\_REDUCE value', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -558,7 +558,7 @@ module GwfWelInputModule
     gwfwel_fileout, &
     gwfwel_afrcsvfile, &
     gwfwel_iflowredlen, &
-    gwfwel_auxlengthname, &
+    gwfwel_afrauxname, &
     gwfwel_ts_filerecord, &
     gwfwel_ts6, &
     gwfwel_filein, &

--- a/src/Idm/gwf-welidm.f90
+++ b/src/Idm/gwf-welidm.f90
@@ -24,6 +24,7 @@ module GwfWelInputModule
     logical :: fileout = .false.
     logical :: afrcsvfile = .false.
     logical :: iflowredlen = .false.
+    logical :: auxlengthname = .false.
     logical :: ts_filerecord = .false.
     logical :: ts6 = .false.
     logical :: filein = .false.
@@ -267,6 +268,26 @@ module GwfWelInputModule
     'KEYWORD', & ! type
     '', & ! shape
     'flow reduction length keyword', & ! longname
+    .false., & ! required
+    .false., & ! developmode
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfwel_auxlengthname = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'WEL', & ! subcomponent
+    'OPTIONS', & ! block
+    'AUXLENGTHNAME', & ! tag name
+    'AUXLENGTHNAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'name of auxiliary variable for per-well flow reduction '// &
+    'length or fraction', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record
@@ -537,6 +558,7 @@ module GwfWelInputModule
     gwfwel_fileout, &
     gwfwel_afrcsvfile, &
     gwfwel_iflowredlen, &
+    gwfwel_auxlengthname, &
     gwfwel_ts_filerecord, &
     gwfwel_ts6, &
     gwfwel_filein, &

--- a/src/Model/GroundWaterFlow/gwf-wel.f90
+++ b/src/Model/GroundWaterFlow/gwf-wel.f90
@@ -43,12 +43,13 @@ module WelModule
     real(DP), pointer :: flowred => null() !< AUTO_FLOW_REDUCE variable
     integer(I4B), pointer :: ioutafrcsv => null() !< unit number for CSV output file containing wells with reduced puping rates
     integer(I4B), pointer :: iflowredlen => null() !< flag indicating flowred variable is a length value
-    integer(I4B), pointer :: iauxlengthcol => null() !< column index in auxvar for AUXLENGTHNAME (0 if not active)
+    integer(I4B), pointer :: iafrauxcol => null() !< column index in auxvar for AUTO_FLOW_REDUCE_AUXNAME (0 if not active)
   contains
     procedure :: allocate_scalars => wel_allocate_scalars
     procedure :: allocate_arrays => wel_allocate_arrays
     procedure :: source_options => wel_options
     procedure :: log_wel_options
+    procedure :: bnd_ck => wel_ck
     procedure :: bnd_cf => wel_cf
     procedure :: bnd_fc => wel_fc
     procedure :: bnd_fn => wel_fn
@@ -127,7 +128,7 @@ contains
     call mem_deallocate(this%flowred)
     call mem_deallocate(this%ioutafrcsv)
     call mem_deallocate(this%iflowredlen)
-    call mem_deallocate(this%iauxlengthcol)
+    call mem_deallocate(this%iafrauxcol)
     call mem_deallocate(this%q, 'Q', this%memoryPath)
   end subroutine wel_da
 
@@ -151,14 +152,14 @@ contains
     call mem_allocate(this%flowred, 'FLOWRED', this%memoryPath)
     call mem_allocate(this%ioutafrcsv, 'IOUTAFRCSV', this%memoryPath)
     call mem_allocate(this%iflowredlen, 'IFLOWREDLEN', this%memoryPath)
-    call mem_allocate(this%iauxlengthcol, 'IAUXLENGTHCOL', this%memoryPath)
+    call mem_allocate(this%iafrauxcol, 'IAFRAUXCOL', this%memoryPath)
     !
     ! -- Set values
     this%iflowred = 0
     this%ioutafrcsv = 0
     this%flowred = DZERO
     this%iflowredlen = 0
-    this%iauxlengthcol = 0
+    this%iafrauxcol = 0
   end subroutine wel_allocate_scalars
 
   !> @ brief Allocate arrays
@@ -200,7 +201,7 @@ contains
     class(WelType), intent(inout) :: this !< WelType object
     ! -- local variables
     character(len=LINELENGTH) :: fname
-    character(len=LENAUXNAME) :: auxlengthname
+    character(len=LENAUXNAME) :: afrauxname
     type(GwfWelParamFoundType) :: found
     integer(I4B) :: n
     ! -- formats
@@ -218,8 +219,8 @@ contains
     call mem_set_value(this%imover, 'MOVER', this%input_mempath, found%mover)
     call mem_set_value(this%iflowredlen, 'IFLOWREDLEN', this%input_mempath, &
                        found%iflowredlen)
-    call mem_set_value(auxlengthname, 'AUXLENGTHNAME', this%input_mempath, &
-                       found%auxlengthname)
+    call mem_set_value(afrauxname, 'AFRAUXNAME', this%input_mempath, &
+                       found%afrauxname)
 
     if (found%iflowredlen) then
       if (found%flowred .eqv. .FALSE.) then
@@ -256,37 +257,38 @@ contains
       this%imover = 1
     end if
 
-    if (found%auxlengthname) then
+    if (found%afrauxname) then
       if (.not. found%flowred) then
         write (warnmsg, '(a)') &
-          'AUXLENGTHNAME is specified but AUTO_FLOW_REDUCE is not specified. &
-          &The AUXLENGTHNAME option will be ignored.'
+          'AUTO_FLOW_REDUCE_AUXNAME is specified but AUTO_FLOW_REDUCE is not &
+          &specified. The AUTO_FLOW_REDUCE_AUXNAME option will be ignored.'
         call store_warning(warnmsg)
       end if
       if (.not. found%iflowredlen) then
         write (warnmsg, '(a)') &
-          'AUXLENGTHNAME is specified but FLOW_REDUCTION_LENGTH is not &
-          &specified. The AUXLENGTHNAME value will be interpreted as a &
-          &fraction of the cell thickness.'
+          'AUTO_FLOW_REDUCE_AUXNAME is specified but FLOW_REDUCTION_LENGTH is &
+          &not specified. The AUTO_FLOW_REDUCE_AUXNAME value will be &
+          &interpreted as a fraction of the cell thickness.'
         call store_warning(warnmsg)
       end if
       if (found%flowred) then
         if (this%naux == 0) then
           write (errmsg, '(a,2(1x,a))') &
-            'AUXLENGTHNAME was specified as', trim(adjustl(auxlengthname)), &
-            'but no AUX variables specified.'
+            'AUTO_FLOW_REDUCE_AUXNAME was specified as', &
+            trim(adjustl(afrauxname)), 'but no AUX variables specified.'
           call store_error(errmsg)
         end if
-        this%iauxlengthcol = 0
+        this%iafrauxcol = 0
         do n = 1, this%naux
-          if (auxlengthname == this%auxname(n)) then
-            this%iauxlengthcol = n
+          if (afrauxname == this%auxname(n)) then
+            this%iafrauxcol = n
             exit
           end if
         end do
-        if (this%iauxlengthcol == 0) then
+        if (this%iafrauxcol == 0) then
           write (errmsg, '(a,2(1x,a))') &
-            'AUXLENGTHNAME was specified as', trim(adjustl(auxlengthname)), &
+            'AUTO_FLOW_REDUCE_AUXNAME was specified as', &
+            trim(adjustl(afrauxname)), &
             'but no AUX variable found with this name.'
           call store_error(errmsg)
         end if
@@ -340,15 +342,83 @@ contains
       write (this%iout, '(4x,A)') 'MOVER OPTION ENABLED'
     end if
 
-    if (found%auxlengthname) then
+    if (found%afrauxname) then
       write (this%iout, '(4x,A)') &
-        'AUXLENGTHNAME OPTION ENABLED FOR PER-WELL FLOW REDUCTION'
+        'AUTO_FLOW_REDUCE_AUXNAME OPTION ENABLED FOR PER-WELL FLOW REDUCTION'
     end if
     !
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
   end subroutine log_wel_options
+
+  !> @ brief Check WEL period data.
+    !!
+    !!  Verify that the per-well AUTO_FLOW_REDUCE_AUXNAME auxiliary values are
+    !!  within valid bounds. When FLOW_REDUCTION_LENGTH is not specified the
+    !!  value is interpreted as a fraction of the cell thickness and must be
+    !!  between 0 and 1. When FLOW_REDUCTION_LENGTH is specified the value is
+    !!  interpreted as a length above the cell bottom and must be between 0 and
+    !!  the cell thickness. The check runs each stress period because the
+    !!  auxiliary values may change between periods.
+    !!
+  !<
+  subroutine wel_ck(this)
+    ! -- modules
+    use SimModule, only: count_errors, store_error_unit
+    ! -- dummy variables
+    class(WelType), intent(inout) :: this !< WelType object
+    ! -- local variables
+    character(len=LINELENGTH) :: errmsg
+    integer(I4B) :: i
+    integer(I4B) :: node
+    real(DP) :: afraux
+    real(DP) :: thick
+    ! -- formats
+    character(len=*), parameter :: fmtfracerr = &
+      "('WELL (',i0,') AUTO_FLOW_REDUCE_AUXNAME value (',g0,') must be greater &
+      &than 0 and less than or equal to 1 when FLOW_REDUCTION_LENGTH is not &
+      &specified (it is interpreted as a fraction of the cell thickness).')"
+    character(len=*), parameter :: fmtlenerr = &
+      "('WELL (',i0,') AUTO_FLOW_REDUCE_AUXNAME value (',g0,') must be greater &
+      &than 0 and less than or equal to the cell thickness (',g0,') when &
+      &FLOW_REDUCTION_LENGTH is specified.')"
+    !
+    ! -- nothing to check unless AUTO_FLOW_REDUCE_AUXNAME is active
+    if (this%iflowred == 0 .or. this%iafrauxcol == 0) return
+    !
+    ! -- check the per-well auxiliary flow reduction values. The value must be
+    !    strictly greater than zero: a value of zero places the turnoff
+    !    threshold at the cell bottom, giving a zero-width smoothing interval
+    !    (a divide-by-zero in sQSaturation), consistent with the global
+    !    AUTO_FLOW_REDUCE length-mode check.
+    do i = 1, this%nbound
+      node = this%nodelist(i)
+      if (node == 0) cycle
+      ! -- the reduction is only applied to convertible cells
+      if (this%icelltype(node) == 0) cycle
+      afraux = this%auxvar(this%iafrauxcol, i)
+      if (this%iflowredlen == 0) then
+        ! -- value is a fraction of the cell thickness: valid range (0, 1]
+        if (afraux <= DZERO .or. afraux > DONE) then
+          write (errmsg, fmt=fmtfracerr) i, afraux
+          call store_error(errmsg)
+        end if
+      else
+        ! -- value is a length above the cell bottom: valid range (0, thick]
+        thick = this%dis%top(node) - this%dis%bot(node)
+        if (afraux <= DZERO .or. afraux > thick) then
+          write (errmsg, fmt=fmtlenerr) i, afraux, thick
+          call store_error(errmsg)
+        end if
+      end if
+    end do
+    !
+    ! -- terminate if any errors were detected
+    if (count_errors() > 0) then
+      call store_error_unit(this%inunit)
+    end if
+  end subroutine wel_ck
 
   !> @ brief Formulate the package hcof and rhs terms.
     !!
@@ -388,8 +458,8 @@ contains
           else
             thick = DONE
           end if
-          if (this%iauxlengthcol > 0) then
-            tp = bt + this%auxvar(this%iauxlengthcol, i) * thick
+          if (this%iafrauxcol > 0) then
+            tp = bt + this%auxvar(this%iafrauxcol, i) * thick
           else
             tp = bt + this%flowred * thick
           end if
@@ -486,8 +556,8 @@ contains
           else
             thick = DONE
           end if
-          if (this%iauxlengthcol > 0) then
-            tp = bt + this%auxvar(this%iauxlengthcol, i) * thick
+          if (this%iafrauxcol > 0) then
+            tp = bt + this%auxvar(this%iafrauxcol, i) * thick
           else
             tp = bt + this%flowred * thick
           end if

--- a/src/Model/GroundWaterFlow/gwf-wel.f90
+++ b/src/Model/GroundWaterFlow/gwf-wel.f90
@@ -15,7 +15,8 @@
 module WelModule
   ! -- modules used by WelModule methods
   use KindModule, only: DP, I4B
-  use ConstantsModule, only: DZERO, DEM1, DONE, LENFTYPE, DNODATA, LINELENGTH
+  use ConstantsModule, only: DZERO, DEM1, DONE, LENFTYPE, DNODATA, LINELENGTH, &
+                             LENAUXNAME
   use SimVariablesModule, only: errmsg, warnmsg
   use SimModule, only: store_error, store_error_filename, store_warning
   use MemoryHelperModule, only: create_mem_path
@@ -42,6 +43,7 @@ module WelModule
     real(DP), pointer :: flowred => null() !< AUTO_FLOW_REDUCE variable
     integer(I4B), pointer :: ioutafrcsv => null() !< unit number for CSV output file containing wells with reduced puping rates
     integer(I4B), pointer :: iflowredlen => null() !< flag indicating flowred variable is a length value
+    integer(I4B), pointer :: iauxlengthcol => null() !< column index in auxvar for AUXLENGTHNAME (0 if not active)
   contains
     procedure :: allocate_scalars => wel_allocate_scalars
     procedure :: allocate_arrays => wel_allocate_arrays
@@ -125,6 +127,7 @@ contains
     call mem_deallocate(this%flowred)
     call mem_deallocate(this%ioutafrcsv)
     call mem_deallocate(this%iflowredlen)
+    call mem_deallocate(this%iauxlengthcol)
     call mem_deallocate(this%q, 'Q', this%memoryPath)
   end subroutine wel_da
 
@@ -148,12 +151,14 @@ contains
     call mem_allocate(this%flowred, 'FLOWRED', this%memoryPath)
     call mem_allocate(this%ioutafrcsv, 'IOUTAFRCSV', this%memoryPath)
     call mem_allocate(this%iflowredlen, 'IFLOWREDLEN', this%memoryPath)
+    call mem_allocate(this%iauxlengthcol, 'IAUXLENGTHCOL', this%memoryPath)
     !
     ! -- Set values
     this%iflowred = 0
     this%ioutafrcsv = 0
     this%flowred = DZERO
     this%iflowredlen = 0
+    this%iauxlengthcol = 0
   end subroutine wel_allocate_scalars
 
   !> @ brief Allocate arrays
@@ -195,7 +200,9 @@ contains
     class(WelType), intent(inout) :: this !< WelType object
     ! -- local variables
     character(len=LINELENGTH) :: fname
+    character(len=LENAUXNAME) :: auxlengthname
     type(GwfWelParamFoundType) :: found
+    integer(I4B) :: n
     ! -- formats
     character(len=*), parameter :: fmtflowred = &
       &"(4x, 'AUTOMATIC FLOW REDUCTION OF WELLS IMPLEMENTED.')"
@@ -211,6 +218,8 @@ contains
     call mem_set_value(this%imover, 'MOVER', this%input_mempath, found%mover)
     call mem_set_value(this%iflowredlen, 'IFLOWREDLEN', this%input_mempath, &
                        found%iflowredlen)
+    call mem_set_value(auxlengthname, 'AUXLENGTHNAME', this%input_mempath, &
+                       found%auxlengthname)
 
     if (found%iflowredlen) then
       if (found%flowred .eqv. .FALSE.) then
@@ -245,6 +254,43 @@ contains
 
     if (found%mover) then
       this%imover = 1
+    end if
+
+    if (found%auxlengthname) then
+      if (.not. found%flowred) then
+        write (warnmsg, '(a)') &
+          'AUXLENGTHNAME is specified but AUTO_FLOW_REDUCE is not specified. &
+          &The AUXLENGTHNAME option will be ignored.'
+        call store_warning(warnmsg)
+      end if
+      if (.not. found%iflowredlen) then
+        write (warnmsg, '(a)') &
+          'AUXLENGTHNAME is specified but FLOW_REDUCTION_LENGTH is not &
+          &specified. The AUXLENGTHNAME value will be interpreted as a &
+          &fraction of the cell thickness.'
+        call store_warning(warnmsg)
+      end if
+      if (found%flowred) then
+        if (this%naux == 0) then
+          write (errmsg, '(a,2(1x,a))') &
+            'AUXLENGTHNAME was specified as', trim(adjustl(auxlengthname)), &
+            'but no AUX variables specified.'
+          call store_error(errmsg)
+        end if
+        this%iauxlengthcol = 0
+        do n = 1, this%naux
+          if (auxlengthname == this%auxname(n)) then
+            this%iauxlengthcol = n
+            exit
+          end if
+        end do
+        if (this%iauxlengthcol == 0) then
+          write (errmsg, '(a,2(1x,a))') &
+            'AUXLENGTHNAME was specified as', trim(adjustl(auxlengthname)), &
+            'but no AUX variable found with this name.'
+          call store_error(errmsg)
+        end if
+      end if
     end if
 
     ! -- log WEL specific options
@@ -293,6 +339,11 @@ contains
     if (found%mover) then
       write (this%iout, '(4x,A)') 'MOVER OPTION ENABLED'
     end if
+
+    if (found%auxlengthname) then
+      write (this%iout, '(4x,A)') &
+        'AUXLENGTHNAME OPTION ENABLED FOR PER-WELL FLOW REDUCTION'
+    end if
     !
     ! -- close logging block
     write (this%iout, '(1x,a)') &
@@ -337,7 +388,11 @@ contains
           else
             thick = DONE
           end if
-          tp = bt + this%flowred * thick
+          if (this%iauxlengthcol > 0) then
+            tp = bt + this%auxvar(this%iauxlengthcol, i) * thick
+          else
+            tp = bt + this%flowred * thick
+          end if
           qmult = sQSaturation(tp, bt, this%xnew(node))
           q = q * qmult
         end if
@@ -431,7 +486,11 @@ contains
           else
             thick = DONE
           end if
-          tp = bt + this%flowred * thick
+          if (this%iauxlengthcol > 0) then
+            tp = bt + this%auxvar(this%iauxlengthcol, i) * thick
+          else
+            tp = bt + this%flowred * thick
+          end if
           drterm = sQSaturationDerivative(tp, bt, this%xnew(node))
           drterm = drterm * this%q_mult(i)
           !--fill amat and rhs with newton-raphson terms


### PR DESCRIPTION
Add auto_flow_reduce_auxname option that allows flow reduction lengths to be specified on a well by well basis.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
