### PR TITLE
feat: tolerate boundary conditions on inactive cells

### DIFF
--- a/autotest/test_stress_pkg_inactive_cell.py
+++ b/autotest/test_stress_pkg_inactive_cell.py
@@ -1,0 +1,167 @@
+"""
+Test that stress packages issue a warning (not an error) when a boundary
+condition entry references a cell that is not in the active grid domain.
+The model should run to completion and the listing file should contain a
+warning about the inactive cell.
+
+Packages tested: RCH, WEL, GHB, DRN, RIV, CHD
+"""
+
+import os
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = [
+    "inact_rch",
+    "inact_wel",
+    "inact_ghb",
+    "inact_drn",
+    "inact_riv",
+    "inact_chd",
+]
+
+nlay, nrow, ncol = 1, 3, 3
+inactive_cell = (0, 0, 0)
+chd_cell = (0, 2, 2)
+top = 10.0
+botm = 0.0
+strt = 5.0
+idomain = np.ones((nlay, nrow, ncol), dtype=int)
+idomain[inactive_cell] = 0
+
+
+def _base_sim(test, name):
+    ws = test.workspace
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+    flopy.mf6.ModflowIms(
+        sim,
+        outer_dvclose=1e-6,
+        inner_dvclose=1e-6,
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        top=top,
+        botm=botm,
+        idomain=idomain,
+    )
+    flopy.mf6.ModflowGwfnpf(gwf, k=1.0)
+    flopy.mf6.ModflowGwfic(gwf, strt=strt)
+    flopy.mf6.ModflowGwfchd(
+        gwf,
+        stress_period_data={0: [[chd_cell, strt]]},
+    )
+
+    return sim, gwf
+
+
+def build_models(idx, test):
+    name = cases[idx]
+    sim, gwf = _base_sim(test, name)
+
+    if idx == 0:
+        # RCH: one entry on the inactive cell, one on an active cell
+        flopy.mf6.ModflowGwfrch(
+            gwf,
+            stress_period_data={
+                0: [
+                    [inactive_cell, 1e-3],
+                    [(0, 1, 1), 1e-3],
+                ]
+            },
+        )
+
+    elif idx == 1:
+        # WEL: one entry on the inactive cell
+        flopy.mf6.ModflowGwfwel(
+            gwf,
+            stress_period_data={
+                0: [
+                    [inactive_cell, -1.0],
+                    [(0, 1, 1), -1.0],
+                ]
+            },
+        )
+
+    elif idx == 2:
+        # GHB: one entry on the inactive cell
+        flopy.mf6.ModflowGwfghb(
+            gwf,
+            stress_period_data={
+                0: [
+                    [inactive_cell, strt, 1.0],
+                    [(0, 1, 1), strt, 1.0],
+                ]
+            },
+        )
+
+    elif idx == 3:
+        # DRN: one entry on the inactive cell
+        flopy.mf6.ModflowGwfdrn(
+            gwf,
+            stress_period_data={
+                0: [
+                    [inactive_cell, 3.0, 1.0],
+                    [(0, 1, 1), 3.0, 1.0],
+                ]
+            },
+        )
+
+    elif idx == 4:
+        # RIV: one entry on the inactive cell
+        flopy.mf6.ModflowGwfriv(
+            gwf,
+            stress_period_data={
+                0: [
+                    [inactive_cell, strt, 1.0, botm],
+                    [(0, 1, 1), strt, 1.0, botm],
+                ]
+            },
+        )
+
+    elif idx == 5:
+        # CHD: one entry on the inactive cell (the base sim already has a
+        # CHD on an active cell; add a separate package with the bad entry)
+        flopy.mf6.ModflowGwfchd(
+            gwf,
+            stress_period_data={
+                0: [
+                    [inactive_cell, strt],
+                    [(0, 0, 1), strt],
+                ]
+            },
+            pname="chd_bad",
+            filename=f"{name}_bad.chd",
+        )
+
+    return sim, None
+
+
+def check_output(idx, test):
+    mfsim_lst = os.path.join(test.workspace, "mfsim.lst")
+    assert os.path.isfile(mfsim_lst)
+    lst_text = open(mfsim_lst).read()
+    assert "Normal termination" in lst_text
+    warning_phrase = "outside active grid domain"
+    assert warning_phrase.lower() in lst_text.lower()
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        targets=targets,
+    )
+    test.run()

