### PR TITLE
chore(meson): force max optimization=1 on macOS/gfortran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,8 +424,6 @@ jobs:
           setupargs=""
           if [[ "${{ matrix.debug }}" == "true" ]]; then
             setupargs="-Ddebug=true -Doptimization=0"
-          elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
-            setupargs="-Doptimization=1"
           fi
           echo "MESON_SETUP_ARGS=$setupargs" >> $GITHUB_ENV
 
@@ -509,7 +507,7 @@ jobs:
         run: |
           filters=""
           if [[ "${{ matrix.os }}" == "macos-14" ]]; then
-            # comparison fails on macos-14 with optimization=1
+            # sfr rewet comparison fails on macos-14
             filters="not test028_sfr_rewet"
           fi
           echo "filters=$filters" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,23 +62,19 @@ jobs:
           - os: ${{ inputs.linux_version }}
             compiler: ${{ inputs.compiler_toolchain }}
             version: ${{ inputs.compiler_version }}
-            optimization: 2
             extended: false
           - os: macos-14
             compiler: gcc
             version: 13
-            optimization: 1
             extended: false
             xcode-version: '15.1.0'
           - os: windows-2022
             compiler: ${{ inputs.compiler_toolchain }}
             version: ${{ inputs.compiler_version }}
-            optimization: 2
             extended: false
           - os: windows-2022
             compiler: intel-classic
             version: "2021.6"
-            optimization: 2
             extended: true
     defaults:
       run:
@@ -200,7 +196,7 @@ jobs:
             # run only parallel/extended tests in developmode, run all tests in releasemode
             filters="test_par or test_netcdf"
           fi
-          # comparison fails on macos with optimization=1
+          # sfr rewet comparison fails on macos
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             if [[ "$filters" != "" ]]; then
               filters="$filters and not test028_sfr_rewet"
@@ -238,14 +234,14 @@ jobs:
         if: (!(runner.os == 'Windows' && matrix.extended))
         working-directory: modflow6
         run: |
-          pixi run setup builddir -Doptimization=${{ matrix.optimization }}
+          pixi run setup builddir
           pixi run build builddir
 
       - name: Build mf5to6 converter
         if: (!(runner.os == 'Windows' && matrix.extended))
         working-directory: modflow6
         run: |
-          pixi run setup-mf5to6 builddir -Doptimization=${{ matrix.optimization }}
+          pixi run setup-mf5to6 builddir
           pixi run build-mf5to6 builddir
 
       - name: Show build log

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,13 @@ if fc_id == 'gcc'
     compile_args += '-D__linux__'
   elif system == 'darwin'
     compile_args += '-D__APPLE__'
+    # gfortran on macOS has a bug at optimization > 1 that produces incorrect
+    # PRT results; cap to -O1 unless the user already chose a lower level.
+    opt = get_option('optimization')
+    if opt == '2' or opt == '3' or opt == 's'
+      warning('macOS gfortran: capping optimization to -O1 to avoid a compiler bug affecting PRT results')
+      compile_args += '-O1'
+    endif
   elif system == 'windows'
     compile_args += '-D_WIN32'
   endif


### PR DESCRIPTION
PRT may crash or produce incorrect results, and results may change for other models, on macOS/gfortran with aggressive optimizations. Up to now we have explicitly passed `-Doptimization=1` to avoid this. Encode this in `meson.build` so it applies for local as well as CI/release builds.