### PR TITLE
feat: tolerate empty traditional stress packages

### DIFF
--- a/autotest/test_gwf_bnd_empty.py
+++ b/autotest/test_gwf_bnd_empty.py
@@ -1,0 +1,199 @@
+"""
+Test that boundary packages with MAXBOUND=0 and no period data run successfully
+with a warning, and that MAXBOUND=0 with period data still produces an error.
+
+Cases:
+  *_warn  - MAXBOUND=0, no period data: should succeed with a warning
+  *_err   - MAXBOUND=0, with period data: should fail
+"""
+
+import pathlib as pl
+import re
+
+import flopy
+import pytest
+from framework import TestFramework
+
+cases = [
+    "bwel_warn",
+    "bwel_err",
+    "bghb_warn",
+    "bghb_err",
+    "bdrn_warn",
+    "bdrn_err",
+    "bchd_warn",
+    "bchd_err",
+]
+
+xfail = [
+    False,  # bwel_warn - MAXBOUND=0, no data: should succeed
+    True,  # bwel_err  - MAXBOUND=0 with data: should fail
+    False,  # bghb_warn - MAXBOUND=0, no data: should succeed
+    True,  # bghb_err  - MAXBOUND=0 with data: should fail
+    False,  # bdrn_warn - MAXBOUND=0, no data: should succeed
+    True,  # bdrn_err  - MAXBOUND=0 with data: should fail
+    False,  # bchd_warn - MAXBOUND=0, no data: should succeed
+    True,  # bchd_err  - MAXBOUND=0 with data: should fail
+]
+
+# Simple 1-layer, 1-row, 3-column grid
+nlay, nrow, ncol = 1, 1, 3
+nper = 2
+top = 10.0
+botm = [0.0]
+strt = 5.0
+hk = 1.0
+
+
+def _make_sim(name, ws):
+    """Build base GWF simulation with DIS, IC, NPF, CHD, OC."""
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name,
+        version="mf6",
+        exe_name="mf6",
+        sim_ws=str(ws),
+    )
+    flopy.mf6.ModflowTdis(
+        sim,
+        time_units="DAYS",
+        nper=nper,
+        perioddata=[(1.0, 1, 1.0), (1.0, 1, 1.0)],
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
+    ims = flopy.mf6.ModflowIms(sim, complexity="simple")
+    sim.register_ims_package(ims, [gwf.name])
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=10.0,
+        delc=10.0,
+        top=top,
+        botm=botm,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=strt)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=hk)
+    flopy.mf6.ModflowGwfoc(gwf, printrecord=[("HEAD", "ALL")])
+    return sim, gwf
+
+
+def _patch_maxbound(ws, pkg_file):
+    """Change MAXBOUND to 0 in the given package file."""
+    path = pl.Path(ws) / pkg_file
+    txt = path.read_text()
+    txt = re.sub(r"(MAXBOUND\s+)\d+", r"\g<1>0", txt)
+    path.write_text(txt)
+
+
+def build_models(idx, test):
+    name = cases[idx]
+    ws = test.workspace
+    is_err = "err" in name
+
+    if "chd" in name:
+        # CHD tests: don't add a base CHD (the package under test IS the CHD)
+        sim, gwf = _make_sim(name, ws)
+        if not is_err:
+            flopy.mf6.ModflowGwfchd(gwf, maxbound=0)
+        else:
+            # Write with valid maxbound so flopy doesn't auto-compute to 0
+            flopy.mf6.ModflowGwfchd(
+                gwf,
+                maxbound=1,
+                stress_period_data={0: [((0, 0, 0), strt)]},
+            )
+    elif "wel" in name:
+        sim, gwf = _make_sim(name, ws)
+        # Add a CHD to keep head from going unbounded
+        flopy.mf6.ModflowGwfchd(
+            gwf, maxbound=1, stress_period_data={0: [((0, 0, 0), strt)]}
+        )
+        if not is_err:
+            flopy.mf6.ModflowGwfwel(gwf, maxbound=0)
+        else:
+            flopy.mf6.ModflowGwfwel(
+                gwf,
+                maxbound=1,
+                stress_period_data={0: [((0, 0, 1), -1.0)]},
+            )
+    elif "ghb" in name:
+        sim, gwf = _make_sim(name, ws)
+        flopy.mf6.ModflowGwfchd(
+            gwf, maxbound=1, stress_period_data={0: [((0, 0, 0), strt)]}
+        )
+        if not is_err:
+            flopy.mf6.ModflowGwfghb(gwf, maxbound=0)
+        else:
+            flopy.mf6.ModflowGwfghb(
+                gwf,
+                maxbound=1,
+                stress_period_data={0: [((0, 0, 2), strt, 1.0)]},
+            )
+    elif "drn" in name:
+        sim, gwf = _make_sim(name, ws)
+        flopy.mf6.ModflowGwfchd(
+            gwf, maxbound=1, stress_period_data={0: [((0, 0, 0), strt)]}
+        )
+        if not is_err:
+            flopy.mf6.ModflowGwfdrn(gwf, maxbound=0)
+        else:
+            flopy.mf6.ModflowGwfdrn(
+                gwf,
+                maxbound=1,
+                stress_period_data={0: [((0, 0, 2), strt - 1.0, 1.0)]},
+            )
+
+    if is_err:
+        # Write files now so we can patch MAXBOUND before the framework re-writes
+        sim.write_simulation()
+        if "wel" in name:
+            pkg_file = f"{name}.wel"
+        elif "ghb" in name:
+            pkg_file = f"{name}.ghb"
+        elif "drn" in name:
+            pkg_file = f"{name}.drn"
+        else:  # chd
+            pkg_file = f"{name}.chd"
+        _patch_maxbound(ws, pkg_file)
+
+    return sim, None
+
+
+def check_output(idx, test):
+    name = cases[idx]
+    if "warn" not in name:
+        return
+
+    # Warnings are written to mfsim.lst under "WARNING REPORT:"
+    lst = pl.Path(test.workspace) / "mfsim.lst"
+    lines = lst.read_text().splitlines()
+
+    in_warning_report = False
+    found_warning = False
+    for line in lines:
+        if "WARNING REPORT:" in line:
+            in_warning_report = True
+        if in_warning_report and "MAXBOUND of zero" in line:
+            found_warning = True
+            break
+
+    assert found_warning, (
+        f"Expected MAXBOUND=0 warning not found in mfsim.lst for {name}"
+    )
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    is_err = "err" in name
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        xfail=xfail[idx],
+        compare=None,
+        overwrite=not is_err,  # don't overwrite pre-patched files for error cases
+    )
+    test.run()

