### PR TITLE
fix(fseek_stream): position with read/write based on file action

### DIFF
--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -1717,6 +1717,7 @@ contains
     integer(I4B), intent(inout) :: status
     ! -- local
     integer(I8B) :: ipos
+    character(len=20) :: file_action
     !
     inquire (unit=iu, size=ipos)
     !
@@ -1737,8 +1738,15 @@ contains
       ipos = ipos + offset
     end select
     !
-    ! -- position the file pointer to ipos
-    write (iu, pos=ipos, iostat=status)
+    ! -- position the file pointer to ipos using read or write depending
+    !    on the file action, since write fails on read-only files and
+    !    read fails on write-only files
+    inquire (unit=iu, action=file_action)
+    if (trim(file_action) == 'READ') then
+      read (iu, pos=ipos, iostat=status)
+    else
+      write (iu, pos=ipos, iostat=status)
+    end if
     inquire (unit=iu, pos=ipos)
   end subroutine fseek_stream
 


### PR DESCRIPTION
The `fseek_stream` subroutine assumed the file is open in write mode. If the file is open in read-only mode, use `read` instead to position the file pointer. Just a preemptive, defensive fix as this is a general-purpose module/subroutine.