### PR TITLE
fix(fmi): open files in read-only mode

### DIFF
--- a/autotest/test_gwt_fmi03.py
+++ b/autotest/test_gwt_fmi03.py
@@ -1,12 +1,11 @@
 """
 Tests that multiple GWT models in the same simulation can reference
 the same GWF head and budget files via the FMI package without error.
-Repro https://github.com/MODFLOW-ORG/modflow6/issues/2832.
 
-A transport simulation contains two GWT models, each for a different
-species, both of whose FMI packages point to the same GWF head/budget
-files. Previously this caused an error because the second FMI open
-attempt found the file already open on a unit held by the first FMI.
+Previously this caused an error because the second FMI open attempt
+found the output files already open on units held by the first FMI.
+
+Reported in https://github.com/MODFLOW-ORG/modflow6/issues/2832.
 """
 
 import flopy
@@ -17,16 +16,12 @@ from framework import TestFramework
 simname = "gwtfmi03"
 cases = [simname]
 
-# grid
 nlay, nrow, ncol = 1, 1, 10
 delr = delc = 1.0
 top = 1.0
 botm = [0.0]
-# time discretisation
 nper = 2
 tdis_pd = [(5.0, 5, 1.0)] * nper
-
-# transport
 porosity = 0.1
 
 

--- a/autotest/test_gwt_fmi03.py
+++ b/autotest/test_gwt_fmi03.py
@@ -1,0 +1,157 @@
+"""
+Tests that multiple GWT models in the same simulation can reference
+the same GWF head and budget files via the FMI package without error.
+Repro https://github.com/MODFLOW-ORG/modflow6/issues/2832.
+
+A transport simulation contains two GWT models, each for a different
+species, both of whose FMI packages point to the same GWF head/budget
+files. Previously this caused an error because the second FMI open
+attempt found the file already open on a unit held by the first FMI.
+"""
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+simname = "gwtfmi03"
+cases = [simname]
+
+# grid
+nlay, nrow, ncol = 1, 1, 10
+delr = delc = 1.0
+top = 1.0
+botm = [0.0]
+# time discretisation
+nper = 2
+tdis_pd = [(5.0, 5, 1.0)] * nper
+
+# transport
+porosity = 0.1
+
+
+def get_model_name(name, mdl):
+    return f"{name}_{mdl}"
+
+
+def build_gwf_sim(name, ws, mf6):
+    gwf_name = get_model_name(name, "gwf")
+    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=ws, exe_name=mf6)
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_pd)
+    flopy.mf6.ModflowIms(sim)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwf_name, save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=1.0)
+    flopy.mf6.ModflowGwfnpf(
+        gwf,
+        save_specific_discharge=True,
+        save_saturation=True,
+    )
+    chd_spd = {0: [[(0, 0, 0), 1.0, 1.0], [(0, 0, ncol - 1), 0.0, 0.0]]}
+    flopy.mf6.ModflowGwfchd(
+        gwf,
+        pname="CHD-1",
+        stress_period_data=chd_spd,
+        auxiliary=["concentration"],
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=f"{gwf_name}.bud",
+        head_filerecord=f"{gwf_name}.hds",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+    return sim
+
+
+def build_gwt_model(sim, name, gwf_ws, gwf_name, model_suffix):
+    gwt_name = get_model_name(name, model_suffix)
+    gwt = flopy.mf6.ModflowGwt(sim, modelname=gwt_name, save_flows=True)
+    flopy.mf6.ModflowGwtdis(
+        gwt,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+    flopy.mf6.ModflowGwtic(gwt, strt=0.0)
+    flopy.mf6.ModflowGwtmst(gwt, porosity=porosity)
+    flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM")
+    pd = [
+        ("GWFBUDGET", gwf_ws / f"{gwf_name}.bud", None),
+        ("GWFHEAD", gwf_ws / f"{gwf_name}.hds", None),
+    ]
+    flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd)
+    flopy.mf6.ModflowGwtssm(gwt, sources=[("CHD-1", "AUX", "CONCENTRATION")])
+    flopy.mf6.ModflowGwtoc(
+        gwt,
+        budget_filerecord=f"{gwt_name}.bud",
+        concentration_filerecord=f"{gwt_name}.ucn",
+        saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
+    )
+    return gwt
+
+
+def build_gwt_sim(name, gwf_ws, gwt_ws, mf6):
+    gwf_name = get_model_name(name, "gwf")
+    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=gwt_ws, exe_name=mf6)
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_pd)
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        linear_acceleration="BICGSTAB",
+        filename="gwt.ims",
+    )
+    gwt1 = build_gwt_model(sim, name, gwf_ws, gwf_name, "gwt1")
+    gwt2 = build_gwt_model(sim, name, gwf_ws, gwf_name, "gwt2")
+    sim.register_ims_package(ims, [gwt1.name, gwt2.name])
+    return sim
+
+
+def build_models(idx, test):
+    gwf_ws = test.workspace / "gwf"
+    gwt_ws = test.workspace / "gwt"
+    gwf_sim = build_gwf_sim(test.name, gwf_ws, test.targets["mf6"])
+    gwt_sim = build_gwt_sim(test.name, gwf_ws, gwt_ws, test.targets["mf6"])
+    return gwf_sim, gwt_sim
+
+
+def check_output(idx, test):
+    gwt_ws = test.workspace / "gwt"
+    name = test.name
+
+    def read_conc(gwt_name):
+        fpth = gwt_ws / f"{gwt_name}.ucn"
+        return flopy.utils.HeadFile(
+            fpth, precision="double", text="CONCENTRATION"
+        ).get_alldata()
+
+    conc1 = read_conc(get_model_name(name, "gwt1"))
+    conc2 = read_conc(get_model_name(name, "gwt2"))
+
+    assert np.allclose(conc1, conc2)
+    assert np.all(conc1 >= 0.0)
+    assert np.all(conc1 <= 1.0 + 1.0e-6)
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        compare=None,
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -73,3 +73,8 @@ description = "Stop with an informative error if a discretization package is mis
 section = "fixes"
 subsection = "model"
 description = "Fix the PRT PRP package's DRAPE option's behavior. A draped particle's release was previously reported in the original release position, followed by a DROPPED (ireason=6) event due to the particle reaching the water table at tracking time as a result of the default DRY\\_TRACKING\\_METHOD setting DROP. This is inconsistent with the intent of the DRAPE option: DRAPE is applied before release to control a particle's release position. Draped particles will now be released in the highest active cell, at the water table if the cell is convertible or at the geometric top if the cell is confined, and no DROPPED event will be reported."