--- a/doc/ReleaseNotes/changes/inactive-cell-bc-warning.toml
+++ b/doc/ReleaseNotes/changes/inactive-cell-bc-warning.toml
@@ -1,0 +1,3 @@
+section = "fixes"
+subsection = "stress"
+description = "Placing a boundary condition in an inactive cell previously caused an error in most stress packages (WEL, DRN, RIV, CHD, GHB, FLW, CDB, ZDG, CNC, SRC, CTP, ESL). This has been changed to a warning, and the inactive boundary entry is silently ignored during the simulation. Packages that already skipped inactive cells (RCH, EVT, PCP, EVP) are unaffected."

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -123,3 +123,8 @@ description = "The Multi-Aquifer Well (MAW) Package now supports non-vertical (s
 section = "features"
 subsection = "stress"
 description = "Grid array-based input (READARRAYGRID) is now available for the CHD, WEL, DRN, RIV, and GHB stress packages.  Grid array-based input allows stress package data to be specified as full-grid arrays using the DNODATA value (3.0E+30) to identify inactive cells.  Auxiliary variable arrays persist across stress periods if not re-specified, and CONSTANT array input is supported for any array after the first in a period block."
+
+[[items]]
+section = "fixes"
+subsection = "stress"
+description = "Placing a boundary condition in an inactive cell previously caused an error in most stress packages (WEL, DRN, RIV, CHD, GHB, FLW, CDB, ZDG, CNC, SRC, CTP, ESL). This has been changed to a warning. Packages that already skipped inactive cells (RCH, EVT, PCP, EVP) are unaffected."

--- a/src/Model/GroundWaterEnergy/gwe-ctp.f90
+++ b/src/Model/GroundWaterEnergy/gwe-ctp.f90
@@ -142,6 +142,7 @@ contains
     ! -- Reset previous CTPs to active cell
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       this%ibound(node) = this%ibcnum
     end do
     !
@@ -152,6 +153,7 @@ contains
     ierr = 0
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       ibd = this%ibound(node)
       if (ibd < 0) then
         call this%dis%noder_to_string(node, nodestr)
@@ -188,6 +190,7 @@ contains
     ! -- Process each entry in the constant temperature cell list
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       cb = this%temp_mult(i)
       !
       this%xnew(node) = cb
@@ -217,6 +220,7 @@ contains
     ! -- check stress period data
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       ! -- accumulate errors
       if (this%temp_mult(i) < DZERO) then
         call this%dis%noder_to_string(node, nodestr)
@@ -271,6 +275,7 @@ contains
       ! -- Loop through each boundary calculating flow.
       do i = 1, this%nbound
         node = this%nodelist(i)
+        if (node <= 0) cycle
         idiag = this%dis%con%ia(node)
         rate = DZERO
         ratein = DZERO

--- a/src/Model/GroundWaterEnergy/gwe-esl.f90
+++ b/src/Model/GroundWaterEnergy/gwe-esl.f90
@@ -190,6 +190,10 @@ contains
     do i = 1, this%nbound
       node = this%nodelist(i)
       this%hcof(i) = DZERO
+      if (node <= 0) then
+        this%rhs(i) = DZERO
+        cycle
+      end if
       if (this%ibound(node) <= 0) then
         this%rhs(i) = DZERO
         cycle
@@ -224,6 +228,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
+      if (n <= 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))

--- a/src/Model/GroundWaterFlow/gwf-chd.f90
+++ b/src/Model/GroundWaterFlow/gwf-chd.f90
@@ -136,6 +136,7 @@ contains
     ! -- Reset previous CHDs to active cell
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       this%ibound(node) = this%ibcnum
     end do
     !
@@ -146,6 +147,7 @@ contains
     ierr = 0
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       ibd = this%ibound(node)
       if (ibd < 0) then
         call this%dis%noder_to_string(node, nodestr)
