### PR TITLE
refactor(input): auxvars should persist in layer array loads

### DIFF
--- a/autotest/test_gwf_evta_auxmult01.py
+++ b/autotest/test_gwf_evta_auxmult01.py
@@ -1,0 +1,122 @@
+"""
+Test that EVTA with READASARRAYS and AUXMULTNAME correctly persists the
+auxiliary multiplier array across stress periods when it is not re-read.
+
+The multiplier is specified only in period 1. The ET rate is updated in
+period 2 without re-specifying the multiplier. The test verifies that the
+multiplier from period 1 continues to be applied.
+"""
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = ["evta_auxmult01"]
+
+# spatial discretization
+nlay, nrow, ncol = 1, 5, 5
+delr = delc = 1000.0
+top = 10.0
+botm = [0.0]
+strt = 9.0
+k = 10.0
+
+# ET parameters
+et_surface = 10.0
+et_rate = 0.005
+et_depth = 5.0
+mult_val = 0.5
+
+
+def build_models(idx, test):
+    name = cases[idx]
+    ws = test.workspace
+    nper = 3
+
+    # ET rate changes in period 2; multiplier only in period 1
+    rate1 = np.full((nrow, ncol), et_rate)
+    rate2 = np.full((nrow, ncol), et_rate * 2.0)
+    evt_rate = {0: rate1, 1: rate2}
+    evt_aux = {0: [np.full((nrow, ncol), mult_val)]}
+
+    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=ws)
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=[(1.0, 1, 1.0)] * nper)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
+    flopy.mf6.ModflowIms(sim, outer_dvclose=1e-9, inner_dvclose=1e-9)
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=strt)
+    flopy.mf6.ModflowGwfnpf(gwf, k=k)
+
+    # constant head on one side
+    chd_spd = [[(0, i, ncol - 1), strt] for i in range(nrow)]
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data={0: chd_spd})
+
+    # evta with auxmultname
+    flopy.mf6.ModflowGwfevta(
+        gwf,
+        readasarrays=True,
+        surface=et_surface,
+        rate=evt_rate,
+        depth=et_depth,
+        auxiliary="ET_MULT",
+        auxmultname="ET_MULT",
+        aux=evt_aux,
+    )
+
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=f"{name}.cbc",
+        head_filerecord=f"{name}.hds",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
+    return sim, None
+
+
+def check_output(idx, test):
+    name = cases[idx]
+    fpth = test.workspace / f"{name}.cbc"
+    cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
+    evt_budgets = cobj.get_data(text="EVT")
+
+    # Key checks:
+    # 1. ET is non-zero in all periods (multiplier persists)
+    # 2. Period 2 ET > period 1 ET (rate doubled, mult same)
+    # 3. Period 3 ET == period 2 ET (both persist)
+    for iper, evt_data in enumerate(evt_budgets):
+        q = evt_data["q"]
+        et_out = -q.min()
+        assert et_out > 0.0, (
+            f"Period {iper + 1}: ET is zero - AUXMULTNAME not persisting across periods"
+        )
+
+    et1 = -evt_budgets[0]["q"].sum()
+    et2 = -evt_budgets[1]["q"].sum()
+    et3 = -evt_budgets[2]["q"].sum()
+
+    assert et2 > et1, f"Period 2 ET ({et2}) should exceed period 1 ({et1})"
+    assert np.isclose(et3, et2, rtol=1e-6), (
+        f"Period 3 ET ({et3}) should equal period 2 ({et2})"
+    )
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        targets=targets,
+    )
+    test.run()