+
+[[items]]
+section = "fixes"
+subsection = "basic"
+description = "Previously, GWF model output files could only be referenced by a single coupled model's FMI package. Referencing the same GWF output files from multiple coupled models would cause a crash. Fix file-opening logic to allow multiple coupled models to refer to the same GWF model's output files."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -77,4 +77,4 @@ description = "Fix the PRT PRP package's DRAPE option's behavior. A draped parti
 [[items]]
 section = "fixes"
 subsection = "basic"
-description = "Previously, GWF model output files could only be referenced by a single coupled model's FMI package. Referencing the same GWF output files from multiple coupled models would cause a crash. Fix file-opening logic to allow multiple coupled models to refer to the same GWF model's output files."
+description = "Previously, GWF model output files could only be referenced by a single coupled model's FMI package. This might be necessary for certain configurations where multiple transport models or particle tracking models in the same simulation need flow information from a previous GWF simulation. Referencing the same GWF output files from multiple coupled models would cause a crash. Fix file-opening logic to allow multiple coupled models to refer to the same GWF model's output files."

--- a/src/Model/ModelUtilities/FlowModelInterface.f90
+++ b/src/Model/ModelUtilities/FlowModelInterface.f90
@@ -387,19 +387,19 @@ contains
       case ('GWFBUDGET')
         inunit = getunit()
         call openfile(inunit, this%iout, fname, 'DATA(BINARY)', FORM, &
-                      ACCESS, 'UNKNOWN')
+                      ACCESS, 'OLD')
         this%iubud = inunit
         call this%initialize_bfr()
       case ('GWFHEAD')
         inunit = getunit()
         call openfile(inunit, this%iout, fname, 'DATA(BINARY)', FORM, &
-                      ACCESS, 'UNKNOWN')
+                      ACCESS, 'OLD')
         this%iuhds = inunit
         call this%initialize_hfr()
       case ('GWFMOVER')
         inunit = getunit()
         call openfile(inunit, this%iout, fname, 'DATA(BINARY)', FORM, &
-                      ACCESS, 'UNKNOWN')
+                      ACCESS, 'OLD')
         this%iumvr = inunit
         call budgetobject_cr_bfr(this%mvrbudobj, 'MVT', this%iumvr, &
                                  this%iout)
@@ -407,7 +407,7 @@ contains
       case ('GWFGRID')
         inunit = getunit()
         call openfile(inunit, this%iout, fname, 'DATA(BINARY)', &
-                      FORM, ACCESS, 'UNKNOWN')
+                      FORM, ACCESS, 'OLD')
         this%iugrb = inunit
         call this%read_grid()
       case default

