### PR TITLE
fix(ci): show contiguity via local pointer variable

### DIFF
--- a/src/Utilities/Export/NCExportCreate.f90
+++ b/src/Utilities/Export/NCExportCreate.f90
@@ -154,6 +154,7 @@ contains
     class(AsciiDynamicPkgLoadBaseType), pointer :: rp_loader
     type(ExportPackageType), pointer :: export_pkg
     integer(I4B), pointer :: export_arrays
+    integer(I4B), dimension(:), pointer, contiguous :: mshape
     class(*), pointer :: obj
     logical(LGP) :: found, readasarrays
     integer(I4B) :: n
@@ -186,18 +187,20 @@ contains
           select type (rp_loader)
           type is (LayerArrayLoadType)
             ! create the export object
+            mshape => rp_loader%ctx%mshape
             allocate (export_pkg)
             call export_pkg%init(rp_loader%mf6_input, &
-                                 rp_loader%ctx%mshape, &
+                                 mshape, &
                                  rp_loader%ctx%naux, &
                                  rp_loader%param_names, rp_loader%nparam)
             obj => export_pkg
             call pkglist%add(obj)
           type is (GridArrayLoadType)
             ! create the export object
+            mshape => rp_loader%ctx%mshape
             allocate (export_pkg)
             call export_pkg%init(rp_loader%mf6_input, &
-                                 rp_loader%ctx%mshape, &
+                                 mshape, &
                                  rp_loader%ctx%naux, &
                                  rp_loader%param_names, rp_loader%nparam)
             obj => export_pkg


### PR DESCRIPTION
Fix extended mac build:  assign `rp_loader%ctx%mshape` to a local variable. Newer gfortran with -std=f2018 -pedantic can't prove contiguity through a derived-type component chain at the call site, but accepts a local pointer assignment.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
