### PR TITLE
feat(maw): add damping for newton underrelaxation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ autotest/notebooks/
 **.DS_Store
 # pixi environments
 .pixi
+.notes
 
 **/*.lock
 doc/ReleaseNotes/develop.tex

--- a/autotest/TestMawNur.f90
+++ b/autotest/TestMawNur.f90
@@ -1,0 +1,102 @@
+module TestMawNur
+
+  use KindModule, only: I4B, DP
+  use ConstantsModule, only: DZERO, DONE
+  use MathUtilModule, only: is_close
+  use testdrive, only: check, error_type, new_unittest, unittest_type
+  use MawModule, only: maw_damp_weight
+
+  implicit none
+  private
+  public :: collect_mawnur
+
+  ! default damping parameters, matching the values used in maw_nur
+  real(DP), parameter :: damptheta = 0.7_DP
+  real(DP), parameter :: damptol = 0.5_DP
+  real(DP), parameter :: weightmin = 0.01_DP
+  real(DP), parameter :: recover = 0.2_DP
+
+contains
+
+  subroutine collect_mawnur(testsuite)
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    testsuite = [ &
+                new_unittest("same_direction_recovers", test_same_direction), &
+                new_unittest("decaying_reversal_recovers", &
+                             test_decaying_reversal), &
+                new_unittest("sustained_reversal_damps", &
+                             test_sustained_reversal), &
+                new_unittest("weight_floor", test_weight_floor), &
+                new_unittest("recover_caps_at_one", test_recover_cap), &
+                new_unittest("first_iteration_no_damp", test_first_iteration) &
+                ]
+  end subroutine collect_mawnur
+
+  !> @brief A head change in the same direction as the last is not damped.
+  !<
+  subroutine test_same_direction(error)
+    type(error_type), allocatable, intent(out) :: error
+    real(DP) :: w
+    ! same sign change, weight grows back by recover
+    w = maw_damp_weight(8.0_DP, 3.0_DP, 0.7_DP, damptheta, damptol, &
+                        weightmin, recover)
+    call check(error, is_close(w, 0.9_DP))
+  end subroutine test_same_direction
+
+  !> @brief A reversal that is already shrinking is not damped.
+  !<
+  subroutine test_decaying_reversal(error)
+    type(error_type), allocatable, intent(out) :: error
+    real(DP) :: w
+    ! reversal but |dxprop| = 1 < damptol * |dxold| = 0.5 * 8 = 4, so recover
+    w = maw_damp_weight(-1.0_DP, 8.0_DP, 1.0_DP, damptheta, damptol, &
+                        weightmin, recover)
+    call check(error, is_close(w, DONE))
+  end subroutine test_decaying_reversal
+
+  !> @brief A reversal that is not shrinking (a real oscillation) is damped.
+  !<
+  subroutine test_sustained_reversal(error)
+    type(error_type), allocatable, intent(out) :: error
+    real(DP) :: w
+    ! reversal and |dxprop| = 53 > damptol * |dxold| = 0.5 * 56 = 28, so damp
+    w = maw_damp_weight(-53.0_DP, 56.0_DP, 1.0_DP, damptheta, damptol, &
+                        weightmin, recover)
+    call check(error, is_close(w, damptheta))
+  end subroutine test_sustained_reversal
+
+  !> @brief Damping never reduces the weight below weightmin.
+  !<
+  subroutine test_weight_floor(error)
+    type(error_type), allocatable, intent(out) :: error
+    real(DP) :: w
+    ! damptheta * 0.011 = 0.0077, which is below the floor, so weightmin is used
+    w = maw_damp_weight(-53.0_DP, 56.0_DP, 0.011_DP, damptheta, damptol, &
+                        weightmin, recover)
+    call check(error, is_close(w, weightmin))
+  end subroutine test_weight_floor
+
+  !> @brief Recovery never increases the weight above one.
+  !<
+  subroutine test_recover_cap(error)
+    type(error_type), allocatable, intent(out) :: error
+    real(DP) :: w
+    ! 0.95 + recover = 1.15, which is capped at one
+    w = maw_damp_weight(5.0_DP, 5.0_DP, 0.95_DP, damptheta, damptol, &
+                        weightmin, recover)
+    call check(error, is_close(w, DONE))
+  end subroutine test_recover_cap
+
+  !> @brief On the first iteration there is no previous change, so nothing is
+  !! treated as a reversal and the weight is not damped.
+  !<
+  subroutine test_first_iteration(error)
+    type(error_type), allocatable, intent(out) :: error
+    real(DP) :: w
+    ! dxold = 0, so dxprop * dxold = 0 (not a reversal) and the weight recovers
+    w = maw_damp_weight(-53.0_DP, DZERO, 1.0_DP, damptheta, damptol, &
+                        weightmin, recover)
+    call check(error, is_close(w, DONE))
+  end subroutine test_first_iteration
+
+end module TestMawNur

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -10,6 +10,7 @@ if test_drive.found() and not fc_id.contains('intel')
     'List',
     'ListIterator',
     'MathUtil',
+    'MawNur',
     'MemoryContainerIterator',
     'MemoryStore',
     'Message',

--- a/autotest/test_gwf_maw_lowk.py
+++ b/autotest/test_gwf_maw_lowk.py
@@ -1,0 +1,134 @@
+"""
+Tests for a multi-aquifer well (MAW) with a single connection to a low
+hydraulic conductivity cell, solved with the Newton-Raphson formulation. The
+well head is very sensitive in this case, so without help the Newton head can
+oscillate and never settle; the MAW package damps these oscillations in
+maw_nur.
+
+Two cases are tested:
+
+  1. "maw_lowk_conv" - a feasible well. RATE_SCALING reduces the rate as the
+     head drops, so a steady answer exists. The model should converge with no
+     over-demand warning.
+
+  2. "maw_lowk_fail" - an infeasible well. A fixed rate asks for more water
+     than the cell can supply with no rate reduction, so no steady answer
+     exists. The model should fail to converge and print a warning naming the
+     well.
+"""
+
+import flopy
+import pytest
+from framework import TestFramework
+
+cases = ["maw_lowk_conv", "maw_lowk_fail"]
+
+# whether each case is expected to fail to converge
+xfails = [False, True]
+
+# shared model setup
+nlay, nrow, ncol = 1, 1, 11
+delr = delc = 100.0
+top = 0.0
+botm = -50.0
+hk = 1.0e-4  # low aquifer hydraulic conductivity
+well_col = 5  # interior cell that hosts the single-connection well
+well_bottom = -50.0
+pump_rate = -20.0  # extraction (negative), larger than the cell can supply
+pump_elev = -45.0
+reduction_length = 5.0
+
+
+def build_models(idx, test):
+    name = cases[idx]
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
+    )
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=1, perioddata=[(1.0, 1, 1.0)])
+
+    # Use no solver-level under-relaxation so the test exercises the MAW
+    # package's own head damping (maw_nur), which is turned on by the model
+    # NEWTON UNDER_RELAXATION option.
+    flopy.mf6.ModflowIms(
+        sim,
+        print_option="ALL",
+        outer_dvclose=1e-7,
+        outer_maximum=200,
+        under_relaxation="NONE",
+        inner_maximum=100,
+        inner_dvclose=1e-8,
+        linear_acceleration="BICGSTAB",
+    )
+
+    gwf = flopy.mf6.ModflowGwf(
+        sim, modelname=name, newtonoptions="NEWTON UNDER_RELAXATION"
+    )
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=0.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=1, k=hk)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=1e-5, sy=0.2, steady_state={0: True})
+
+    # constant heads at both ends supply water to the aquifer
+    chd = [[(0, 0, 0), 0.0], [(0, 0, ncol - 1), 0.0]]
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd)
+
+    # single-connection MAW well
+    perioddata = [(0, "rate", pump_rate)]
+    if not xfails[idx]:
+        # feasible case: reduce the rate as the head drops so an answer exists
+        perioddata.append((0, "rate_scaling", pump_elev, reduction_length))
+    flopy.mf6.ModflowGwfmaw(
+        gwf,
+        print_head=True,
+        no_well_storage=True,
+        packagedata=[[0, 0.15, well_bottom, 0.0, "THIEM", 1]],
+        connectiondata=[[0, 0, (0, 0, well_col), 0.0, well_bottom, 0.0, 0.0]],
+        perioddata={0: perioddata},
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=f"{name}.hds",
+        saverecord=[("HEAD", "ALL")],
+    )
+    return sim
+
+
+def check_output(idx, test):
+    with open(test.workspace / "mfsim.lst") as f:
+        listing = f.read()
+
+    warning = "aquifer can supply" in listing
+
+    if xfails[idx]:
+        # the infeasible well should trigger the over-demand warning, and the
+        # warning should name the well
+        assert warning, "expected the MAW over-demand warning, but it was not found"
+        assert "MAW well" in listing
+        assert "(MAW_1-1)" in listing, "warning did not identify the well"
+    else:
+        # the feasible well should converge with no over-demand warning
+        assert "Normal termination" in listing, "model did not terminate normally"
+        assert not warning, "unexpected MAW over-demand warning for a feasible well"
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        compare=None,
+        xfail=xfails[idx],
+    )
+    test.run()

--- a/autotest/tester.f90
+++ b/autotest/tester.f90
@@ -11,6 +11,7 @@ program tester
   use TestList, only: collect_list
   use TestListIterator, only: collect_listiterator
   use TestMathUtil, only: collect_mathutil
+  use TestMawNur, only: collect_mawnur
   use TestMemoryContainerIterator, only: collect_memorycontaineriterator
   use TestMemoryStore, only: collect_memorystore
   use TestMessage, only: collect_message
@@ -41,6 +42,7 @@ program tester
                new_testsuite("List", collect_list), &
                new_testsuite("ListIterator", collect_listiterator), &
                new_testsuite("MathUtil", collect_mathutil), &
+               new_testsuite("MawNur", collect_mawnur), &
                new_testsuite("MemoryContainerIterator", &
                              collect_memorycontaineriterator), &
                new_testsuite("MemoryStore", collect_memorystore), &

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -148,3 +148,24 @@ description = "Improved CF-1.11 and UGRID-1.0 compliance for NetCDF output. A ne
 section = "fixes"
 subsection = "advanced"
 description = "When the Streamflow Routing (SFR) Package STORAGE option was active, a dry reach that was gaining (groundwater head above the streambed top) with little or no inflow could remain dry and receive no groundwater discharge, instead of rewetting from groundwater as it does when the STORAGE option is not used. This has been fixed so that a dry gaining reach rewets and receives groundwater discharge."
+
+
+[[items]]
+section = "fixes"
+subsection = "advanced"
+description = "For the Multi-Aquifer Well (MAW) Package, a well with a single connection to a low hydraulic conductivity cell could fail to converge with the Newton-Raphson formulation. In this situation a small change in flow forces a large change in the well head, so the well head could swing back and forth (oscillate) from one outer iteration to the next without settling. When the model uses the NEWTON UNDER\\_RELAXATION option, the MAW Package now damps these well-head oscillations: a well head change is reduced when it reverses direction without getting smaller, and the reduction is relaxed again as the head moves steadily toward its solution. This allows many of these wells to converge that previously did not, without slowing down wells that were already converging."
+
+[[items]]
+section = "features"
+subsection = "advanced"
+description = "For the Multi-Aquifer Well (MAW) Package, a non-converging simulation gave no indication when the cause was a pumping well asking for more water than the aquifer could supply. When the solution fails to converge, the MAW Package now checks each active extraction well to see whether the requested rate is larger than the maximum rate the connected aquifer can supply with the well head drawn down to the bottom of the well. If so, a warning is written that names the well and reports both the requested rate and the maximum available rate. The warning suggests reducing the requested rate, activating or widening RATE\\_SCALING, or reviewing the connection conductance (for example, the aquifer hydraulic conductivity)."
+
+[[items]]
+section = "fixes"
+subsection = "advanced"
+description = "For the Multi-Aquifer Well (MAW) Package, the well storage term treated the well as holding water even when the simulated well head dropped below the bottom of the well, which is not physically possible. The water level used in the storage calculation is now limited so that storage smoothly goes to zero as the well head approaches the bottom of the well, removing this phantom storage. Results are unchanged while the well head remains above the bottom of the well."
+
+[[items]]
+section = "fixes"
+subsection = "advanced"
+description = "For the Multi-Aquifer Well (MAW) Package, the Newton-Raphson formulation added a saturation-derivative matrix term for a well connection to a confined (non-convertible) cell. Because the connection saturation is held constant at one for a confined cell, this derivative should be zero, and the extra term could slow Newton convergence when a confined cell's head dropped into the well screen interval. The saturation derivative is now set to zero for connections to confined cells, so the Newton matrix terms are consistent with the flow that is calculated. Converged results are unaffected."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -153,7 +153,7 @@ description = "When the Streamflow Routing (SFR) Package STORAGE option was acti
 [[items]]
 section = "fixes"
 subsection = "advanced"
-description = "For the Multi-Aquifer Well (MAW) Package, a well with a single connection to a low hydraulic conductivity cell could fail to converge with the Newton-Raphson formulation. In this situation a small change in flow forces a large change in the well head, so the well head could swing back and forth (oscillate) from one outer iteration to the next without settling. When the model uses the NEWTON UNDER\\_RELAXATION option, the MAW Package now damps these well-head oscillations: a well head change is reduced when it reverses direction without getting smaller, and the reduction is relaxed again as the head moves steadily toward its solution. This allows many of these wells to converge that previously did not, without slowing down wells that were already converging."
+description = "For the Multi-Aquifer Well (MAW) Package, a well with a single connection to a low hydraulic conductivity cell could fail to converge with the Newton-Raphson formulation, because the well head oscillated from one outer iteration to the next instead of settling. When the model uses the NEWTON UNDER\\_RELAXATION option, the MAW Package now damps these well-head oscillations, allowing many of these wells to converge that previously did not. To keep the damping from letting a model converge while a well is still adjusting, the package also holds off convergence until the well's pumping rate has stopped changing. Wells that are not being damped, and models that do not use the NEWTON UNDER\\_RELAXATION option, are unaffected."
 
 [[items]]
 section = "features"
@@ -163,7 +163,7 @@ description = "For the Multi-Aquifer Well (MAW) Package, a non-converging simula
 [[items]]
 section = "fixes"
 subsection = "advanced"
-description = "For the Multi-Aquifer Well (MAW) Package, the well storage term treated the well as holding water even when the simulated well head dropped below the bottom of the well, which is not physically possible. The water level used in the storage calculation is now limited so that storage smoothly goes to zero as the well head approaches the bottom of the well, removing this phantom storage. Results are unchanged while the well head remains above the bottom of the well."
+description = "For the Multi-Aquifer Well (MAW) Package, the well storage term treated the well as holding water even when the simulated well head dropped below the bottom of the well, which is not physically possible. The water level used in the storage calculation is now limited so that storage smoothly goes to zero as the well head approaches the bottom of the well, removing this unrealistic storage. Results are unchanged while the well head remains above the bottom of the well."
 
 [[items]]
 section = "fixes"

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -153,19 +153,19 @@ description = "When the Streamflow Routing (SFR) Package STORAGE option was acti
 [[items]]
 section = "fixes"
 subsection = "advanced"
-description = "For the Multi-Aquifer Well (MAW) Package, a well with a single connection to a low hydraulic conductivity cell could fail to converge with the Newton-Raphson formulation, because the well head oscillated from one outer iteration to the next instead of settling. When the model uses the NEWTON UNDER\\_RELAXATION option, the MAW Package now damps these well-head oscillations, allowing many of these wells to converge that previously did not. To keep the damping from letting a model converge while a well is still adjusting, the package also holds off convergence until the well's pumping rate has stopped changing. Wells that are not being damped, and models that do not use the NEWTON UNDER\\_RELAXATION option, are unaffected."
+description = "The Multi-Aquifer Well (MAW) Package now damps well-head oscillations under the NEWTON UNDER\\_RELAXATION option, so wells with a single connection to a low hydraulic conductivity cell that could previously oscillate between outer iterations and fail to converge are able to settle. Convergence is also withheld until a damped well's pumping rate stops changing, so a model does not converge while a well is still adjusting. Models that do not use NEWTON UNDER\\_RELAXATION are unaffected."
 
 [[items]]
 section = "features"
 subsection = "advanced"
-description = "For the Multi-Aquifer Well (MAW) Package, a non-converging simulation gave no indication when the cause was a pumping well asking for more water than the aquifer could supply. When the solution fails to converge, the MAW Package now checks each active extraction well to see whether the requested rate is larger than the maximum rate the connected aquifer can supply with the well head drawn down to the bottom of the well. If so, a warning is written that names the well and reports both the requested rate and the maximum available rate. The warning suggests reducing the requested rate, activating or widening RATE\\_SCALING, or reviewing the connection conductance (for example, the aquifer hydraulic conductivity)."
+description = "When a simulation fails to converge, the Multi-Aquifer Well (MAW) Package now warns for any active extraction well whose requested rate exceeds the maximum the connected aquifer can supply with the well head drawn down to the bottom of the well. The warning names the well, reports the requested and maximum available rates, and suggests reducing the rate, using RATE\\_SCALING, or reviewing the connection conductance."
 
 [[items]]
 section = "fixes"
 subsection = "advanced"
-description = "For the Multi-Aquifer Well (MAW) Package, the well storage term treated the well as holding water even when the simulated well head dropped below the bottom of the well, which is not physically possible. The water level used in the storage calculation is now limited so that storage smoothly goes to zero as the well head approaches the bottom of the well, removing this unrealistic storage. Results are unchanged while the well head remains above the bottom of the well."
+description = "The Multi-Aquifer Well (MAW) Package well storage term previously held water even when the well head dropped below the bottom of the well. Storage now smoothly goes to zero as the well head approaches the well bottom, removing this unphysical storage; results are unchanged while the well head remains above the well bottom."
 
 [[items]]
 section = "fixes"
 subsection = "advanced"
-description = "For the Multi-Aquifer Well (MAW) Package, the Newton-Raphson formulation added a saturation-derivative matrix term for a well connection to a confined (non-convertible) cell. Because the connection saturation is held constant at one for a confined cell, this derivative should be zero, and the extra term could slow Newton convergence when a confined cell's head dropped into the well screen interval. The saturation derivative is now set to zero for connections to confined cells, so the Newton matrix terms are consistent with the flow that is calculated. Converged results are unaffected."
+description = "For the Multi-Aquifer Well (MAW) Package, the Newton-Raphson formulation added a nonzero saturation-derivative matrix term for connections to confined (non-convertible) cells, where the saturation is constant and the derivative should be zero. This term is now set to zero, making the Newton matrix consistent with the calculated flow and improving convergence when a confined cell's head drops into the well screen interval; converged results are unaffected."

--- a/src/Model/GroundWaterFlow/gwf-maw.f90
+++ b/src/Model/GroundWaterFlow/gwf-maw.f90
@@ -3045,6 +3045,15 @@ contains
       else
         qtolfact = DZERO
       end if
+      ! -- qsim0 and ratesim are both set in maw_fc (before the solve), so dq
+      !    is the rate change over the previous outer iteration and lags the
+      !    just-solved heads by one iteration. This is acceptable because it can
+      !    only delay convergence -- DVCLOSE independently guards correctness,
+      !    since stable heads imply stable rates. A future tightening to the
+      !    current-head rate would need a side-effect-free rate calculation
+      !    (maw_calculate_wellq mutates the RATE_SCALING/shutoff state, so it
+      !    cannot be re-evaluated here) and would change convergence paths, so
+      !    it is not behavior-preserving and would need test re-baselining.
       dq = (this%qsim0(n) - this%ratesim(n)) * qtolfact
       if (abs(dq) > abs(dpakmax)) then
         dpakmax = dq

--- a/src/Model/GroundWaterFlow/gwf-maw.f90
+++ b/src/Model/GroundWaterFlow/gwf-maw.f90
@@ -2475,7 +2475,10 @@ contains
       !
       ! -- start each time step with no Newton under-relaxation damping so the
       !    rate convergence check does not compare rates across the time-step
-      !    boundary
+      !    boundary. Reset both the damping weight and the previous head change
+      !    so a change carried over from the last time step cannot spuriously
+      !    trigger damping on the first outer iteration.
+      this%nurdxold(n) = DZERO
       this%nurweight(n) = DONE
     end do
     !
@@ -3003,6 +3006,7 @@ contains
     real(DP) :: bmaw
     real(DP) :: hgwf
     real(DP) :: hv
+    real(DP) :: h_temp
     real(DP) :: sat
     real(DP) :: cmaw
     real(DP) :: qmax
@@ -3071,13 +3075,30 @@ contains
       do j = 1, this%ngwfnodes(n)
         jpos = this%get_jpos(n, j)
         igwfnode = this%get_gwfnode(n, j)
-        call this%maw_calculate_saturation(n, j, igwfnode, sat)
-        cmaw = this%satcond(jpos) * sat
         hgwf = this%xnew(igwfnode)
         bmaw = this%botscrn(jpos)
         hv = max(botw, bmaw)
-        if (hgwf < bmaw) hgwf = bmaw
-        qmax = qmax + cmaw * (hgwf - hv)
+        !
+        ! -- connection saturation evaluated with the well head at the bottom of
+        !    the well (hv), consistent with this maximum-supply estimate, rather
+        !    than at the current well head
+        if (this%icelltype(igwfnode) /= 0) then
+          if (this%inewton == 1) then
+            h_temp = max(hgwf, hv)
+          else
+            h_temp = DHALF * (max(hgwf, bmaw) + hv)
+          end if
+          sat = sQuadraticSaturation(this%topscrn(jpos), bmaw, h_temp, &
+                                     this%satomega)
+        else
+          sat = DONE
+        end if
+        cmaw = this%satcond(jpos) * sat
+        !
+        ! -- only accumulate connections that can supply water; a connection
+        !    whose aquifer head is below the well head at the bottom would lose
+        !    water and must not reduce the maximum the aquifer can supply
+        qmax = qmax + cmaw * max(hgwf - hv, DZERO)
       end do
       !
       ! -- warn if the well is asking for more than the aquifer can supply

--- a/src/Model/GroundWaterFlow/gwf-maw.f90
+++ b/src/Model/GroundWaterFlow/gwf-maw.f90
@@ -2473,11 +2473,9 @@ contains
         this%xnewpak(n) = this%well_head(n)
       end if
       !
-      ! -- start each time step with no Newton under-relaxation damping so the
-      !    rate convergence check does not compare rates across the time-step
-      !    boundary. Reset both the damping weight and the previous head change
-      !    so a change carried over from the last time step cannot spuriously
-      !    trigger damping on the first outer iteration.
+      ! -- start each time step with damping turned off. Clearing the weight
+      !    and the previous head change stops a leftover value from the last
+      !    time step from triggering damping on the first iteration.
       this%nurdxold(n) = DZERO
       this%nurweight(n) = DONE
     end do
@@ -2568,16 +2566,14 @@ contains
       call this%pakmvrobj%fc()
     end if
     !
-    ! -- save the well rate from the previous outer iteration before it is
-    !    recalculated below, for the rate convergence check in maw_cc
-    do n = 1, this%nmawwells
-      this%qsim0(n) = this%ratesim(n)
-    end do
-    !
     ! -- Copy package rhs and hcof into solution rhs and amat
     idx = 1
     do n = 1, this%nmawwells
       iloc = this%idxlocnode(n)
+      !
+      ! -- save the well rate from the previous outer iteration before it is
+      !    recalculated below, for the rate convergence check in maw_cc
+      this%qsim0(n) = this%ratesim(n)
       !
       ! -- update head value for constant head maw wells
       if (this%iboundpak(n) < 0) then
@@ -2620,13 +2616,12 @@ contains
         ! -- add maw storage changes
         if (this%imawiss /= 1) then
           if (this%ifwdischarge(n) /= 1) then
-            ! -- well storage. The water level used for storage is not allowed
-            !    to go below the bottom of the well: ss is a smooth version of
-            !    max(hmaw, well bottom). This way the storage release (and its
-            !    matrix term) fades out as the well empties, instead of
-            !    releasing water from a level below the well bottom that is not
-            !    really there. While the well head is above its bottom this is
-            !    exactly the original term (sd = 1, ss = hmaw, so -area/delt).
+            ! -- well storage. The storage water level is not allowed to drop
+            !    below the bottom of the well: ss is a smooth version of
+            !    max(hmaw, well bottom). The storage release then fades out as
+            !    the well empties instead of drawing water from below the well
+            !    bottom. While the head is above the bottom this is the original
+            !    term (sd = 1, ss = hmaw, giving -area/delt).
             tled = this%area(n) / delt
             sd = sQuadratic0spDerivative(hmaw, this%bot(n), this%satomega)
             ss = sQuadratic0sp(hmaw, this%bot(n), this%satomega)
@@ -2899,13 +2894,12 @@ contains
       ! -- full Newton head change proposed for this outer iteration
       dxprop = x(n) - xtemp(n)
       !
-      ! -- oscillation damping. Cut the weight only when the head change flipped
-      !    direction AND is not already shrinking on its own (it is at least
-      !    damptol times the size of the previous change); otherwise let the
-      !    weight grow back toward one. A head change that is steadily getting
-      !    smaller is left alone so a normal, converging well is not slowed
-      !    down. This handles the part of the oscillation that stays above the
-      !    well bottom, which the bottom limit below cannot catch.
+      ! -- oscillation damping. Cut the weight only when the head change flips
+      !    direction and is not already shrinking on its own (it is still at
+      !    least damptol times the previous change). Otherwise let the weight
+      !    grow back toward one, so a normal, converging well is not slowed
+      !    down. This catches oscillations above the well bottom, which the
+      !    bottom limit below cannot.
       weight = maw_damp_weight(dxprop, this%nurdxold(n), this%nurweight(n), &
                                damptheta, damptol, weightmin, recover)
       this%nurweight(n) = weight
@@ -3006,7 +3000,6 @@ contains
     real(DP) :: bmaw
     real(DP) :: hgwf
     real(DP) :: hv
-    real(DP) :: h_temp
     real(DP) :: sat
     real(DP) :: cmaw
     real(DP) :: qmax
@@ -3015,7 +3008,6 @@ contains
     real(DP) :: dq
     real(DP) :: dpakmax
     character(len=LENPAKLOC) :: cloc
-    character(len=MAXCHARLEN) :: warnmsg
     ! -- parameters
     real(DP), parameter :: qtol = 1.001_DP !the request must exceed supply by this factor to warn
     ! -- formats
@@ -3026,15 +3018,12 @@ contains
       &Consider reducing the requested rate, applying or widening RATE_SCALING, &
       &or reviewing the connection conductance (e.g. aquifer K).')"
     !
-    ! -- rate convergence check. While a well is being damped by Newton
-    !    under-relaxation (nurweight < 1), its head step is deliberately small,
-    !    so make sure the well rate has actually stopped changing before the
-    !    model is allowed to converge. The rate change is converted to a well
-    !    head-equivalent change (using the well area and time step) so it can be
-    !    compared with the solver tolerance, and is reported through dpak. This
-    !    only affects wells that are being damped, so models that do not use
-    !    Newton under-relaxation, and wells that are not oscillating, are
-    !    unchanged.
+    ! -- rate convergence check. While a well is being damped (nurweight < 1)
+    !    its head barely moves, so also require the well rate to stop changing
+    !    before the model is allowed to converge. The rate change is turned
+    !    into an equivalent head change (using the well area and time step) so
+    !    it can be compared with the solver tolerance, and is passed back in
+    !    dpak. Wells that are not being damped are left unchanged.
     dpakmax = DZERO
     locdpak = 0
     do n = 1, this%nmawwells
@@ -3045,15 +3034,13 @@ contains
       else
         qtolfact = DZERO
       end if
-      ! -- qsim0 and ratesim are both set in maw_fc (before the solve), so dq
-      !    is the rate change over the previous outer iteration and lags the
-      !    just-solved heads by one iteration. This is acceptable because it can
-      !    only delay convergence -- DVCLOSE independently guards correctness,
-      !    since stable heads imply stable rates. A future tightening to the
-      !    current-head rate would need a side-effect-free rate calculation
-      !    (maw_calculate_wellq mutates the RATE_SCALING/shutoff state, so it
-      !    cannot be re-evaluated here) and would change convergence paths, so
-      !    it is not behavior-preserving and would need test re-baselining.
+      ! -- qsim0 and ratesim both come from maw_fc (before the solve), so dq is
+      !    the rate change from the previous outer iteration -- one step behind
+      !    the newest heads. That is fine here: a lagged rate can only delay
+      !    convergence, never accept a bad answer, because the solver already
+      !    checks the heads and steady heads mean a steady rate. The up-to-date
+      !    rate is not used because recomputing it would change the well's
+      !    shutoff and RATE_SCALING state.
       dq = (this%qsim0(n) - this%ratesim(n)) * qtolfact
       if (abs(dq) > abs(dpakmax)) then
         dpakmax = dq
@@ -3091,22 +3078,12 @@ contains
         ! -- connection saturation evaluated with the well head at the bottom of
         !    the well (hv), consistent with this maximum-supply estimate, rather
         !    than at the current well head
-        if (this%icelltype(igwfnode) /= 0) then
-          if (this%inewton == 1) then
-            h_temp = max(hgwf, hv)
-          else
-            h_temp = DHALF * (max(hgwf, bmaw) + hv)
-          end if
-          sat = sQuadraticSaturation(this%topscrn(jpos), bmaw, h_temp, &
-                                     this%satomega)
-        else
-          sat = DONE
-        end if
+        call this%maw_calculate_saturation(n, j, igwfnode, sat, hv)
         cmaw = this%satcond(jpos) * sat
         !
-        ! -- only accumulate connections that can supply water; a connection
-        !    whose aquifer head is below the well head at the bottom would lose
-        !    water and must not reduce the maximum the aquifer can supply
+        ! -- only count connections that can supply water. A connection whose
+        !    aquifer head is below the well bottom would take water in, so skip
+        !    it instead of letting it lower the maximum supply.
         qmax = qmax + cmaw * max(hgwf - hv, DZERO)
       end do
       !
@@ -3181,7 +3158,12 @@ contains
       if (this%iflowingwells > 0) then
         if (this%fwcond(n) > DZERO) then
           cfw = this%fwcondsim(n)
-          this%xsto(n) = this%fwelev(n)
+          ! -- only raise the storage level to the flowing-well elevation when
+          !    the well is actually discharging (ifwdischarge == 1), matching
+          !    the storage term assembled in maw_fc
+          if (this%ifwdischarge(n) == 1) then
+            this%xsto(n) = this%fwelev(n)
+          end if
           rrate = cfw * (this%fwelev(n) - hmaw)
           this%qfw(n) = rrate
           !
@@ -3190,12 +3172,14 @@ contains
         end if
       end if
       !
-      ! -- Calculate qsto. for a well that is not a flowing well, the water
-      !    level used for storage is not allowed to drop below the bottom of
-      !    the well (this matches the matrix term in maw_fc). A flowing well
-      !    uses the flowing-well elevation (xsto), which is unchanged.
+      ! -- Calculate qsto so it matches the storage term built in maw_fc. A
+      !    flowing well that is actively discharging (ifwdischarge == 1) uses
+      !    the flowing-well elevation (xsto = fwelev). Otherwise the storage
+      !    water level is not allowed to drop below the bottom of the well.
+      !    Testing ifwdischarge (not fwcond) keeps the budget in step with the
+      !    matrix when a flowing well is at or below its discharge elevation.
       if (this%imawiss /= 1) then
-        if (this%iflowingwells > 0 .and. this%fwcond(n) > DZERO) then
+        if (this%iflowingwells > 0 .and. this%ifwdischarge(n) == 1) then
           rrate = -this%area(n) * (this%xsto(n) - this%xoldsto(n)) / delt
         else
           ss = sQuadratic0sp(hmaw, this%bot(n), this%satomega)
@@ -4160,13 +4144,14 @@ contains
 
   !> @brief Calculate the saturation between the aquifer maw well_head
   !<
-  subroutine maw_calculate_saturation(this, n, j, node, sat)
+  subroutine maw_calculate_saturation(this, n, j, node, sat, hwell_in)
     ! -- dummy
     class(MawType), intent(inout) :: this
     integer(I4B), intent(in) :: n
     integer(I4B), intent(in) :: j
     integer(I4B), intent(in) :: node
     real(DP), intent(inout) :: sat
+    real(DP), intent(in), optional :: hwell_in !well head to use instead of the current well head
     ! -- local
     integer(I4B) :: jpos
     real(DP) :: h_temp
@@ -4181,8 +4166,11 @@ contains
     ! -- calculate current saturation for convertible cells
     if (this%icelltype(node) /= 0) then
       !
-      ! -- set hwell
+      ! -- set hwell (use the caller-supplied head if provided)
       hwell = this%xnewpak(n)
+      if (present(hwell_in)) then
+        hwell = hwell_in
+      end if
       !
       ! -- set connection position
       jpos = this%get_jpos(n, j)

--- a/src/Model/GroundWaterFlow/gwf-maw.f90
+++ b/src/Model/GroundWaterFlow/gwf-maw.f90
@@ -5,7 +5,8 @@ module MawModule
                              LENBUDTXT, DZERO, DEM9, DEM6, DEM4, DEM2, DQUARTER, &
                              DHALF, DP7, DP9, DONE, DTWO, DPI, DTWOPI, DEIGHT, &
                              DHUNDRED, DEP20, NAMEDBOUNDFLAG, LENPACKAGENAME, &
-                             LENAUXNAME, LENFTYPE, DHNOFLO, DHDRY, DNODATA, &
+                             LENAUXNAME, LENFTYPE, LENPAKLOC, DHNOFLO, DHDRY, &
+                             DNODATA, &
                              MAXCHARLEN, TABLEFT, TABCENTER, TABRIGHT, &
                              TABSTRING, TABUCSTRING, TABINTEGER, TABREAL
   use SmoothingModule, only: sQuadraticSaturation, sQSaturation, &
@@ -41,6 +42,7 @@ module MawModule
 
   private
   public :: maw_create
+  public :: maw_damp_weight
   !
   type, extends(BndType) :: MawType
     !
@@ -88,6 +90,7 @@ module MawModule
     real(DP), dimension(:), pointer, contiguous :: pumpelev => null()
     real(DP), dimension(:), pointer, contiguous :: bot => null()
     real(DP), dimension(:), pointer, contiguous :: ratesim => null()
+    real(DP), dimension(:), pointer, contiguous :: qsim0 => null() !well rate from the previous outer iteration (rate convergence check)
     real(DP), dimension(:), pointer, contiguous :: reduction_length => null()
     real(DP), dimension(:), pointer, contiguous :: fwelev => null()
     real(DP), dimension(:), pointer, contiguous :: fwcond => null()
@@ -101,6 +104,8 @@ module MawModule
     real(DP), dimension(:), pointer, contiguous :: shutoffweight => null()
     real(DP), dimension(:), pointer, contiguous :: shutoffdq => null()
     real(DP), dimension(:), pointer, contiguous :: shutoffqold => null()
+    real(DP), dimension(:), pointer, contiguous :: nurdxold => null() !well head change applied in the previous outer iteration
+    real(DP), dimension(:), pointer, contiguous :: nurweight => null() !how much each well head change is cut back to stop it from oscillating
     character(len=LENBOUNDNAME), dimension(:), pointer, &
       contiguous :: cmawname => null()
     !
@@ -188,6 +193,7 @@ module MawModule
     procedure :: bnd_fc => maw_fc
     procedure :: bnd_fn => maw_fn
     procedure :: bnd_nur => maw_nur
+    procedure :: bnd_cc => maw_cc
     procedure :: bnd_cq => maw_cq
     procedure :: bnd_ot_model_flows => maw_ot_model_flows
     procedure :: bnd_ot_package_flows => maw_ot_package_flows
@@ -371,6 +377,7 @@ contains
     call mem_allocate(this%pumpelev, this%nmawwells, 'PUMPELEV', this%memoryPath)
     call mem_allocate(this%bot, this%nmawwells, 'BOT', this%memoryPath)
     call mem_allocate(this%ratesim, this%nmawwells, 'RATESIM', this%memoryPath)
+    call mem_allocate(this%qsim0, this%nmawwells, 'QSIM0', this%memoryPath)
     call mem_allocate(this%reduction_length, this%nmawwells, 'REDUCTION_LENGTH', &
                       this%memoryPath)
     call mem_allocate(this%fwelev, this%nmawwells, 'FWELEV', this%memoryPath)
@@ -391,6 +398,10 @@ contains
     call mem_allocate(this%shutoffdq, this%nmawwells, 'SHUTOFFDQ', &
                       this%memoryPath)
     call mem_allocate(this%shutoffqold, this%nmawwells, 'SHUTOFFQOLD', &
+                      this%memoryPath)
+    call mem_allocate(this%nurdxold, this%nmawwells, 'NURDXOLD', &
+                      this%memoryPath)
+    call mem_allocate(this%nurweight, this%nmawwells, 'NURWEIGHT', &
                       this%memoryPath)
     !
     ! -- timeseries aware variables
@@ -449,6 +460,7 @@ contains
       this%pumpelev(n) = DEP20
       this%bot(n) = DEP20
       this%ratesim(n) = DZERO
+      this%qsim0(n) = DZERO
       this%reduction_length(n) = DEP20
       this%fwelev(n) = DZERO
       this%fwcond(n) = DZERO
@@ -462,6 +474,8 @@ contains
       this%shutoffweight(n) = DONE
       this%shutoffdq(n) = DONE
       this%shutoffqold(n) = DONE
+      this%nurdxold(n) = DZERO
+      this%nurweight(n) = DONE
       !
       ! -- timeseries aware variables
       this%rate(n) = DZERO
@@ -2458,6 +2472,11 @@ contains
       if (this%iboundpak(n) < 0) then
         this%xnewpak(n) = this%well_head(n)
       end if
+      !
+      ! -- start each time step with no Newton under-relaxation damping so the
+      !    rate convergence check does not compare rates across the time-step
+      !    boundary
+      this%nurweight(n) = DONE
     end do
     !
     !--use the appropriate xoldsto if initial heads are above the
@@ -2536,11 +2555,21 @@ contains
     real(DP) :: rate
     real(DP) :: ratefw
     real(DP) :: flow
+    real(DP) :: tled
+    real(DP) :: sd
+    real(DP) :: ss
+    real(DP) :: ssold
     !
     ! -- pakmvrobj fc
     if (this%imover == 1) then
       call this%pakmvrobj%fc()
     end if
+    !
+    ! -- save the well rate from the previous outer iteration before it is
+    !    recalculated below, for the rate convergence check in maw_cc
+    do n = 1, this%nmawwells
+      this%qsim0(n) = this%ratesim(n)
+    end do
     !
     ! -- Copy package rhs and hcof into solution rhs and amat
     idx = 1
@@ -2588,8 +2617,19 @@ contains
         ! -- add maw storage changes
         if (this%imawiss /= 1) then
           if (this%ifwdischarge(n) /= 1) then
-            call matrix_sln%add_value_pos(iposd, -this%area(n) / delt)
-            rhs(iloc) = rhs(iloc) - (this%area(n) * this%xoldsto(n) / delt)
+            ! -- well storage. The water level used for storage is not allowed
+            !    to go below the bottom of the well: ss is a smooth version of
+            !    max(hmaw, well bottom). This way the storage release (and its
+            !    matrix term) fades out as the well empties, instead of
+            !    releasing water from a level below the well bottom that is not
+            !    really there. While the well head is above its bottom this is
+            !    exactly the original term (sd = 1, ss = hmaw, so -area/delt).
+            tled = this%area(n) / delt
+            sd = sQuadratic0spDerivative(hmaw, this%bot(n), this%satomega)
+            ss = sQuadratic0sp(hmaw, this%bot(n), this%satomega)
+            ssold = sQuadratic0sp(this%xoldsto(n), this%bot(n), this%satomega)
+            call matrix_sln%add_value_pos(iposd, -tled * sd)
+            rhs(iloc) = rhs(iloc) - tled * (sd * hmaw - ss + ssold)
           else
             cterm = this%xoldsto(n) - this%fwelev(n)
             rhs(iloc) = rhs(iloc) - (this%area(n) * cterm / delt)
@@ -2813,8 +2853,17 @@ contains
     end do
   end subroutine maw_fn
 
-  !> @brief Calculate under-relaxation of groundwater flow model MAW Package heads
-  !! for current outer iteration using the well bottom
+  !> @brief Apply Newton under-relaxation to the MAW Package well heads.
+  !!
+  !! Two corrections are applied to each well head, in order:
+  !!   1. Oscillation damping. If the well head change reverses direction and is
+  !!      not getting smaller, it is cut back by a per-well weight. The weight
+  !!      shrinks while the head oscillates and grows back when the head moves
+  !!      steadily in one direction. This settles poorly connected wells (for
+  !!      example a low-K cell or a single connection) whose full Newton step is
+  !!      too large.
+  !!   2. Bottom limit. If the head is still below the well bottom, it is moved
+  !!      back up toward the well bottom (the original behavior).
   !<
   subroutine maw_nur(this, neqpak, x, xtemp, dx, inewtonur, dxmax, locmax)
     ! -- dummy
@@ -2831,14 +2880,48 @@ contains
     real(DP) :: botw
     real(DP) :: xx
     real(DP) :: dxx
+    real(DP) :: dxprop
+    real(DP) :: weight
+    ! -- parameters
+    real(DP), parameter :: damptheta = DP7 !factor the weight is cut by when the head oscillates
+    real(DP), parameter :: damptol = DHALF !only damp if the change is at least this fraction of the last one
+    real(DP), parameter :: weightmin = DEM2 !smallest allowed weight
+    real(DP), parameter :: recover = 0.2_DP !amount the weight grows back each iteration
     !
     ! -- Newton-Raphson under-relaxation
     do n = 1, this%nmawwells
       if (this%iboundpak(n) < 1) cycle
       botw = this%bot(n)
       !
-      ! -- only apply Newton-Raphson under-relaxation if
-      !    solution head is below the bottom of the well
+      ! -- full Newton head change proposed for this outer iteration
+      dxprop = x(n) - xtemp(n)
+      !
+      ! -- oscillation damping. Cut the weight only when the head change flipped
+      !    direction AND is not already shrinking on its own (it is at least
+      !    damptol times the size of the previous change); otherwise let the
+      !    weight grow back toward one. A head change that is steadily getting
+      !    smaller is left alone so a normal, converging well is not slowed
+      !    down. This handles the part of the oscillation that stays above the
+      !    well bottom, which the bottom limit below cannot catch.
+      weight = maw_damp_weight(dxprop, this%nurdxold(n), this%nurweight(n), &
+                               damptheta, damptol, weightmin, recover)
+      this%nurweight(n) = weight
+      !
+      ! -- apply the reduced step when damping is turned on
+      if (weight < DONE) then
+        inewtonur = 1
+        xx = xtemp(n) + weight * dxprop
+        dxx = x(n) - xx
+        if (abs(dxx) > abs(dxmax)) then
+          locmax = n
+          dxmax = dxx
+        end if
+        x(n) = xx
+        dx(n) = weight * dxprop
+      end if
+      !
+      ! -- bottom limit: if the (reduced) head is still below the bottom of the
+      !    well, move it back up toward the well bottom
       if (x(n) < botw) then
         inewtonur = 1
         xx = xtemp(n) * (DONE - DP9) + botw * DP9
@@ -2850,8 +2933,163 @@ contains
         x(n) = xx
         dx(n) = DZERO
       end if
+      !
+      ! -- save the head change actually applied this iteration (after damping
+      !    and the bottom limit). Saving it after the bottom limit lets the
+      !    next iteration see the downward push from the limit, so the upward
+      !    swing that follows can be damped.
+      this%nurdxold(n) = x(n) - xtemp(n)
     end do
   end subroutine maw_nur
+
+  !> @brief Update the oscillation-damping weight for a single MAW well head.
+  !!
+  !! This is the decision used by maw_nur. The weight is cut back (multiplied by
+  !! damptheta, but never below weightmin) only when the proposed head change
+  !! reversed direction and is not already getting smaller (its size is at least
+  !! damptol times the previous change). Otherwise the weight grows back toward
+  !! one by recover. It is a pure function so the logic can be unit tested.
+  !<
+  pure function maw_damp_weight(dxprop, dxold, weight, damptheta, damptol, &
+                                weightmin, recover) result(new_weight)
+    ! -- dummy
+    real(DP), intent(in) :: dxprop !proposed well head change this outer iteration
+    real(DP), intent(in) :: dxold !well head change applied last outer iteration
+    real(DP), intent(in) :: weight !current damping weight
+    real(DP), intent(in) :: damptheta !factor the weight is cut by when oscillating
+    real(DP), intent(in) :: damptol !smallest |dxprop|/|dxold| ratio that is damped
+    real(DP), intent(in) :: weightmin !smallest allowed weight
+    real(DP), intent(in) :: recover !amount the weight grows back each iteration
+    ! -- return
+    real(DP) :: new_weight
+    !
+    if (dxprop * dxold < DZERO .and. abs(dxprop) > damptol * abs(dxold)) then
+      new_weight = max(damptheta * weight, weightmin)
+    else
+      new_weight = min(weight + recover, DONE)
+    end if
+  end function maw_damp_weight
+
+  !> @brief Extra convergence check for the MAW package.
+  !!
+  !! This does two things:
+  !!   1. While a well is being damped by Newton under-relaxation, it keeps the
+  !!      model from converging until the well rate has also stopped changing
+  !!      (reported through dpak). Wells that are not being damped, and models
+  !!      that do not use Newton under-relaxation, are not affected.
+  !!   2. When the model fails to converge, it warns about any pumping well that
+  !!      is asking for more water than the aquifer can supply, a likely reason
+  !!      for the failure.
+  !<
+  subroutine maw_cc(this, innertot, kiter, iend, icnvgmod, cpak, ipak, dpak)
+    ! -- modules
+    use TdisModule, only: delt
+    ! -- dummy
+    class(MawType), intent(inout) :: this
+    integer(I4B), intent(in) :: innertot
+    integer(I4B), intent(in) :: kiter
+    integer(I4B), intent(in) :: iend
+    integer(I4B), intent(in) :: icnvgmod
+    character(len=LENPAKLOC), intent(inout) :: cpak
+    integer(I4B), intent(inout) :: ipak
+    real(DP), intent(inout) :: dpak
+    ! -- local
+    integer(I4B) :: n
+    integer(I4B) :: j
+    integer(I4B) :: jpos
+    integer(I4B) :: igwfnode
+    integer(I4B) :: locdpak
+    real(DP) :: botw
+    real(DP) :: bmaw
+    real(DP) :: hgwf
+    real(DP) :: hv
+    real(DP) :: sat
+    real(DP) :: cmaw
+    real(DP) :: qmax
+    real(DP) :: qreq
+    real(DP) :: qtolfact
+    real(DP) :: dq
+    real(DP) :: dpakmax
+    character(len=LENPAKLOC) :: cloc
+    character(len=MAXCHARLEN) :: warnmsg
+    ! -- parameters
+    real(DP), parameter :: qtol = 1.001_DP !the request must exceed supply by this factor to warn
+    ! -- formats
+    character(len=*), parameter :: fmtwarn = &
+      "('MAW well ', a, ' requests an extraction rate (', g0.5, &
+      &') larger than the maximum rate (', g0.5, ') the aquifer can supply &
+      &with the well head at its bottom. This may be preventing convergence. &
+      &Consider reducing the requested rate, applying or widening RATE_SCALING, &
+      &or reviewing the connection conductance (e.g. aquifer K).')"
+    !
+    ! -- rate convergence check. While a well is being damped by Newton
+    !    under-relaxation (nurweight < 1), its head step is deliberately small,
+    !    so make sure the well rate has actually stopped changing before the
+    !    model is allowed to converge. The rate change is converted to a well
+    !    head-equivalent change (using the well area and time step) so it can be
+    !    compared with the solver tolerance, and is reported through dpak. This
+    !    only affects wells that are being damped, so models that do not use
+    !    Newton under-relaxation, and wells that are not oscillating, are
+    !    unchanged.
+    dpakmax = DZERO
+    locdpak = 0
+    do n = 1, this%nmawwells
+      if (this%iboundpak(n) < 1) cycle
+      if (this%nurweight(n) >= DONE) cycle
+      if (this%area(n) > DZERO) then
+        qtolfact = delt / this%area(n)
+      else
+        qtolfact = DZERO
+      end if
+      dq = (this%qsim0(n) - this%ratesim(n)) * qtolfact
+      if (abs(dq) > abs(dpakmax)) then
+        dpakmax = dq
+        locdpak = n
+      end if
+    end do
+    if (locdpak > 0 .and. abs(dpakmax) > abs(dpak)) then
+      ipak = locdpak
+      dpak = dpakmax
+      write (cloc, "(a,'-',a)") trim(this%packName), 'rate'
+      cpak = trim(cloc)
+    end if
+    !
+    ! -- the over-demand warning is only written on the last outer iteration of
+    !    a model that did not converge
+    if (iend == 0) return
+    if (icnvgmod /= 0) return
+    !
+    ! -- look at each active pumping (extraction) well
+    do n = 1, this%nmawwells
+      if (this%iboundpak(n) < 1) cycle
+      if (this%rate(n) >= DZERO) cycle
+      botw = this%bot(n)
+      !
+      ! -- largest rate the aquifer could supply if the well head dropped all
+      !    the way to the bottom of the well
+      qmax = DZERO
+      do j = 1, this%ngwfnodes(n)
+        jpos = this%get_jpos(n, j)
+        igwfnode = this%get_gwfnode(n, j)
+        call this%maw_calculate_saturation(n, j, igwfnode, sat)
+        cmaw = this%satcond(jpos) * sat
+        hgwf = this%xnew(igwfnode)
+        bmaw = this%botscrn(jpos)
+        hv = max(botw, bmaw)
+        if (hgwf < bmaw) hgwf = bmaw
+        qmax = qmax + cmaw * (hgwf - hv)
+      end do
+      !
+      ! -- warn if the well is asking for more than the aquifer can supply
+      qreq = -this%rate(n)
+      if (qmax >= DZERO .and. qreq > qtol * qmax) then
+        write (cloc, '(a, a, a, a, i0, a, i0, a)') trim(this%name_model), '-(', &
+          trim(this%filtyp), '_', this%ibcnum, '-', n, ')'
+        write (warnmsg, fmtwarn) trim(cloc), qreq, qmax
+        call store_warning(warnmsg)
+      end if
+    end do
+  end subroutine maw_cc
 
   !> @brief Calculate flows
   !<
@@ -2867,6 +3105,8 @@ contains
     integer(I4B), optional, intent(in) :: iadv
     ! -- local
     real(DP) :: rrate
+    real(DP) :: ss
+    real(DP) :: ssold
     ! -- for budget
     integer(I4B) :: j
     integer(I4B) :: n
@@ -2920,9 +3160,18 @@ contains
         end if
       end if
       !
-      ! -- Calculate qsto
+      ! -- Calculate qsto. for a well that is not a flowing well, the water
+      !    level used for storage is not allowed to drop below the bottom of
+      !    the well (this matches the matrix term in maw_fc). A flowing well
+      !    uses the flowing-well elevation (xsto), which is unchanged.
       if (this%imawiss /= 1) then
-        rrate = -this%area(n) * (this%xsto(n) - this%xoldsto(n)) / delt
+        if (this%iflowingwells > 0 .and. this%fwcond(n) > DZERO) then
+          rrate = -this%area(n) * (this%xsto(n) - this%xoldsto(n)) / delt
+        else
+          ss = sQuadratic0sp(hmaw, this%bot(n), this%satomega)
+          ssold = sQuadratic0sp(this%xoldsto(n), this%bot(n), this%satomega)
+          rrate = -this%area(n) * (ss - ssold) / delt
+        end if
         this%qsto(n) = rrate
       end if
     end do
@@ -3117,6 +3366,7 @@ contains
     call mem_deallocate(this%pumpelev)
     call mem_deallocate(this%bot)
     call mem_deallocate(this%ratesim)
+    call mem_deallocate(this%qsim0)
     call mem_deallocate(this%reduction_length)
     call mem_deallocate(this%fwelev)
     call mem_deallocate(this%fwcond)
@@ -3130,6 +3380,8 @@ contains
     call mem_deallocate(this%shutoffweight)
     call mem_deallocate(this%shutoffdq)
     call mem_deallocate(this%shutoffqold)
+    call mem_deallocate(this%nurdxold)
+    call mem_deallocate(this%nurweight)
     !
     ! -- timeseries aware variables
     call mem_deallocate(this%mauxvar)
@@ -4018,8 +4270,15 @@ contains
         hups = hgwf
       end if
       !
-      ! -- calculate the derivative of saturation
-      drterm = sQuadraticSaturationDerivative(tmaw, bmaw, hups, this%satomega)
+      ! -- slope of the saturation with head. In a confined (non-convertible)
+      !    cell the saturation is always one and does not change with head, so
+      !    this slope must be zero. Otherwise the matrix terms would not match
+      !    the flow that is actually calculated for the well.
+      if (this%icelltype(igwfnode) /= 0) then
+        drterm = sQuadraticSaturationDerivative(tmaw, bmaw, hups, this%satomega)
+      else
+        drterm = DZERO
+      end if
     else
       term = cmaw
     end if
@@ -4132,7 +4391,7 @@ contains
         dq = q - this%shutoffqold(n)
         weight = this%shutoffweight(n)
         !
-        ! -- for flip-flop condition, decrease factor
+        ! -- for oscillating condition, decrease factor
         if (this%shutoffdq(n) * dq < DZERO) then
           weight = this%theta * this%shutoffweight(n)
           !
@@ -4222,7 +4481,7 @@ contains
         dq = q - this%shutoffqold(n)
         weight = this%shutoffweight(n)
         !
-        ! -- for flip-flop condition, decrease factor
+        ! -- for oscillating condition, decrease factor
         if (this%shutoffdq(n) * dq < DZERO) then
           weight = this%theta * this%shutoffweight(n)
           !


### PR DESCRIPTION
Add dampening to maw when Newton Under-relaxation and autoflow reduce is enabled to help convergence issues observed when maw wells are connected to a single cells that have low hydraulic conductivity values. 

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated meson files, makefiles, and Visual Studio project files for new source files
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