--- a/src/Model/TransportModel/tsp-fmi.f90
+++ b/src/Model/TransportModel/tsp-fmi.f90
@@ -605,19 +605,19 @@ contains
       case ('GWFBUDGET')
         inunit = getunit()
         call openfile(inunit, this%iout, fname, 'DATA(BINARY)', FORM, &
-                      ACCESS, 'UNKNOWN')
+                      ACCESS, 'OLD')
         this%iubud = inunit
         call this%initialize_bfr()
       case ('GWFHEAD')
         inunit = getunit()
         call openfile(inunit, this%iout, fname, 'DATA(BINARY)', FORM, &
-                      ACCESS, 'UNKNOWN')
+                      ACCESS, 'OLD')
         this%iuhds = inunit
         call this%initialize_hfr()
       case ('GWFMOVER')
         inunit = getunit()
         call openfile(inunit, this%iout, fname, 'DATA(BINARY)', FORM, &
-                      ACCESS, 'UNKNOWN')
+                      ACCESS, 'OLD')
         this%iumvr = inunit
         call budgetobject_cr_bfr(this%mvrbudobj, 'MVT', this%iumvr, &
                                  this%iout)
@@ -640,7 +640,7 @@ contains
         iapt = iapt + 1
         inunit = getunit()
         call openfile(inunit, this%iout, fname, 'DATA(BINARY)', FORM, &
-                      ACCESS, 'UNKNOWN')
+                      ACCESS, 'OLD')
         call budgetobject_cr_bfr(budobjptr, flowtype, inunit, &
                                  this%iout, colconv2=['GWF             '])
         call budobjptr%fill_from_bfr(this%dis, this%iout)

--- a/src/Utilities/BinaryFileReader.f90
+++ b/src/Utilities/BinaryFileReader.f90
@@ -107,7 +107,7 @@ contains
       inquire (this%inunit, pos=this%headernext%pos)
       read (this%inunit, iostat=iostat) this%headernext%kstp, this%headernext%kper
       if (iostat == 0) then
-        call fseek_stream(this%inunit, -2 * I4B, 1, iostat)
+        read (this%inunit, pos=this%headernext%pos, iostat=iostat)
       else if (iostat < 0) then
         this%endoffile = .true.
         if (allocated(this%headernext)) deallocate (this%headernext)

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -101,14 +101,10 @@ contains
         call freeunitnumber(iu)
       end if
       !
-      ! -- Check to see if file is already open, if not then open the file
+      ! -- Check if file is already open (retained for error reporting only)
       inquire (file=fname(1:iflen), number=iuop)
-      if (iuop > 0) then
-        ivar = -1
-      else
-        open (unit=iu, file=fname(1:iflen), form=fmtarg, access=accarg, &
-              status=filstat, action=filact, iostat=ivar)
-      end if
+      open (unit=iu, file=fname(1:iflen), form=fmtarg, access=accarg, &
+            status=filstat, action=filact, iostat=ivar)
       !
       ! -- Check for an error
       if (ivar /= 0) then
@@ -1742,7 +1738,7 @@ contains
     end select
     !
     ! -- position the file pointer to ipos
-    write (iu, pos=ipos, iostat=status)
+    read (iu, pos=ipos, iostat=status)
     inquire (unit=iu, pos=ipos)
   end subroutine fseek_stream
 

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -1738,7 +1738,7 @@ contains
     end select
     !
     ! -- position the file pointer to ipos
-    read (iu, pos=ipos, iostat=status)
+    write (iu, pos=ipos, iostat=status)
     inquire (unit=iu, pos=ipos)
   end subroutine fseek_stream
 

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -101,7 +101,7 @@ contains
         call freeunitnumber(iu)
       end if
       !
-      ! -- Check if file is already open (retained for error reporting only)
+      ! -- Check if file is already open
       inquire (file=fname(1:iflen), number=iuop)
       open (unit=iu, file=fname(1:iflen), form=fmtarg, access=accarg, &
             status=filstat, action=filact, iostat=ivar)


### PR DESCRIPTION
Previously multiple models in a simulation consuming flow model output via FMI could not reference the same flow model output files, because the output files were opened with status "UNKNOWN" i.e. for both reading and writing. Per the fortran 2003 standard files can only be opened multiple times in read-only mode.

FMI only needs to read flow model output files, so open them in read-only mode with "OLD". And make a small change in `openfile()` to accommodate: previously if an `inquire()` call indicated a file was open, `openfile()` would abort, but an already-open file is now valid as long as it's in read-only mode.

Also replace an unnecessary `fseek_stream()` with a simple `read()` in `BinaryFileReader%peek_record()`, that I introduced by mistake in #2384.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Closes #2832
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request