--- a/doc/mf6io/mf6ivar/dfn/chf-cdb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-cdb.dfn
@@ -112,7 +112,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/chf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-chd.dfn
@@ -150,7 +150,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/chf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-evp.dfn
@@ -152,7 +152,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/chf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-flw.dfn
@@ -149,7 +149,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/chf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-pcp.dfn
@@ -152,7 +152,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/chf-zdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-zdg.dfn
@@ -144,7 +144,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwe-ctp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-ctp.dfn
@@ -153,7 +153,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwe-esl.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-esl.dfn
@@ -152,7 +152,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-chd.dfn
@@ -163,7 +163,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-chdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-chdg.dfn
@@ -142,7 +142,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-drn.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-drn.dfn
@@ -181,7 +181,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-drng.dfn
@@ -159,7 +159,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-evt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-evt.dfn
@@ -178,7 +178,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-ghb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-ghb.dfn
@@ -162,7 +162,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-ghbg.dfn
@@ -140,7 +140,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-rch.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rch.dfn
@@ -162,7 +162,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-riv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-riv.dfn
@@ -162,7 +162,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-rivg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rivg.dfn
@@ -141,7 +141,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-wel.dfn
@@ -226,7 +226,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-welg.dfn
@@ -205,7 +205,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwt-cnc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-cnc.dfn
@@ -153,7 +153,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/gwt-src.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-src.dfn
@@ -163,7 +163,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/olf-cdb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-cdb.dfn
@@ -112,7 +112,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/olf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-chd.dfn
@@ -150,7 +150,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/olf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-evp.dfn
@@ -152,7 +152,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/olf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-flw.dfn
@@ -149,7 +149,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/olf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-pcp.dfn
@@ -152,7 +152,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/olf-zdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-zdg.dfn
@@ -144,7 +144,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/swf-cdb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-cdb.dfn
@@ -112,7 +112,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/swf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-chd.dfn
@@ -150,7 +150,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/swf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-evp.dfn
@@ -152,7 +152,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/swf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-flw.dfn
@@ -149,7 +149,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/swf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-pcp.dfn
@@ -152,7 +152,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/swf-zdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-zdg.dfn
@@ -144,7 +144,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/doc/mf6io/mf6ivar/dfn/utl-spc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-spc.dfn
@@ -73,7 +73,7 @@ tagged false
 shape
 valid
 reader urword
-optional false
+optional true
 longname stress period number
 description REPLACE iper {}
 