--- a/autotest/test_gwf_rcha_auxmult01.py
+++ b/autotest/test_gwf_rcha_auxmult01.py
@@ -1,10 +1,13 @@
 """
 Test that RCHA with READASARRAYS and AUXMULTNAME correctly persists the
-auxiliary multiplier array across stress periods when it is not re-read.
+auxiliary multiplier array across stress periods when it is not re-read,
+and that the multiplier is correctly overwritten when re-specified.
 
-The multiplier is specified only in period 1. Recharge is updated in period 2
-without re-specifying the multiplier. The test verifies that the multiplier
-from period 1 continues to be applied in period 2 (i.e., recharge is not zero).
+Case 1 (rcha_auxmult01): Multiplier set in period 1 only, recharge updated
+in period 2. Verifies multiplier persists.
+
+Case 2 (rcha_auxmult02): Multiplier set in period 1, then overridden with a
+new value in period 3. Verifies override takes effect.
 """
 
 import flopy
@@ -12,13 +15,7 @@ import numpy as np
 import pytest
 from framework import TestFramework
 
-cases = ["rcha_auxmult01"]
-
-# temporal discretization
-nper = 3
-perlen = [1.0, 1.0, 1.0]
-nstp = [1, 1, 1]
-tsmult = [1.0, 1.0, 1.0]
+cases = ["rcha_auxmult01", "rcha_auxmult02"]
 
 # spatial discretization
 nlay, nrow, ncol = 1, 5, 5
@@ -26,34 +23,32 @@ delr = delc = 1000.0
 top = 10.0
 botm = [0.0]
 strt = 5.0
-
-# npf
 k = 10.0
-
-# recharge - provided in periods 1 and 2
 rech_rate = 0.001
-rech1 = np.full((nrow, ncol), rech_rate)
-rech2 = np.full((nrow, ncol), rech_rate * 2.0)
-rech = {0: rech1, 1: rech2}
-
-# auxiliary multiplier - only provided in period 1
-rch_mult = np.full((nrow, ncol), 0.5)
-rch_aux = {0: [rch_mult]}
 
 
 def build_models(idx, test):
     name = cases[idx]
     ws = test.workspace
 
+    if idx == 0:
+        # Case 1: multiplier persists (not re-specified after period 1)
+        nper = 3
+        rech = {
+            0: np.full((nrow, ncol), rech_rate),
+            1: np.full((nrow, ncol), rech_rate * 2.0),
+        }
+        rch_aux = {0: [np.full((nrow, ncol), 0.5)]}
+    else:
+        # Case 2: multiplier overridden in period 3
+        nper = 4
+        rech = {0: np.full((nrow, ncol), rech_rate)}
+        rch_aux = {0: [np.full((nrow, ncol), 0.5)], 2: [np.full((nrow, ncol), 2.0)]}
+
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=ws)
-
-    tdis_rc = [(p, n, t) for p, n, t in zip(perlen, nstp, tsmult)]
-    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc)
-
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=[(1.0, 1, 1.0)] * nper)
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
-
     flopy.mf6.ModflowIms(sim, outer_dvclose=1e-9, inner_dvclose=1e-9)
-
     flopy.mf6.ModflowGwfdis(
         gwf,
         nlay=nlay,
@@ -64,15 +59,12 @@ def build_models(idx, test):
         top=top,
         botm=botm,
     )
-
     flopy.mf6.ModflowGwfic(gwf, strt=strt)
     flopy.mf6.ModflowGwfnpf(gwf, k=k)
 
-    # constant head on one side to allow flow
     chd_spd = [[(0, i, ncol - 1), strt] for i in range(nrow)]
     flopy.mf6.ModflowGwfchd(gwf, stress_period_data={0: chd_spd})
 
