### PR TITLE
doc(dfn): add missing mf6internal attributes

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/chf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-chd.dfn
@@ -35,6 +35,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'constant-head'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -43,6 +44,7 @@ reader urword
 optional true
 longname print CHD flows to listing file
 description REPLACE print_flows {'{#1}': 'constant-head'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -51,6 +53,7 @@ reader urword
 optional true
 longname save CHD flows to budget file
 description REPLACE save_flows {'{#1}': 'constant-head'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -195,6 +198,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'constant head'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/doc/mf6io/mf6ivar/dfn/chf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-flw.dfn
@@ -35,6 +35,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'inflow'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -43,6 +44,7 @@ reader urword
 optional true
 longname print calculated flows to listing file
 description REPLACE print_flows {'{#1}': 'inflow'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -51,6 +53,7 @@ reader urword
 optional true
 longname save well flows to budget file
 description REPLACE save_flows {'{#1}': 'inflow'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -194,6 +197,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'inflow'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/doc/mf6io/mf6ivar/dfn/olf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-chd.dfn
@@ -35,6 +35,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'constant-head'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -43,6 +44,7 @@ reader urword
 optional true
 longname print CHD flows to listing file
 description REPLACE print_flows {'{#1}': 'constant-head'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -51,6 +53,7 @@ reader urword
 optional true
 longname save CHD flows to budget file
 description REPLACE save_flows {'{#1}': 'constant-head'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -195,6 +198,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'constant head'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/doc/mf6io/mf6ivar/dfn/olf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-flw.dfn
@@ -35,6 +35,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'inflow'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -43,6 +44,7 @@ reader urword
 optional true
 longname print calculated flows to listing file
 description REPLACE print_flows {'{#1}': 'inflow'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -51,6 +53,7 @@ reader urword
 optional true
 longname save well flows to budget file
 description REPLACE save_flows {'{#1}': 'inflow'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -194,6 +197,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'inflow'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/doc/mf6io/mf6ivar/dfn/swf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-chd.dfn
@@ -35,6 +35,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'constant-head'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -43,6 +44,7 @@ reader urword
 optional true
 longname print CHD flows to listing file
 description REPLACE print_flows {'{#1}': 'constant-head'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -51,6 +53,7 @@ reader urword
 optional true
 longname save CHD flows to budget file
 description REPLACE save_flows {'{#1}': 'constant-head'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -195,6 +198,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'constant head'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/doc/mf6io/mf6ivar/dfn/swf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-flw.dfn
@@ -35,6 +35,7 @@ reader urword
 optional true
 longname print input to listing file
 description REPLACE print_input {'{#1}': 'inflow'}
+mf6internal iprpak
 
 block options
 name print_flows
@@ -43,6 +44,7 @@ reader urword
 optional true
 longname print calculated flows to listing file
 description REPLACE print_flows {'{#1}': 'inflow'}
+mf6internal iprflow
 
 block options
 name save_flows
@@ -51,6 +53,7 @@ reader urword
 optional true
 longname save well flows to budget file
 description REPLACE save_flows {'{#1}': 'inflow'}
+mf6internal ipakcb
 
 block options
 name ts_filerecord
@@ -194,6 +197,7 @@ optional true
 time_series true
 longname auxiliary variables
 description REPLACE aux {'{#1}': 'inflow'}
+mf6internal auxvar
 
 block period
 name boundname

--- a/src/Idm/chf-chdidm.f90
+++ b/src/Idm/chf-chdidm.f90
@@ -15,9 +15,9 @@ module ChfChdInputModule
     logical :: auxiliary = .false.
     logical :: auxmultname = .false.
     logical :: boundnames = .false.
-    logical :: print_input = .false.
-    logical :: print_flows = .false.
-    logical :: save_flows = .false.
+    logical :: iprpak = .false.
+    logical :: iprflow = .false.
+    logical :: ipakcb = .false.
     logical :: ts_filerecord = .false.
     logical :: ts6 = .false.
     logical :: filein = .false.
@@ -28,7 +28,7 @@ module ChfChdInputModule
     logical :: maxbound = .false.
     logical :: cellid = .false.
     logical :: head = .false.
-    logical :: aux = .false.
+    logical :: auxvar = .false.
     logical :: boundname = .false.
   end type ChfChdParamFoundType
 
@@ -98,13 +98,13 @@ module ChfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfchd_print_input = InputParamDefinitionType &
+    chfchd_iprpak = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'CHD', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_INPUT', & ! tag name
-    'PRINT_INPUT', & ! fortran variable
+    'IPRPAK', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print input to listing file', & ! longname
@@ -117,13 +117,13 @@ module ChfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfchd_print_flows = InputParamDefinitionType &
+    chfchd_iprflow = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'CHD', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_FLOWS', & ! tag name
-    'PRINT_FLOWS', & ! fortran variable
+    'IPRFLOW', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print CHD flows to listing file', & ! longname
@@ -136,13 +136,13 @@ module ChfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfchd_save_flows = InputParamDefinitionType &
+    chfchd_ipakcb = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'CHD', & ! subcomponent
     'OPTIONS', & ! block
     'SAVE_FLOWS', & ! tag name
-    'SAVE_FLOWS', & ! fortran variable
+    'IPAKCB', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'save CHD flows to budget file', & ! longname
@@ -345,13 +345,13 @@ module ChfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfchd_aux = InputParamDefinitionType &
+    chfchd_auxvar = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'CHD', & ! subcomponent
     'PERIOD', & ! block
     'AUX', & ! tag name
-    'AUX', & ! fortran variable
+    'AUXVAR', & ! fortran variable
     'DOUBLE1D', & ! type
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
@@ -388,9 +388,9 @@ module ChfChdInputModule
     chfchd_auxiliary, &
     chfchd_auxmultname, &
     chfchd_boundnames, &
-    chfchd_print_input, &
-    chfchd_print_flows, &
-    chfchd_save_flows, &
+    chfchd_iprpak, &
+    chfchd_iprflow, &
+    chfchd_ipakcb, &
     chfchd_ts_filerecord, &
     chfchd_ts6, &
     chfchd_filein, &
@@ -401,7 +401,7 @@ module ChfChdInputModule
     chfchd_maxbound, &
     chfchd_cellid, &
     chfchd_head, &
-    chfchd_aux, &
+    chfchd_auxvar, &
     chfchd_boundname &
     ]
 

--- a/src/Idm/chf-flwidm.f90
+++ b/src/Idm/chf-flwidm.f90
@@ -15,9 +15,9 @@ module ChfFlwInputModule
     logical :: auxiliary = .false.
     logical :: auxmultname = .false.
     logical :: boundnames = .false.
-    logical :: print_input = .false.
-    logical :: print_flows = .false.
-    logical :: save_flows = .false.
+    logical :: iprpak = .false.
+    logical :: iprflow = .false.
+    logical :: ipakcb = .false.
     logical :: ts_filerecord = .false.
     logical :: ts6 = .false.
     logical :: filein = .false.
@@ -28,7 +28,7 @@ module ChfFlwInputModule
     logical :: maxbound = .false.
     logical :: cellid = .false.
     logical :: q = .false.
-    logical :: aux = .false.
+    logical :: auxvar = .false.
     logical :: boundname = .false.
   end type ChfFlwParamFoundType
 
@@ -98,13 +98,13 @@ module ChfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfflw_print_input = InputParamDefinitionType &
+    chfflw_iprpak = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'FLW', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_INPUT', & ! tag name
-    'PRINT_INPUT', & ! fortran variable
+    'IPRPAK', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print input to listing file', & ! longname
@@ -117,13 +117,13 @@ module ChfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfflw_print_flows = InputParamDefinitionType &
+    chfflw_iprflow = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'FLW', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_FLOWS', & ! tag name
-    'PRINT_FLOWS', & ! fortran variable
+    'IPRFLOW', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print calculated flows to listing file', & ! longname
@@ -136,13 +136,13 @@ module ChfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfflw_save_flows = InputParamDefinitionType &
+    chfflw_ipakcb = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'FLW', & ! subcomponent
     'OPTIONS', & ! block
     'SAVE_FLOWS', & ! tag name
-    'SAVE_FLOWS', & ! fortran variable
+    'IPAKCB', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'save well flows to budget file', & ! longname
@@ -345,13 +345,13 @@ module ChfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfflw_aux = InputParamDefinitionType &
+    chfflw_auxvar = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'FLW', & ! subcomponent
     'PERIOD', & ! block
     'AUX', & ! tag name
-    'AUX', & ! fortran variable
+    'AUXVAR', & ! fortran variable
     'DOUBLE1D', & ! type
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
@@ -388,9 +388,9 @@ module ChfFlwInputModule
     chfflw_auxiliary, &
     chfflw_auxmultname, &
     chfflw_boundnames, &
-    chfflw_print_input, &
-    chfflw_print_flows, &
-    chfflw_save_flows, &
+    chfflw_iprpak, &
+    chfflw_iprflow, &
+    chfflw_ipakcb, &
     chfflw_ts_filerecord, &
     chfflw_ts6, &
     chfflw_filein, &
@@ -401,7 +401,7 @@ module ChfFlwInputModule
     chfflw_maxbound, &
     chfflw_cellid, &
     chfflw_q, &
-    chfflw_aux, &
+    chfflw_auxvar, &
     chfflw_boundname &
     ]
 

--- a/src/Idm/olf-chdidm.f90
+++ b/src/Idm/olf-chdidm.f90
@@ -15,9 +15,9 @@ module OlfChdInputModule
     logical :: auxiliary = .false.
     logical :: auxmultname = .false.
     logical :: boundnames = .false.
-    logical :: print_input = .false.
-    logical :: print_flows = .false.
-    logical :: save_flows = .false.
+    logical :: iprpak = .false.
+    logical :: iprflow = .false.
+    logical :: ipakcb = .false.
     logical :: ts_filerecord = .false.
     logical :: ts6 = .false.
     logical :: filein = .false.
@@ -28,7 +28,7 @@ module OlfChdInputModule
     logical :: maxbound = .false.
     logical :: cellid = .false.
     logical :: head = .false.
-    logical :: aux = .false.
+    logical :: auxvar = .false.
     logical :: boundname = .false.
   end type OlfChdParamFoundType
 
@@ -98,13 +98,13 @@ module OlfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    olfchd_print_input = InputParamDefinitionType &
+    olfchd_iprpak = InputParamDefinitionType &
     ( &
     'OLF', & ! component
     'CHD', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_INPUT', & ! tag name
-    'PRINT_INPUT', & ! fortran variable
+    'IPRPAK', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print input to listing file', & ! longname
@@ -117,13 +117,13 @@ module OlfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    olfchd_print_flows = InputParamDefinitionType &
+    olfchd_iprflow = InputParamDefinitionType &
     ( &
     'OLF', & ! component
     'CHD', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_FLOWS', & ! tag name
-    'PRINT_FLOWS', & ! fortran variable
+    'IPRFLOW', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print CHD flows to listing file', & ! longname
@@ -136,13 +136,13 @@ module OlfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    olfchd_save_flows = InputParamDefinitionType &
+    olfchd_ipakcb = InputParamDefinitionType &
     ( &
     'OLF', & ! component
     'CHD', & ! subcomponent
     'OPTIONS', & ! block
     'SAVE_FLOWS', & ! tag name
-    'SAVE_FLOWS', & ! fortran variable
+    'IPAKCB', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'save CHD flows to budget file', & ! longname
@@ -345,13 +345,13 @@ module OlfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    olfchd_aux = InputParamDefinitionType &
+    olfchd_auxvar = InputParamDefinitionType &
     ( &
     'OLF', & ! component
     'CHD', & ! subcomponent
     'PERIOD', & ! block
     'AUX', & ! tag name
-    'AUX', & ! fortran variable
+    'AUXVAR', & ! fortran variable
     'DOUBLE1D', & ! type
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
@@ -388,9 +388,9 @@ module OlfChdInputModule
     olfchd_auxiliary, &
     olfchd_auxmultname, &
     olfchd_boundnames, &
-    olfchd_print_input, &
-    olfchd_print_flows, &
-    olfchd_save_flows, &
+    olfchd_iprpak, &
+    olfchd_iprflow, &
+    olfchd_ipakcb, &
     olfchd_ts_filerecord, &
     olfchd_ts6, &
     olfchd_filein, &
@@ -401,7 +401,7 @@ module OlfChdInputModule
     olfchd_maxbound, &
     olfchd_cellid, &
     olfchd_head, &
-    olfchd_aux, &
+    olfchd_auxvar, &
     olfchd_boundname &
     ]
 

--- a/src/Idm/olf-flwidm.f90
+++ b/src/Idm/olf-flwidm.f90
@@ -15,9 +15,9 @@ module OlfFlwInputModule
     logical :: auxiliary = .false.
     logical :: auxmultname = .false.
     logical :: boundnames = .false.
-    logical :: print_input = .false.
-    logical :: print_flows = .false.
-    logical :: save_flows = .false.
+    logical :: iprpak = .false.
+    logical :: iprflow = .false.
+    logical :: ipakcb = .false.
     logical :: ts_filerecord = .false.
     logical :: ts6 = .false.
     logical :: filein = .false.
@@ -28,7 +28,7 @@ module OlfFlwInputModule
     logical :: maxbound = .false.
     logical :: cellid = .false.
     logical :: q = .false.
-    logical :: aux = .false.
+    logical :: auxvar = .false.
     logical :: boundname = .false.
   end type OlfFlwParamFoundType
 
@@ -98,13 +98,13 @@ module OlfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    olfflw_print_input = InputParamDefinitionType &
+    olfflw_iprpak = InputParamDefinitionType &
     ( &
     'OLF', & ! component
     'FLW', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_INPUT', & ! tag name
-    'PRINT_INPUT', & ! fortran variable
+    'IPRPAK', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print input to listing file', & ! longname
@@ -117,13 +117,13 @@ module OlfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    olfflw_print_flows = InputParamDefinitionType &
+    olfflw_iprflow = InputParamDefinitionType &
     ( &
     'OLF', & ! component
     'FLW', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_FLOWS', & ! tag name
-    'PRINT_FLOWS', & ! fortran variable
+    'IPRFLOW', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print calculated flows to listing file', & ! longname
@@ -136,13 +136,13 @@ module OlfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    olfflw_save_flows = InputParamDefinitionType &
+    olfflw_ipakcb = InputParamDefinitionType &
     ( &
     'OLF', & ! component
     'FLW', & ! subcomponent
     'OPTIONS', & ! block
     'SAVE_FLOWS', & ! tag name
-    'SAVE_FLOWS', & ! fortran variable
+    'IPAKCB', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'save well flows to budget file', & ! longname
@@ -345,13 +345,13 @@ module OlfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    olfflw_aux = InputParamDefinitionType &
+    olfflw_auxvar = InputParamDefinitionType &
     ( &
     'OLF', & ! component
     'FLW', & ! subcomponent
     'PERIOD', & ! block
     'AUX', & ! tag name
-    'AUX', & ! fortran variable
+    'AUXVAR', & ! fortran variable
     'DOUBLE1D', & ! type
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
@@ -388,9 +388,9 @@ module OlfFlwInputModule
     olfflw_auxiliary, &
     olfflw_auxmultname, &
     olfflw_boundnames, &
-    olfflw_print_input, &
-    olfflw_print_flows, &
-    olfflw_save_flows, &
+    olfflw_iprpak, &
+    olfflw_iprflow, &
+    olfflw_ipakcb, &
     olfflw_ts_filerecord, &
     olfflw_ts6, &
     olfflw_filein, &
@@ -401,7 +401,7 @@ module OlfFlwInputModule
     olfflw_maxbound, &
     olfflw_cellid, &
     olfflw_q, &
-    olfflw_aux, &
+    olfflw_auxvar, &
     olfflw_boundname &
     ]
 

--- a/src/Idm/swf-chdidm.f90
+++ b/src/Idm/swf-chdidm.f90
@@ -15,9 +15,9 @@ module SwfChdInputModule
     logical :: auxiliary = .false.
     logical :: auxmultname = .false.
     logical :: boundnames = .false.
-    logical :: print_input = .false.
-    logical :: print_flows = .false.
-    logical :: save_flows = .false.
+    logical :: iprpak = .false.
+    logical :: iprflow = .false.
+    logical :: ipakcb = .false.
     logical :: ts_filerecord = .false.
     logical :: ts6 = .false.
     logical :: filein = .false.
@@ -28,7 +28,7 @@ module SwfChdInputModule
     logical :: maxbound = .false.
     logical :: cellid = .false.
     logical :: head = .false.
-    logical :: aux = .false.
+    logical :: auxvar = .false.
     logical :: boundname = .false.
   end type SwfChdParamFoundType
 
@@ -98,13 +98,13 @@ module SwfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    swfchd_print_input = InputParamDefinitionType &
+    swfchd_iprpak = InputParamDefinitionType &
     ( &
     'SWF', & ! component
     'CHD', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_INPUT', & ! tag name
-    'PRINT_INPUT', & ! fortran variable
+    'IPRPAK', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print input to listing file', & ! longname
@@ -117,13 +117,13 @@ module SwfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    swfchd_print_flows = InputParamDefinitionType &
+    swfchd_iprflow = InputParamDefinitionType &
     ( &
     'SWF', & ! component
     'CHD', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_FLOWS', & ! tag name
-    'PRINT_FLOWS', & ! fortran variable
+    'IPRFLOW', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print CHD flows to listing file', & ! longname
@@ -136,13 +136,13 @@ module SwfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    swfchd_save_flows = InputParamDefinitionType &
+    swfchd_ipakcb = InputParamDefinitionType &
     ( &
     'SWF', & ! component
     'CHD', & ! subcomponent
     'OPTIONS', & ! block
     'SAVE_FLOWS', & ! tag name
-    'SAVE_FLOWS', & ! fortran variable
+    'IPAKCB', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'save CHD flows to budget file', & ! longname
@@ -345,13 +345,13 @@ module SwfChdInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    swfchd_aux = InputParamDefinitionType &
+    swfchd_auxvar = InputParamDefinitionType &
     ( &
     'SWF', & ! component
     'CHD', & ! subcomponent
     'PERIOD', & ! block
     'AUX', & ! tag name
-    'AUX', & ! fortran variable
+    'AUXVAR', & ! fortran variable
     'DOUBLE1D', & ! type
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
@@ -388,9 +388,9 @@ module SwfChdInputModule
     swfchd_auxiliary, &
     swfchd_auxmultname, &
     swfchd_boundnames, &
-    swfchd_print_input, &
-    swfchd_print_flows, &
-    swfchd_save_flows, &
+    swfchd_iprpak, &
+    swfchd_iprflow, &
+    swfchd_ipakcb, &
     swfchd_ts_filerecord, &
     swfchd_ts6, &
     swfchd_filein, &
@@ -401,7 +401,7 @@ module SwfChdInputModule
     swfchd_maxbound, &
     swfchd_cellid, &
     swfchd_head, &
-    swfchd_aux, &
+    swfchd_auxvar, &
     swfchd_boundname &
     ]
 

--- a/src/Idm/swf-flwidm.f90
+++ b/src/Idm/swf-flwidm.f90
@@ -15,9 +15,9 @@ module SwfFlwInputModule
     logical :: auxiliary = .false.
     logical :: auxmultname = .false.
     logical :: boundnames = .false.
-    logical :: print_input = .false.
-    logical :: print_flows = .false.
-    logical :: save_flows = .false.
+    logical :: iprpak = .false.
+    logical :: iprflow = .false.
+    logical :: ipakcb = .false.
     logical :: ts_filerecord = .false.
     logical :: ts6 = .false.
     logical :: filein = .false.
@@ -28,7 +28,7 @@ module SwfFlwInputModule
     logical :: maxbound = .false.
     logical :: cellid = .false.
     logical :: q = .false.
-    logical :: aux = .false.
+    logical :: auxvar = .false.
     logical :: boundname = .false.
   end type SwfFlwParamFoundType
 
@@ -98,13 +98,13 @@ module SwfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    swfflw_print_input = InputParamDefinitionType &
+    swfflw_iprpak = InputParamDefinitionType &
     ( &
     'SWF', & ! component
     'FLW', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_INPUT', & ! tag name
-    'PRINT_INPUT', & ! fortran variable
+    'IPRPAK', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print input to listing file', & ! longname
@@ -117,13 +117,13 @@ module SwfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    swfflw_print_flows = InputParamDefinitionType &
+    swfflw_iprflow = InputParamDefinitionType &
     ( &
     'SWF', & ! component
     'FLW', & ! subcomponent
     'OPTIONS', & ! block
     'PRINT_FLOWS', & ! tag name
-    'PRINT_FLOWS', & ! fortran variable
+    'IPRFLOW', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'print calculated flows to listing file', & ! longname
@@ -136,13 +136,13 @@ module SwfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    swfflw_save_flows = InputParamDefinitionType &
+    swfflw_ipakcb = InputParamDefinitionType &
     ( &
     'SWF', & ! component
     'FLW', & ! subcomponent
     'OPTIONS', & ! block
     'SAVE_FLOWS', & ! tag name
-    'SAVE_FLOWS', & ! fortran variable
+    'IPAKCB', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
     'save well flows to budget file', & ! longname
@@ -345,13 +345,13 @@ module SwfFlwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    swfflw_aux = InputParamDefinitionType &
+    swfflw_auxvar = InputParamDefinitionType &
     ( &
     'SWF', & ! component
     'FLW', & ! subcomponent
     'PERIOD', & ! block
     'AUX', & ! tag name
-    'AUX', & ! fortran variable
+    'AUXVAR', & ! fortran variable
     'DOUBLE1D', & ! type
     'NAUX', & ! shape
     'auxiliary variables', & ! longname
@@ -388,9 +388,9 @@ module SwfFlwInputModule
     swfflw_auxiliary, &
     swfflw_auxmultname, &
     swfflw_boundnames, &
-    swfflw_print_input, &
-    swfflw_print_flows, &
-    swfflw_save_flows, &
+    swfflw_iprpak, &
+    swfflw_iprflow, &
+    swfflw_ipakcb, &
     swfflw_ts_filerecord, &
     swfflw_ts6, &
     swfflw_filein, &
@@ -401,7 +401,7 @@ module SwfFlwInputModule
     swfflw_maxbound, &
     swfflw_cellid, &
     swfflw_q, &
-    swfflw_aux, &
+    swfflw_auxvar, &
     swfflw_boundname &
     ]
 


### PR DESCRIPTION
Add `mf6internal` attributes to other model packages consistent with usage for GWF packages. This attribute may no longer be necessary if we add a memory catalog to the DFN files, which can point in the opposite direction (i.e. a memory variable can identify an input variable it corresponds to), but for now this makes things consistent