--- a/src/Idm/chf-cdbidm.f90
+++ b/src/Idm/chf-cdbidm.f90
@@ -384,7 +384,7 @@ module ChfCdbInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/chf-chdidm.f90
+++ b/src/Idm/chf-chdidm.f90
@@ -447,7 +447,7 @@ module ChfChdInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/chf-evpidm.f90
+++ b/src/Idm/chf-evpidm.f90
@@ -447,7 +447,7 @@ module ChfEvpInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/chf-flwidm.f90
+++ b/src/Idm/chf-flwidm.f90
@@ -447,7 +447,7 @@ module ChfFlwInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/chf-pcpidm.f90
+++ b/src/Idm/chf-pcpidm.f90
@@ -447,7 +447,7 @@ module ChfPcpInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/chf-zdgidm.f90
+++ b/src/Idm/chf-zdgidm.f90
@@ -489,7 +489,7 @@ module ChfZdgInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwe-ctpidm.f90
+++ b/src/Idm/gwe-ctpidm.f90
@@ -447,7 +447,7 @@ module GweCtpInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwe-eslidm.f90
+++ b/src/Idm/gwe-eslidm.f90
@@ -447,7 +447,7 @@ module GweEslInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwf-chdidm.f90
+++ b/src/Idm/gwf-chdidm.f90
@@ -468,7 +468,7 @@ module GwfChdInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwf-drnidm.f90
+++ b/src/Idm/gwf-drnidm.f90
@@ -531,7 +531,7 @@ module GwfDrnInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwf-evtidm.f90
+++ b/src/Idm/gwf-evtidm.f90
@@ -617,7 +617,7 @@ module GwfEvtInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwf-ghbidm.f90
+++ b/src/Idm/gwf-ghbidm.f90
@@ -489,7 +489,7 @@ module GwfGhbInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwf-rchidm.f90
+++ b/src/Idm/gwf-rchidm.f90
@@ -468,7 +468,7 @@ module GwfRchInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwf-rividm.f90
+++ b/src/Idm/gwf-rividm.f90
@@ -510,7 +510,7 @@ module GwfRivInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwf-welidm.f90
+++ b/src/Idm/gwf-welidm.f90
@@ -594,7 +594,7 @@ module GwfWelInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwt-cncidm.f90
+++ b/src/Idm/gwt-cncidm.f90
@@ -447,7 +447,7 @@ module GwtCncInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/gwt-srcidm.f90
+++ b/src/Idm/gwt-srcidm.f90
@@ -468,7 +468,7 @@ module GwtSrcInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/olf-cdbidm.f90
+++ b/src/Idm/olf-cdbidm.f90
@@ -384,7 +384,7 @@ module OlfCdbInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/olf-chdidm.f90
+++ b/src/Idm/olf-chdidm.f90
@@ -447,7 +447,7 @@ module OlfChdInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/olf-evpidm.f90
+++ b/src/Idm/olf-evpidm.f90
@@ -447,7 +447,7 @@ module OlfEvpInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/olf-flwidm.f90
+++ b/src/Idm/olf-flwidm.f90
@@ -447,7 +447,7 @@ module OlfFlwInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/olf-pcpidm.f90
+++ b/src/Idm/olf-pcpidm.f90
@@ -447,7 +447,7 @@ module OlfPcpInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/olf-zdgidm.f90
+++ b/src/Idm/olf-zdgidm.f90
@@ -489,7 +489,7 @@ module OlfZdgInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/swf-cdbidm.f90
+++ b/src/Idm/swf-cdbidm.f90
@@ -384,7 +384,7 @@ module SwfCdbInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/swf-chdidm.f90
+++ b/src/Idm/swf-chdidm.f90
@@ -447,7 +447,7 @@ module SwfChdInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/swf-evpidm.f90
+++ b/src/Idm/swf-evpidm.f90
@@ -447,7 +447,7 @@ module SwfEvpInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/swf-flwidm.f90
+++ b/src/Idm/swf-flwidm.f90
@@ -447,7 +447,7 @@ module SwfFlwInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/swf-pcpidm.f90
+++ b/src/Idm/swf-pcpidm.f90
@@ -447,7 +447,7 @@ module SwfPcpInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/swf-zdgidm.f90
+++ b/src/Idm/swf-zdgidm.f90
@@ -489,7 +489,7 @@ module SwfZdgInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Idm/utl-spcidm.f90
+++ b/src/Idm/utl-spcidm.f90
@@ -278,7 +278,7 @@ module UtlSpcInputModule
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
-    .true., & ! required
+    .false., & ! required
     .true., & ! aggregate
     .true. & ! block_variable
     ) &