-    # rcha with auxmultname - multiplier only in period 1
     flopy.mf6.ModflowGwfrcha(
         gwf,
         readasarrays=True,
@@ -96,30 +88,32 @@ def check_output(idx, test):
     name = cases[idx]
     fpth = test.workspace / f"{name}.cbc"
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
-
-    # get recharge for each stress period
     rch_budgets = cobj.get_data(text="RCH")
+    area = delr * delc
 
-    # period 1: recharge * mult = 0.001 * 0.5 = 0.0005
-    # period 2: recharge * mult = 0.002 * 0.5 = 0.001 (mult persists)
-    # period 3: same as period 2 (no new data)
-    expected_q = [
-        rech_rate * 0.5 * delr * delc,
-        rech_rate * 2.0 * 0.5 * delr * delc,
-        rech_rate * 2.0 * 0.5 * delr * delc,
-    ]
+    if idx == 0:
+        # Case 1: mult=0.5 persists across all periods
+        expected = [
+            rech_rate * 0.5 * area,  # period 1
+            rech_rate * 2.0 * 0.5 * area,  # period 2: new rech, old mult
+            rech_rate * 2.0 * 0.5 * area,  # period 3: both persist
+        ]
+    else:
+        # Case 2: mult=0.5 in periods 1-2, mult=2.0 in periods 3-4
+        expected = [
+            rech_rate * 0.5 * area,  # period 1
+            rech_rate * 0.5 * area,  # period 2: both persist
+            rech_rate * 2.0 * area,  # period 3: mult overridden to 2.0
+            rech_rate * 2.0 * area,  # period 4: override persists
+        ]
 
-    for iper, (rch_data, exp_flux) in enumerate(zip(rch_budgets, expected_q)):
-        q = rch_data["q"]
-        actual_max = q.max()
-        msg = f"Period {iper + 1}: expected rch flux {exp_flux}, got {actual_max}"
+    for iper, (rch_data, exp_flux) in enumerate(zip(rch_budgets, expected)):
+        actual_max = rch_data["q"].max()
+        msg = (
+            f"Case {idx + 1}, Period {iper + 1}: "
+            f"expected rch flux {exp_flux}, got {actual_max}"
+        )
         assert np.isclose(actual_max, exp_flux, rtol=1e-6), msg
-        # verify no zero recharge (the bug symptom)
-        if iper > 0:
-            assert actual_max > 0.0, (
-                f"Period {iper + 1}: recharge is zero - "
-                f"AUXMULTNAME not persisting across periods"
-            )
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_rcha_auxmult01.py
+++ b/autotest/test_gwf_rcha_auxmult01.py
@@ -1,0 +1,134 @@
+"""
+Test that RCHA with READASARRAYS and AUXMULTNAME correctly persists the
+auxiliary multiplier array across stress periods when it is not re-read.
+
+The multiplier is specified only in period 1. Recharge is updated in period 2
+without re-specifying the multiplier. The test verifies that the multiplier
+from period 1 continues to be applied in period 2 (i.e., recharge is not zero).
+"""
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = ["rcha_auxmult01"]
+
+# temporal discretization
+nper = 3
+perlen = [1.0, 1.0, 1.0]
+nstp = [1, 1, 1]
+tsmult = [1.0, 1.0, 1.0]
+
+# spatial discretization
+nlay, nrow, ncol = 1, 5, 5
+delr = delc = 1000.0
+top = 10.0
+botm = [0.0]
+strt = 5.0
+
+# npf
+k = 10.0
+
+# recharge - provided in periods 1 and 2
+rech_rate = 0.001
+rech1 = np.full((nrow, ncol), rech_rate)
+rech2 = np.full((nrow, ncol), rech_rate * 2.0)
+rech = {0: rech1, 1: rech2}
+
+# auxiliary multiplier - only provided in period 1
+rch_mult = np.full((nrow, ncol), 0.5)
+rch_aux = {0: [rch_mult]}
+
+
+def build_models(idx, test):
+    name = cases[idx]
+    ws = test.workspace
+
+    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=ws)
+
+    tdis_rc = [(p, n, t) for p, n, t in zip(perlen, nstp, tsmult)]
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc)
+
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
+
+    flopy.mf6.ModflowIms(sim, outer_dvclose=1e-9, inner_dvclose=1e-9)
+
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+
+    flopy.mf6.ModflowGwfic(gwf, strt=strt)
+    flopy.mf6.ModflowGwfnpf(gwf, k=k)
+
+    # constant head on one side to allow flow
+    chd_spd = [[(0, i, ncol - 1), strt] for i in range(nrow)]
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data={0: chd_spd})
+
+    # rcha with auxmultname - multiplier only in period 1
+    flopy.mf6.ModflowGwfrcha(
+        gwf,
+        readasarrays=True,
+        recharge=rech,
+        auxiliary="RCH_MULT",
+        auxmultname="RCH_MULT",
+        aux=rch_aux,
+    )
+
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=f"{name}.cbc",
+        head_filerecord=f"{name}.hds",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
+    return sim, None
+
+
+def check_output(idx, test):
+    name = cases[idx]
+    fpth = test.workspace / f"{name}.cbc"
+    cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
+
+    # get recharge for each stress period
+    rch_budgets = cobj.get_data(text="RCH")
+
+    # period 1: recharge * mult = 0.001 * 0.5 = 0.0005
+    # period 2: recharge * mult = 0.002 * 0.5 = 0.001 (mult persists)
+    # period 3: same as period 2 (no new data)
+    expected_q = [
+        rech_rate * 0.5 * delr * delc,
+        rech_rate * 2.0 * 0.5 * delr * delc,
+        rech_rate * 2.0 * 0.5 * delr * delc,
+    ]
+
+    for iper, (rch_data, exp_flux) in enumerate(zip(rch_budgets, expected_q)):
+        q = rch_data["q"]
+        actual_max = q.max()
+        msg = f"Period {iper + 1}: expected rch flux {exp_flux}, got {actual_max}"
+        assert np.isclose(actual_max, exp_flux, rtol=1e-6), msg
+        # verify no zero recharge (the bug symptom)
+        if iper > 0:
+            assert actual_max > 0.0, (
+                f"Period {iper + 1}: recharge is zero - "
+                f"AUXMULTNAME not persisting across periods"
+            )
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        targets=targets,
+    )
+    test.run()