@@ -180,6 +182,7 @@ contains
     ! -- Process each entry in the specified-head cell list
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       hb = this%head_mult(i)
       !
       this%xnew(node) = hb
@@ -211,6 +214,7 @@ contains
     ! -- check stress period data
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       bt = this%dis%bot(node)
       ! -- accumulate errors
       if (this%head_mult(i) < bt .and. this%icelltype(node) /= 0) then
@@ -277,6 +281,7 @@ contains
       ! -- Loop through each boundary calculating flow.
       do i = 1, this%nbound
         node = this%nodelist(i)
+        if (node <= 0) cycle
         idiag = this%dis%con%ia(node)
         rate = DZERO
         ratein = DZERO

--- a/src/Model/GroundWaterFlow/gwf-drn.f90
+++ b/src/Model/GroundWaterFlow/gwf-drn.f90
@@ -349,6 +349,11 @@ contains
     ! -- Calculate hcof and rhs for each drn entry
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) then
+        this%hcof(i) = DZERO
+        this%rhs(i) = DZERO
+        cycle
+      end if
       if (this%ibound(node) <= 0) then
         this%hcof(i) = DZERO
         this%rhs(i) = DZERO
@@ -394,6 +399,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
+      if (n <= 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))
@@ -436,6 +442,7 @@ contains
     if (this%iauxddrncol /= 0) then
       do i = 1, this%nbound
         node = this%nodelist(i)
+        if (node <= 0) cycle
         !
         ! -- test if node is constant or inactive
         if (this%ibound(node) <= 0) then

--- a/src/Model/GroundWaterFlow/gwf-ghb.f90
+++ b/src/Model/GroundWaterFlow/gwf-ghb.f90
@@ -207,7 +207,7 @@ contains
     ! -- check stress period data
     do i = 1, this%nbound
       node = this%nodelist(i)
-      if (node == 0) cycle
+      if (node <= 0) cycle
       bt = this%dis%bot(node)
       ! -- accumulate errors
       if (this%bhead(i) < bt .and. this%icelltype(node) /= 0) then
@@ -249,7 +249,7 @@ contains
     ! -- Calculate hcof and rhs for each ghb entry
     do i = 1, this%nbound
       node = this%nodelist(i)
-      if (node == 0) cycle
+      if (node <= 0) cycle
       if (this%ibound(node) .le. 0) then
         this%hcof(i) = DZERO
         this%rhs(i) = DZERO
@@ -281,7 +281,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
-      if (n == 0) cycle
+      if (n <= 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))

--- a/src/Model/GroundWaterFlow/gwf-riv.f90
+++ b/src/Model/GroundWaterFlow/gwf-riv.f90
@@ -276,6 +276,11 @@ contains
     ! -- Calculate hcof and rhs for each riv entry
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) then
+        this%hcof(i) = DZERO
+        this%rhs(i) = DZERO
+        cycle
+      end if
       if (this%ibound(node) <= 0) then
         this%hcof(i) = DZERO
         this%rhs(i) = DZERO
@@ -315,6 +320,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
+      if (n <= 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))

--- a/src/Model/GroundWaterFlow/gwf-wel.f90
+++ b/src/Model/GroundWaterFlow/gwf-wel.f90
@@ -444,6 +444,10 @@ contains
     do i = 1, this%nbound
       node = this%nodelist(i)
       this%hcof(i) = DZERO
+      if (node <= 0) then
+        this%rhs(i) = DZERO
+        cycle
+      end if
       if (this%ibound(node) <= 0) then
         this%rhs(i) = DZERO
         cycle
@@ -497,6 +501,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
+      if (n <= 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))
@@ -536,6 +541,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       !
       ! -- test if node is constant or inactive
       if (this%ibound(node) <= 0) then
@@ -605,6 +611,7 @@ contains
     ! -- format
     do i = 1, this%nbound
       nodereduced = this%nodelist(i)
+      if (nodereduced <= 0) cycle
       !
       ! -- test if node is constant or inactive
       if (this%ibound(nodereduced) <= 0) then

--- a/src/Model/GroundWaterTransport/gwt-cnc.f90
+++ b/src/Model/GroundWaterTransport/gwt-cnc.f90
@@ -142,6 +142,7 @@ contains
     ! -- Reset previous CNCs to active cell
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       this%ibound(node) = this%ibcnum
     end do
     !