--- a/src/Model/ModelUtilities/BoundaryPackage.f90
+++ b/src/Model/ModelUtilities/BoundaryPackage.f90
@@ -13,9 +13,9 @@ module BndModule
                              LENMEMPATH, MAXCHARLEN, LINELENGTH, &
                              DNODATA, LENLISTLABEL, LENPAKLOC, &
                              TABLEFT, TABCENTER
-  use SimVariablesModule, only: errmsg
+  use SimVariablesModule, only: errmsg, warnmsg
   use SimModule, only: count_errors, store_error, &
-                       store_error_unit
+                       store_error_unit, store_warning
   use NumericalPackageModule, only: NumericalPackageType
   use ObsModule, only: ObsType, obs_cr
   use TdisModule, only: delt, totimc
@@ -1386,8 +1386,10 @@ contains
     !
     ! -- verify dimensions were set
     if (this%maxbound <= 0) then
-      write (errmsg, '(a)') 'MAXBOUND must be an integer greater than zero.'
-      call store_error(errmsg)
+      write (warnmsg, '(a)') &
+        trim(adjustl(this%text))//' package has MAXBOUND of zero. '// &
+        'No boundary conditions will be applied.'
+      call store_warning(warnmsg)
     end if
     !
     ! -- terminate if there are errors

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -11,8 +11,9 @@ module BndExtModule
   use KindModule, only: DP, LGP, I4B
   use ConstantsModule, only: LENMEMPATH, LENBOUNDNAME, LENAUXNAME, LINELENGTH
   use ObsModule, only: obs_cr
-  use SimVariablesModule, only: errmsg
-  use SimModule, only: store_error, count_errors, store_error_filename
+  use SimVariablesModule, only: errmsg, warnmsg
+  use SimModule, only: store_error, count_errors, store_error_filename, &
+                       store_warning
   use BndModule, only: BndType
   use GeomUtilModule, only: get_node, get_ijk
 
@@ -492,9 +493,10 @@ contains
     !
     ! -- verify dimensions were set
     if (this%maxbound <= 0) then
-      write (errmsg, '(a)') 'MAXBOUND must be an integer greater than zero.'
-      call store_error(errmsg)
-      call store_error_filename(this%input_fname)
+      write (warnmsg, '(a)') &
+        trim(adjustl(this%text))//' package has MAXBOUND of zero. '// &
+        'No boundary conditions will be applied.'
+      call store_warning(warnmsg)
     end if
   end subroutine source_dimensions
 

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -185,6 +185,7 @@ def parse_dfn(dfnfspec: Path, common: Optional[dict] = None) -> DfnFile:
             block_data[blockname_upper] = {
                 "required_l": [],
                 "has_block_var": False,
+                "block_var_required": None,
                 "is_aggregate": False,
                 "aggregate_required": False,
             }
@@ -192,6 +193,8 @@ def parse_dfn(dfnfspec: Path, common: Optional[dict] = None) -> DfnFile:
         is_block_variable = vd.get("block_variable", "").lower() == "true"
         if is_block_variable:
             block_data[blockname_upper]["has_block_var"] = True
+            is_optional = vd.get("optional", "").lower() == "true"
+            block_data[blockname_upper]["block_var_required"] = not is_optional
             continue
 
         vn = vd["name"].upper()
@@ -309,7 +312,14 @@ def parse_dfn(dfnfspec: Path, common: Optional[dict] = None) -> DfnFile:
     blocks = []
     for blockname_upper in block_names_ordered:
         bdata = block_data[blockname_upper]
-        if bdata["is_aggregate"]:
+        if bdata.get("block_var_required") is not None and bdata["is_aggregate"]:
+            # For aggregate (recarray) blocks, the block_variable's optional flag
+            # controls whether the block itself is required.  This allows stress
+            # package PERIOD blocks to be made optional via "iper optional true"
+            # in the DFN while leaving non-aggregate blocks (e.g. STO PERIOD) to
+            # derive their required status from their individual params as before.
+            block_required = bdata["block_var_required"]
+        elif bdata["is_aggregate"]:
             block_required = bdata["aggregate_required"]
         else:
             block_required = any(bdata["required_l"])


### PR DESCRIPTION
Allow traditional stress packages to have `MAXBOUND 0`. Issue a warning in this case. Make the `PERIOD` block optional for these packages; providing period data with `MAXBOUND 0` stays an error. Advanced package behavior is unmodified.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [ ] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request