### PR TITLE
fix(mf6bmiUtil): use base model in get_grid_type_model

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -87,4 +87,4 @@ description = "PRT was described as configuring a single release at the beginnin
 [[items]]
 section = "fixes"
 subsection = "basic"
-description = "The BMI interface's get_grid_model_type function worked only for numerical model types such as GWF, GWT, and GWE, but would crash for PRT models. Fix the function's implementation to work with all model types."
+description = "The BMI interface's get\\_grid\\_model\\_type function worked only for numerical model types such as GWF, GWT, and GWE, but would crash for PRT models. Fix the function's implementation to work with all model types."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -83,3 +83,8 @@ description = "Previously, GWF model output files could only be referenced by a 
 section = "fixes"
 subsection = "model"
 description = "PRT was described as configuring a single release at the beginning of the simulation by default, but a release was in fact scheduled for the first time step of every stress period. Fix the default release behavior so a single release occurs at the beginning of the simulation."
+
+[[items]]
+section = "fixes"
+subsection = "basic"
+description = "The BMI interface's get_grid_model_type function worked only for numerical model types such as GWF, GWT, and GWE, but would crash for PRT models. Fix the function's implementation to work with all model types."

--- a/srcbmi/mf6bmiUtil.f90
+++ b/srcbmi/mf6bmiUtil.f90
@@ -238,18 +238,19 @@ contains
   subroutine get_grid_type_model(model_name, grid_type_f)
     ! -- modules
     use ListsModule, only: basemodellist
-    use NumericalModelModule, only: NumericalModelType, GetNumericalModelFromList
+    use BaseModelModule, only: BaseModelType, GetBaseModelFromList
     ! -- dummy variables
     character(len=LENMODELNAME) :: model_name
     character(len=LENGRIDTYPE) :: grid_type_f
     ! -- local variables
     integer(I4B) :: i
-    class(NumericalModelType), pointer :: numericalModel
+    class(BaseModelType), pointer :: baseModel
 
     do i = 1, basemodellist%Count()
-      numericalModel => GetNumericalModelFromList(basemodellist, i)
-      if (numericalModel%name == model_name) then
-        call numericalModel%dis%get_dis_type(grid_type_f)
+      baseModel => GetBaseModelFromList(basemodellist, i)
+      if (baseModel%name == model_name) then
+        call baseModel%dis%get_dis_type(grid_type_f)
+        return
       end if
     end do
   end subroutine get_grid_type_model


### PR DESCRIPTION
#2705 switched PRT to `ExplicitModelType`, but did not accommodate this in the BMI implementation. Up to now `get_grid_type_model` only worked with `NumericalModelType`. Use `BaseModelType` instead. This should fix some test failures in the modflowapi repo.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request