@@ -152,6 +153,7 @@ contains
     ierr = 0
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       ibd = this%ibound(node)
       if (ibd < 0) then
         call this%dis%noder_to_string(node, nodestr)
@@ -190,6 +192,7 @@ contains
     ! -- Process each entry in the constant concentration cell list
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       cb = this%conc_mult(i)
       !
       this%xnew(node) = cb
@@ -220,6 +223,7 @@ contains
     ! -- check stress period data
     do i = 1, this%nbound
       node = this%nodelist(i)
+      if (node <= 0) cycle
       ! -- accumulate errors
       if (this%conc_mult(i) < DZERO) then
         call this%dis%noder_to_string(node, nodestr)
@@ -277,6 +281,7 @@ contains
       ! -- Loop through each boundary calculating flow.
       do i = 1, this%nbound
         node = this%nodelist(i)
+        if (node <= 0) cycle
         idiag = this%dis%con%ia(node)
         rate = DZERO
         ratein = DZERO

--- a/src/Model/GroundWaterTransport/gwt-src.f90
+++ b/src/Model/GroundWaterTransport/gwt-src.f90
@@ -261,6 +261,12 @@ contains
         node = this%nodelist(i)
       end if
       !
+      if (node <= 0) then
+        this%hcof(i) = DZERO
+        this%rhs(i) = DZERO
+        cycle
+      end if
+      !
       ! -- reset nodelist to highest active
       if (this%highest_sat) then
         if (this%fmi%gwfsat(node) == 0) &
@@ -303,6 +309,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
+      if (n <= 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))

--- a/src/Model/ModelUtilities/BoundaryPackage.f90
+++ b/src/Model/ModelUtilities/BoundaryPackage.f90
@@ -466,6 +466,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
+      if (n <= 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -12,7 +12,8 @@ module BndExtModule
   use ConstantsModule, only: LENMEMPATH, LENBOUNDNAME, LENAUXNAME, LINELENGTH
   use ObsModule, only: obs_cr
   use SimVariablesModule, only: errmsg
-  use SimModule, only: store_error, count_errors, store_error_filename
+  use SimModule, only: store_error, store_error_filename, &
+                       store_warning, count_errors
   use BndModule, only: BndType
   use GeomUtilModule, only: get_node, get_ijk
 
@@ -543,22 +544,15 @@ contains
         if (noder <= 0) then
           call this%dis%nodeu_to_string(nodeu, nodestr)
           write (errmsg, *) &
-            ' Cell is outside active grid domain: '// &
+            ' Cell is outside active grid domain and will be ignored: '// &
             trim(adjustl(nodestr))
-          call store_error(errmsg)
+          call store_warning(errmsg)
         end if
         this%nodelist(n) = noder
       else
         this%nodelist(n) = nodeu
       end if
     end do
-    !
-    ! -- exit if errors were found
-    if (count_errors() > 0) then
-      write (errmsg, *) count_errors(), ' errors encountered.'
-      call store_error(errmsg)
-      call store_error_filename(this%input_fname)
-    end if
   end subroutine cellid_to_nlist
 
   !> @ brief Update package nodelist
@@ -572,6 +566,7 @@ contains
     ! -- dummy
     class(BndExtType) :: this !< BndExtType object
     integer(I4B) :: n, noder, nodeuser, ninactive
+    character(len=LINELENGTH) :: nodestr
 
     ninactive = 0
 
@@ -582,6 +577,11 @@ contains
       if (noder > 0) then
         this%nodelist(n) = noder
       else
+        call this%dis%nodeu_to_string(nodeuser, nodestr)
+        write (errmsg, *) &
+          ' Cell is outside active grid domain and will be ignored: '// &
+          trim(adjustl(nodestr))
+        call store_warning(errmsg)
         ninactive = ninactive + 1
       end if
     end do

--- a/src/Model/ModelUtilities/DiscretizationBase.f90
+++ b/src/Model/ModelUtilities/DiscretizationBase.f90
@@ -795,7 +795,8 @@ contains
     use ConstantsModule, only: LENBOUNDNAME, LINELENGTH
     use LongLineReaderModule, only: LongLineReaderType
     use ListReaderModule, only: ListReaderType
-    use SimModule, only: store_error, store_error_unit, count_errors
+    use SimModule, only: store_error, store_warning, &
+                         store_error_unit, count_errors
     use InputOutputModule, only: urword
     use TimeSeriesLinkModule, only: TimeSeriesLinkType
     use TimeSeriesManagerModule, only: read_value_or_time_series
@@ -914,19 +915,12 @@ contains
         if (noder <= 0) then
           call this%nodeu_to_string(nodeu, nodestr)
           write (errmsg, *) &
-            ' Cell is outside active grid domain: '// &
+            ' Cell is outside active grid domain and will be ignored: '// &
             trim(adjustl(nodestr))
-          call store_error(errmsg)
+          call store_warning(errmsg)
         end if
         nodelist(l) = noder
       end do
-      !
-      ! -- Check for errors and terminate if encountered
-      if (count_errors() > 0) then
-        write (errmsg, *) count_errors(), ' errors encountered.'
-        call store_error(errmsg)
-        call store_error_unit(in)
-      end if
     end if
   end subroutine read_list
 

--- a/src/Model/SurfaceWaterFlow/swf-cdb.f90
+++ b/src/Model/SurfaceWaterFlow/swf-cdb.f90
@@ -264,6 +264,11 @@ contains
     do i = 1, this%nbound
 
       node = this%nodelist(i)
+      if (node <= 0) then
+        this%hcof(i) = DZERO
+        this%rhs(i) = DZERO
+        cycle
+      end if
       if (this%ibound(node) <= 0) then
         this%hcof(i) = DZERO
         this%rhs(i) = DZERO
@@ -347,6 +352,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
+      if (n <= 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))