--- a/autotest/test_gwf_welg_auxmult01.py
+++ b/autotest/test_gwf_welg_auxmult01.py
@@ -1,0 +1,117 @@
+"""
+Test that WELG (grid array package) with AUXMULTNAME correctly persists
+the auxiliary multiplier array across stress periods when it is not re-read.
+
+The multiplier is specified only in period 1. The well rate is updated in
+period 2 without re-specifying the multiplier. The test verifies that the
+multiplier from period 1 continues to be applied.
+"""
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = ["welg_auxmult01"]
+
+# spatial discretization
+nlay, nrow, ncol = 1, 5, 5
+delr = delc = 1000.0
+top = 10.0
+botm = [0.0]
+strt = 5.0
+k = 10.0
+
+DNODATA = 3.0e30
+
+
+def build_models(idx, test):
+    name = cases[idx]
+    ws = test.workspace
+    nper = 3
+
+    # well rate arrays - injection in cell (0,2,2) only
+    q1 = np.full((nlay, nrow, ncol), DNODATA)
+    q1[0, 2, 2] = 100.0
+    q2 = np.full((nlay, nrow, ncol), DNODATA)
+    q2[0, 2, 2] = 200.0
+    wel_q = {0: q1, 1: q2}
+
+    # multiplier array - only in period 1
+    mult = np.full((nlay, nrow, ncol), DNODATA)
+    mult[0, 2, 2] = 0.5
+    wel_aux = {0: [mult]}
+
+    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=ws)
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=[(1.0, 1, 1.0)] * nper)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
+    flopy.mf6.ModflowIms(sim, outer_dvclose=1e-9, inner_dvclose=1e-9)
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=strt)
+    flopy.mf6.ModflowGwfnpf(gwf, k=k)
+
+    # constant head on boundary to balance injection
+    chd_spd = [[(0, i, ncol - 1), strt] for i in range(nrow)]
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data={0: chd_spd})
+
+    flopy.mf6.ModflowGwfwelg(
+        gwf,
+        maxbound=1,
+        q=wel_q,
+        auxiliary="WEL_MULT",
+        auxmultname="WEL_MULT",
+        aux=wel_aux,
+    )
+
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=f"{name}.cbc",
+        head_filerecord=f"{name}.hds",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
+    return sim, None
+
+
+def check_output(idx, test):
+    name = cases[idx]
+    fpth = test.workspace / f"{name}.cbc"
+    cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
+    wel_budgets = cobj.get_data(text="WEL")
+
+    # period 1: q=100 * mult=0.5 = 50
+    # period 2: q=200 * mult=0.5 = 100 (mult persists)
+    # period 3: same as period 2 (no new data)
+    expected = [50.0, 100.0, 100.0]
+
+    for iper, (wel_data, exp_q) in enumerate(zip(wel_budgets, expected)):
+        q = wel_data["q"]
+        actual_max = q.max()
+        msg = f"Period {iper + 1}: expected wel flux {exp_q}, got {actual_max}"
+        assert np.isclose(actual_max, exp_q, rtol=1e-6), msg
+        assert actual_max > 0.0, (
+            f"Period {iper + 1}: well rate is zero - "
+            f"AUXMULTNAME not persisting across periods"
+        )
+
+
+@pytest.mark.developmode
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        targets=targets,
+    )
+    test.run()

