### PR TITLE
doc(dfns): add missing package type attributes

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/chf-cdb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-cdb.dfn
@@ -1,5 +1,6 @@
 # --------------------- chf cdb options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/chf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-chd.dfn
@@ -1,5 +1,6 @@
 # --------------------- chf chd options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/chf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-evp.dfn
@@ -1,5 +1,6 @@
 # --------------------- swf evp options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/chf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-flw.dfn
@@ -1,5 +1,6 @@
 # --------------------- chf flw options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/chf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-pcp.dfn
@@ -1,5 +1,6 @@
 # --------------------- swf pcp options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/chf-zdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-zdg.dfn
@@ -1,5 +1,6 @@
 # --------------------- chf zdg options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/gwe-ctp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-ctp.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwe ctp options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/gwe-esl.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-esl.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwe esl options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/gwe-lke.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-lke.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwe lke options ---------------------
 # flopy multi-package
+# package-type advanced-stress-package
 
 block options
 name flow_package_name

--- a/doc/mf6io/mf6ivar/dfn/gwe-mwe.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-mwe.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwe mwe options ---------------------
 # flopy multi-package
+# package-type advanced-stress-package
 
 block options
 name flow_package_name

--- a/doc/mf6io/mf6ivar/dfn/gwe-sfe.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-sfe.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwe sfe options ---------------------
 # flopy multi-package
+# package-type advanced-stress-package
 
 block options
 name flow_package_name

--- a/doc/mf6io/mf6ivar/dfn/gwe-uze.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-uze.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwe uze options ---------------------
 # flopy multi-package
+# package-type advanced-stress-package
 
 block options
 name flow_package_name

--- a/doc/mf6io/mf6ivar/dfn/gwt-cnc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-cnc.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwt cnc options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/gwt-lkt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-lkt.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwt lkt options ---------------------
 # flopy multi-package
+# package-type advanced-stress-package
 
 block options
 name flow_package_name

--- a/doc/mf6io/mf6ivar/dfn/gwt-mwt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-mwt.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwt mwt options ---------------------
 # flopy multi-package
+# package-type advanced-stress-package
 
 block options
 name flow_package_name

--- a/doc/mf6io/mf6ivar/dfn/gwt-sft.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-sft.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwt sft options ---------------------
 # flopy multi-package
+# package-type advanced-stress-package
 
 block options
 name flow_package_name

--- a/doc/mf6io/mf6ivar/dfn/gwt-src.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-src.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwt src options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/gwt-uzt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-uzt.dfn
@@ -1,5 +1,6 @@
 # --------------------- gwt uzt options ---------------------
 # flopy multi-package
+# package-type advanced-stress-package
 
 block options
 name flow_package_name

--- a/doc/mf6io/mf6ivar/dfn/olf-cdb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-cdb.dfn
@@ -1,5 +1,6 @@
 # --------------------- olf cdb options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/olf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-chd.dfn
@@ -1,5 +1,6 @@
 # --------------------- olf chd options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/olf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-evp.dfn
@@ -1,5 +1,6 @@
 # --------------------- swf evp options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/olf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-flw.dfn
@@ -1,5 +1,6 @@
 # --------------------- olf flw options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/olf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-pcp.dfn
@@ -1,5 +1,6 @@
 # --------------------- swf pcp options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/olf-zdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-zdg.dfn
@@ -1,5 +1,6 @@
 # --------------------- olf zdg options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -1,5 +1,6 @@
 # --------------------- prt prp options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name boundnames

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -1,6 +1,5 @@
 # --------------------- prt prp options ---------------------
 # flopy multi-package
-# package-type stress-package
 
 block options
 name boundnames

--- a/doc/mf6io/mf6ivar/dfn/swf-cdb.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-cdb.dfn
@@ -1,5 +1,6 @@
 # --------------------- swf cdb options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/swf-chd.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-chd.dfn
@@ -1,5 +1,6 @@
 # --------------------- swf chd options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/swf-evp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-evp.dfn
@@ -1,5 +1,6 @@
 # --------------------- swf evp options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/swf-flw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-flw.dfn
@@ -1,5 +1,6 @@
 # --------------------- swf flw options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/swf-pcp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-pcp.dfn
@@ -1,5 +1,6 @@
 # --------------------- swf pcp options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary

--- a/doc/mf6io/mf6ivar/dfn/swf-zdg.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-zdg.dfn
@@ -1,5 +1,6 @@
 # --------------------- swf zdg options ---------------------
 # flopy multi-package
+# package-type stress-package
 
 block options
 name auxiliary


### PR DESCRIPTION
Some DFNs were missing comment lines marking them as stress packages or advanced stress packages