--- a/src/Model/SurfaceWaterFlow/swf-flw.f90
+++ b/src/Model/SurfaceWaterFlow/swf-flw.f90
@@ -226,6 +226,10 @@ contains
     do i = 1, this%nbound
       node = this%nodelist(i)
       this%hcof(i) = DZERO
+      if (node <= 0) then
+        this%rhs(i) = DZERO
+        cycle
+      end if
       if (this%ibound(node) <= 0) then
         this%rhs(i) = DZERO
         cycle
@@ -261,6 +265,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
+      if (n <= 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))

--- a/src/Model/SurfaceWaterFlow/swf-zdg.f90
+++ b/src/Model/SurfaceWaterFlow/swf-zdg.f90
@@ -282,6 +282,11 @@ contains
     do i = 1, this%nbound
 
       node = this%nodelist(i)
+      if (node <= 0) then
+        this%hcof(i) = DZERO
+        this%rhs(i) = DZERO
+        cycle
+      end if
       if (this%ibound(node) <= 0) then
         this%hcof(i) = DZERO
         this%rhs(i) = DZERO
@@ -368,6 +373,7 @@ contains
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nbound
       n = this%nodelist(i)
+      if (n <= 0) cycle
       rhs(n) = rhs(n) + this%rhs(i)
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))


### PR DESCRIPTION
Allow boundary conditions to be placed in inactive or pass-through cells, issuing a warning rather than an error. Previously this caused a fatal error in most packages; some were already permissive.

Changes to base types:
- `BndExtType` — `cellid_to_nlist` and `nodeu_to_nlist`: `store_error` → `store_warning`
- `DisBaseType` — `read_list`: same treatment
- `BndType` — `bnd_fc`: skip non-positive node numbers

Changes to boundary packages (add guards for non-positive node numbers):
- gwf-wel, gwf-drn, gwf-riv, gwf-chd, gwf-ghb (also corrects == 0 to <= 0)
- gwt-cnc, gwt-src
- gwe-ctp, gwe-esl
- swf-flw, swf-cdb, swf-zdg (shared by SWF, CHF, and OLF models; swf-chd reuses gwf-chd)

No changes needed (already skipped non-positive node numbers):
- gwf-rch, gwf-evt
- swf-pcp, swf-evp
___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request