--- a/autotest/test_netcdf_gwf_rcha_auxmult.py
+++ b/autotest/test_netcdf_gwf_rcha_auxmult.py
@@ -1,0 +1,218 @@
+"""
+NetCDF structured export test for RCHA READASARRAYS with AUXMULTNAME and
+time-varying recharge across multiple stress periods.
+
+This test verifies that auxiliary multiplier arrays are correctly exported
+to NetCDF and that when read back via the NETCDF keyword, the multiplier
+persists across stress periods (same bug as the non-netcdf case).
+"""
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+xa = pytest.importorskip("xarray")
+nc = pytest.importorskip("netCDF4")
+
+nlay, nrow, ncol = 1, 5, 5
+nper = 3
+name = "rcha_auxmult_nc"
+
+# recharge varies per period; multiplier only in period 1
+rch_vals = [0.001, 0.002, 0.002]
+mult_val = 0.5
+
+
+def build_models(idx, test):
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name,
+        sim_ws=str(test.workspace),
+        exe_name=test.targets["mf6"],
+    )
+
+    tdis_rc = [(1.0, 1, 1.0)] * nper
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
+    flopy.mf6.ModflowIms(sim)
+
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
+
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=100.0,
+        delc=100.0,
+        top=10.0,
+        botm=0.0,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=10.0)
+    flopy.mf6.ModflowGwfnpf(gwf, k=1.0)
+
+    # fixed heads on right column
+    chd_spd = [[(0, j, ncol - 1), 10.0] for j in range(nrow)]
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data={0: chd_spd})
+
+    # recharge with auxmultname - multiplier only in period 1
+    rch_spd = {i: np.full((nrow, ncol), v) for i, v in enumerate(rch_vals)}
+    rch_mult = np.full((nrow, ncol), mult_val)
+    rch_aux = {0: [rch_mult]}
+
+    flopy.mf6.ModflowGwfrcha(
+        gwf,
+        readasarrays=True,
+        recharge=rch_spd,
+        auxiliary="RCH_MULT",
+        auxmultname="RCH_MULT",
+        aux=rch_aux,
+    )
+
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=f"{name}.cbc",
+        head_filerecord=f"{name}.hds",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
+    # netcdf export settings
+    gwf.dis.export_array_netcdf = True
+    gwf.ic.export_array_netcdf = True
+    gwf.npf.export_array_netcdf = True
+    gwf.rcha_0.export_array_netcdf = True
+
+    gwf.name_file.nc_structured_filerecord = f"{name}.input.nc"
+    flopy.mf6.ModflowUtlncf(gwf.dis, filename=f"{name}.dis.ncf")
+
+    return sim, None
+
+
+def check_output(idx, test):
+    # --- verify validate-mode NetCDF input file ---
+    with xa.open_dataset(test.workspace / f"{name}.input.nc") as xds:
+        # check recharge variable
+        assert "rcha_0_recharge" in xds, "rcha_0_recharge missing from NetCDF"
+        rch_var = xds["rcha_0_recharge"]
+        assert rch_var.shape[0] == nper, (
+            f"Expected {nper} time slices for recharge, got {rch_var.shape[0]}"
+        )
+        for i, v in enumerate(rch_vals):
+            assert np.allclose(rch_var[i].values, v), (
+                f"Period {i + 1} recharge mismatch"
+            )
+
+        # check auxiliary multiplier variable
+        assert "rcha_0_rch_mult" in xds, "rcha_0_rch_mult missing from NetCDF"
+        aux_var = xds["rcha_0_rch_mult"]
+        # multiplier provided in period 1 should be exported
+        assert np.allclose(aux_var[0].values, mult_val), (
+            f"Period 1 RCH_MULT mismatch: expected {mult_val}"
+        )
+
+    # --- re-run reading from NetCDF (Pass 2) ---
+    with open(test.workspace / f"{name}.nam", "w") as f:
+        f.write("BEGIN options\n")
+        f.write("  SAVE_FLOWS\n")
+        f.write(f"  NETCDF  FILEIN {name}.input.nc\n")
+        f.write("END options\n\n")
+        f.write("BEGIN packages\n")
+        f.write(f"  DIS6  {name}.dis  dis\n")
+        f.write(f"  IC6  {name}.ic  ic\n")
+        f.write(f"  NPF6  {name}.npf  npf\n")
+        f.write(f"  CHD6  {name}.chd  chd_0\n")
+        f.write(f"  RCH6  {name}.rcha  rcha_0\n")
+        f.write(f"  OC6  {name}.oc  oc\n")
+        f.write("END packages\n")
+
+    with open(test.workspace / f"{name}.dis", "w") as f:
+        f.write("BEGIN options\n")
+        f.write(f"  NCF6  FILEIN  {name}.dis.ncf\n")
+        f.write("END options\n\n")
+        f.write("BEGIN dimensions\n")
+        f.write(f"  NLAY  {nlay}\n")
+        f.write(f"  NROW  {nrow}\n")
+        f.write(f"  NCOL  {ncol}\n")
+        f.write("END dimensions\n\n")
+        f.write("BEGIN griddata\n")
+        f.write("  delr NETCDF\n")
+        f.write("  delc NETCDF\n")
+        f.write("  top NETCDF\n")
+        f.write("  botm NETCDF\n")
+        f.write("END griddata\n\n")
+
+    with open(test.workspace / f"{name}.ic", "w") as f:
+        f.write("BEGIN options\n")
+        f.write("END options\n\n")
+        f.write("BEGIN griddata\n")
+        f.write("  strt NETCDF\n")
+        f.write("END griddata\n")
+
+    with open(test.workspace / f"{name}.npf", "w") as f:
+        f.write("BEGIN options\n")
+        f.write("END options\n\n")
+        f.write("BEGIN griddata\n")
+        f.write("  icelltype NETCDF\n")
+        f.write("  k NETCDF\n")
+        f.write("END griddata\n")
+
+    with open(test.workspace / f"{name}.rcha", "w") as f:
+        f.write("BEGIN options\n")
+        f.write("  READASARRAYS\n")
+        f.write("  auxiliary  RCH_MULT\n")
+        f.write("  AUXMULTNAME  RCH_MULT\n")
+        f.write("END options\n\n")
+        # period 1: both recharge and aux
+        f.write("BEGIN period 1\n")
+        f.write("  recharge NETCDF\n")
+        f.write("  RCH_MULT NETCDF\n")
+        f.write("END period 1\n\n")
+        # period 2: only recharge (aux should persist)
+        f.write("BEGIN period 2\n")
+        f.write("  recharge NETCDF\n")
+        f.write("END period 2\n\n")
+        # period 3: nothing (both should persist from period 2)
+
+    success, buff = flopy.run_model(
+        test.targets["mf6"],
+        test.workspace / "mfsim.nam",
+        model_ws=test.workspace,
+        report=True,
+    )
+    assert success, "Pass 2 run with NETCDF recharge failed"
+
+    # verify recharge budget from pass 2
+    cbc = flopy.utils.CellBudgetFile(
+        str(test.workspace / f"{name}.cbc"), precision="double"
+    )
+    rch_budgets = cbc.get_data(text="RCH")
+
+    expected_q = [
+        rch_vals[0] * mult_val * 100.0 * 100.0,
+        rch_vals[1] * mult_val * 100.0 * 100.0,
+        rch_vals[2] * mult_val * 100.0 * 100.0,
+    ]
+
+    for iper, (rch_data, exp_flux) in enumerate(zip(rch_budgets, expected_q)):
+        q = rch_data["q"]
+        actual_max = q.max()
+        msg = f"Period {iper + 1}: expected rch flux {exp_flux}, got {actual_max}"
+        assert np.isclose(actual_max, exp_flux, rtol=1e-6), msg
+        if iper > 0:
+            assert actual_max > 0.0, (
+                f"Period {iper + 1}: recharge is zero - "
+                f"AUXMULTNAME not persisting across periods (NETCDF path)"
+            )
+
+
+@pytest.mark.netcdf
+@pytest.mark.developmode
+def test_mf6model(function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(0, t),
+        check=lambda t: check_output(0, t),
+        cargs=["--mode=validate"],
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -104,6 +104,7 @@ section = "fixes"
 subsection = "model"
 description = "In MF6.7.0, the PRT model began to require binary grid (GRB) files provided to the Flow Model Interface (FMI) package to contain ICELLTYPE when any Particle Release Point (PRP) package used LOCAL\\_Z release coordinates, so PRT could distinguish confined from convertible cells when converting local z to model z coordinates. This requirement is unnecessary and has been removed. A single formula $z = bot + localz \\cdot sat \\cdot (top - bot)$ works correctly for both cell types, since $sat = 1$ for confined cells, and for convertible cells $sat = (head - bot) / (top - bot)$ clamped to $[0, 1]$. Particle z coordinates near the cell top or bottom may differ slightly from before, since saturation is smoothed near the top and bottom."
 
-[[items]]                                                                                                                                                          section = "fixes"
+[[items]]
+section = "fixes"
 subsection = "stress"
 description = "Reverts a 6.4.3 change that reset auxiliary variable arrays to zero each stress period in READASARRAYS packages (RCHA, EVTA). The earlier change had the consequence of zeroing the AUXMULTNAME multiplier array when not re-specified in a period block, effectively eliminating recharge or ET in subsequent stress periods. This behavior now is consistent across Grid Array and Layer Array package types."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -103,3 +103,7 @@ description = "A PRT model coupled by an exchange to a GWF model that uses adapt
 section = "fixes"
 subsection = "model"
 description = "In MF6.7.0, the PRT model began to require binary grid (GRB) files provided to the Flow Model Interface (FMI) package to contain ICELLTYPE when any Particle Release Point (PRP) package used LOCAL\\_Z release coordinates, so PRT could distinguish confined from convertible cells when converting local z to model z coordinates. This requirement is unnecessary and has been removed. A single formula $z = bot + localz \\cdot sat \\cdot (top - bot)$ works correctly for both cell types, since $sat = 1$ for confined cells, and for convertible cells $sat = (head - bot) / (top - bot)$ clamped to $[0, 1]$. Particle z coordinates near the cell top or bottom may differ slightly from before, since saturation is smoothed near the top and bottom."
+
+[[items]]                                                                                                                                                          section = "fixes"
+subsection = "stress"
+description = "Reverts a 6.4.3 change that reset auxiliary variable arrays to zero each stress period in READASARRAYS packages (RCHA, EVTA). The earlier change had the consequence of zeroing the AUXMULTNAME multiplier array when not re-specified in a period block, effectively eliminating recharge or ET in subsequent stress periods. This behavior now is consistent across Grid Array and Layer Array package types."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -107,4 +107,4 @@ description = "In MF6.7.0, the PRT model began to require binary grid (GRB) file
 [[items]]
 section = "fixes"
 subsection = "stress"
-description = "Reverts a 6.4.3 change that reset auxiliary variable arrays to zero each stress period in READASARRAYS packages (RCHA, EVTA). The earlier change had the consequence of zeroing the AUXMULTNAME multiplier array when not re-specified in a period block, effectively eliminating recharge or ET in subsequent stress periods. This behavior now is consistent across Grid Array and Layer Array package types."
+description = "Reverts a 6.4.3 change that reset auxiliary variable arrays to zero each stress period in READASARRAYS packages (RCHA, EVTA). The earlier change had the consequence of zeroing the AUXMULTNAME multiplier array when not re-specified in a period block, effectively eliminating recharge or ET in subsequent stress periods. This behavior now is consistent across Grid Array and Layer Array package types. GWF models that use RCHA or EVTA and the AUXMULTNAME option may give different answers depending on how auxiliary variables were specified."

--- a/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
@@ -216,5 +216,5 @@ reader readarray
 time_series true
 netcdf true
 longname evapotranspiration auxiliary variable iaux
-description is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.
+description is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then it will retain its value from the most recently specified period block.  If an auxiliary variable array has never been specified, its value is zero.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.
 mf6internal auxvar

--- a/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
@@ -197,5 +197,5 @@ time_series true
 optional true
 netcdf true
 longname recharge auxiliary variable iaux
-description is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array.
+description is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then it will retain its value from the most recently specified period block.  If an auxiliary variable array has never been specified, its value is zero.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array.
 mf6internal auxvar

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileLayerArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileLayerArray.f90
@@ -237,7 +237,7 @@ contains
 
   subroutine reset(this)
     class(LayerArrayLoadType), intent(inout) :: this
-    integer(I4B) :: n, m
+    integer(I4B) :: n
 
     if (this%tas_active /= 0) then
       ! reset tasmanager
@@ -252,12 +252,6 @@ contains
       this%param_reads(n)%invar = 0
     end do
 
-    ! explicitly reset auxvar array each period
-    do m = 1, this%ctx%ncpl
-      do n = 1, this%ctx%naux
-        this%ctx%auxvar(n, m) = DZERO
-      end do
-    end do
   end subroutine reset
 
   subroutine init_charstr1d(this, varname, input_name)


### PR DESCRIPTION
Persist auxiliary variable arrays across stress periods in READASARRAYS packages (RCHA, EVTA)

- Consistency between loader types: Grid array packages (WELG, CHDG, etc.) already persist auxiliary arrays across stress periods when not re-specified. Layer array packages (RCHA, EVTA) should behave the same way.
- Data zeroing: A 6.4.3 change that reset auxiliary arrays each period had the side effect of zeroing AUXMULTNAME multipliers when not re-read, silently eliminating recharge/ET in subsequent stress periods.
- Alignment with documented behavior: The mf6io documentation states that for array-based input, "if an array is not specified in the period block, then that array will retain its present values in memory." Auxiliary arrays should follow this rule like all other arrays.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Added new test or modified an existing test
- [X] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [X] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [X] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
