### PR TITLE
refactor(ims): extract nonlinear outer-loop kernels into ImsNonlinearBase

### DIFF
--- a/autotest/TestImsNonlinearBase.f90
+++ b/autotest/TestImsNonlinearBase.f90
@@ -1,0 +1,421 @@
+module TestImsNonlinearBase
+  use KindModule, only: I4B, DP
+  use ConstantsModule, only: DZERO, DONE, DEM20
+  use testdrive, only: check, error_type, new_unittest, test_failed, &
+                       to_string, unittest_type
+  use ImsNonlinearBaseModule, only: ims_nl_underrelax, ims_nl_maxval, &
+                                    ims_nl_calcdx, ims_nl_dxmax, &
+                                    ims_nl_backtrack_flag, &
+                                    ims_nl_apply_backtrack, &
+                                    ims_nl_has_converged, &
+                                    ims_nl_nur_has_converged
+  implicit none
+  private
+  public :: collect_imsnonlinearbase
+
+  real(DP), parameter :: tol = 1.0e-9_DP
+
+contains
+
+  subroutine collect_imsnonlinearbase(testsuite)
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    testsuite = [ &
+                new_unittest("underrelax_simple", test_underrelax_simple), &
+                new_unittest("underrelax_simple_inactive", &
+                             test_underrelax_simple_inactive), &
+                new_unittest("underrelax_cooley_kiter1", &
+                             test_underrelax_cooley_kiter1), &
+                new_unittest("underrelax_cooley_relax", &
+                             test_underrelax_cooley_relax), &
+                new_unittest("underrelax_dbd_kiter1", &
+                             test_underrelax_dbd_kiter1), &
+                new_unittest("underrelax_dbd_flipflop", &
+                             test_underrelax_dbd_flipflop), &
+                new_unittest("maxval_normalized", test_maxval_normalized), &
+                new_unittest("maxval_zero_denom", test_maxval_zero_denom), &
+                new_unittest("calcdx", test_calcdx), &
+                new_unittest("dxmax", test_dxmax), &
+                new_unittest("dxmax_signed", test_dxmax_signed), &
+                new_unittest("backtrack_flag_on", test_backtrack_flag_on), &
+                new_unittest("backtrack_flag_off", test_backtrack_flag_off), &
+                new_unittest("apply_backtrack", test_apply_backtrack), &
+                new_unittest("has_converged", test_has_converged), &
+                new_unittest("nur_has_converged", test_nur_has_converged) &
+                ]
+  end subroutine collect_imsnonlinearbase
+
+  !> @brief SIMPLE dampening (nonmeth == 1): x = xtemp + gamma * (x - xtemp)
+  !<
+  subroutine test_underrelax_simple(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), parameter :: neq = 2
+    integer(I4B) :: active(neq)
+    real(DP) :: x(neq), xtemp(neq), dxold(neq), wsave(neq), hchold(neq)
+    real(DP) :: deold(neq)
+    real(DP) :: bigch_store, bigchold, relaxold
+    real(DP) :: gamma, theta, akappa, amomentum
+
+    gamma = 0.5_DP; theta = 0.7_DP; akappa = 0.1_DP; amomentum = 0.0_DP
+    bigch_store = DZERO; bigchold = DZERO; relaxold = DZERO
+    active = [1, 1]
+    xtemp = [1.0_DP, 2.0_DP]
+    x = [2.0_DP, 4.0_DP]
+    dxold = DZERO; wsave = DZERO; hchold = DZERO; deold = DZERO
+
+    call ims_nl_underrelax(1, 1, DONE, neq, active, x, xtemp, &
+                           gamma, theta, akappa, amomentum, &
+                           bigch_store, bigchold, relaxold, &
+                           dxold, wsave, hchold, deold)
+
+    ! node 1: delx = 1.0, x = 1.0 + 0.5*1.0 = 1.5
+    call check(error, abs(x(1) - 1.5_DP) < tol, "x(1) expected 1.5")
+    if (allocated(error)) return
+    ! node 2: delx = 2.0, x = 2.0 + 0.5*2.0 = 3.0
+    call check(error, abs(x(2) - 3.0_DP) < tol, "x(2) expected 3.0")
+    if (allocated(error)) return
+    call check(error, abs(dxold(1) - 1.0_DP) < tol, "dxold(1) expected 1.0")
+    if (allocated(error)) return
+    call check(error, abs(dxold(2) - 2.0_DP) < tol, "dxold(2) expected 2.0")
+  end subroutine test_underrelax_simple
+
+  !> @brief SIMPLE dampening leaves inactive nodes untouched
+  !<
+  subroutine test_underrelax_simple_inactive(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), parameter :: neq = 2
+    integer(I4B) :: active(neq)
+    real(DP) :: x(neq), xtemp(neq), dxold(neq), wsave(neq), hchold(neq)
+    real(DP) :: deold(neq)
+    real(DP) :: bigch_store, bigchold, relaxold
+    real(DP) :: gamma, theta, akappa, amomentum
+
+    gamma = 0.5_DP; theta = 0.7_DP; akappa = 0.1_DP; amomentum = 0.0_DP
+    bigch_store = DZERO; bigchold = DZERO; relaxold = DZERO
+    active = [1, 0]
+    xtemp = [1.0_DP, 2.0_DP]
+    x = [2.0_DP, 6.0_DP]
+    dxold = [-999.0_DP, -999.0_DP]
+    wsave = DZERO; hchold = DZERO; deold = DZERO
+
+    call ims_nl_underrelax(1, 1, DONE, neq, active, x, xtemp, &
+                           gamma, theta, akappa, amomentum, &
+                           bigch_store, bigchold, relaxold, &
+                           dxold, wsave, hchold, deold)
+
+    ! active node updated
+    call check(error, abs(x(1) - 1.5_DP) < tol, "x(1) expected 1.5")
+    if (allocated(error)) return
+    ! inactive node unchanged (x and dxold both left alone)
+    call check(error, abs(x(2) - 6.0_DP) < tol, "x(2) inactive unchanged")
+    if (allocated(error)) return
+    call check(error, abs(dxold(2) - (-999.0_DP)) < tol, &
+               "dxold(2) inactive unchanged")
+  end subroutine test_underrelax_simple_inactive
+
+  !> @brief COOLEY (nonmeth == 2) first iteration: relax = 1, no x update,
+  !! state seeded from bigch
+  !<
+  subroutine test_underrelax_cooley_kiter1(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), parameter :: neq = 1
+    integer(I4B) :: active(neq)
+    real(DP) :: x(neq), xtemp(neq), dxold(neq), wsave(neq), hchold(neq)
+    real(DP) :: deold(neq)
+    real(DP) :: bigch_store, bigchold, relaxold
+    real(DP) :: gamma, theta, akappa, amomentum
+
+    gamma = 0.5_DP; theta = 0.7_DP; akappa = 0.1_DP; amomentum = 0.0_DP
+    bigch_store = DZERO; bigchold = DZERO; relaxold = DZERO
+    active = [1]
+    xtemp = [0.0_DP]
+    x = [10.0_DP]
+    dxold = DZERO; wsave = DZERO; hchold = DZERO; deold = DZERO
+
+    call ims_nl_underrelax(2, 1, 5.0_DP, neq, active, x, xtemp, &
+                           gamma, theta, akappa, amomentum, &
+                           bigch_store, bigchold, relaxold, &
+                           dxold, wsave, hchold, deold)
+
+    ! kiter==1: relax = 1.0 so x is not updated
+    call check(error, abs(x(1) - 10.0_DP) < tol, "x(1) unchanged (relax=1)")
+    if (allocated(error)) return
+    call check(error, abs(relaxold - 1.0_DP) < tol, "relaxold expected 1.0")
+    if (allocated(error)) return
+    call check(error, abs(bigch_store - 5.0_DP) < tol, "bigch_store expected 5.0")
+    if (allocated(error)) return
+    ! bigchold = (1-gamma)*bigch + gamma*bigch = bigch = 5.0
+    call check(error, abs(bigchold - 5.0_DP) < tol, "bigchold expected 5.0")
+  end subroutine test_underrelax_cooley_kiter1
+
+  !> @brief COOLEY subsequent iteration computes relaxation and updates x.
+  !! State: bigchold=5, relaxold=1; bigch=-3, gamma=0.5.
+  !! es = -3/5 = -0.6 (>= -1) => relax = (3-0.6)/(3+0.6) = 2/3
+  !<
+  subroutine test_underrelax_cooley_relax(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), parameter :: neq = 1
+    integer(I4B) :: active(neq)
+    real(DP) :: x(neq), xtemp(neq), dxold(neq), wsave(neq), hchold(neq)
+    real(DP) :: deold(neq)
+    real(DP) :: bigch_store, bigchold, relaxold
+    real(DP) :: gamma, theta, akappa, amomentum
+    real(DP) :: relax_expect
+
+    gamma = 0.5_DP; theta = 0.7_DP; akappa = 0.1_DP; amomentum = 0.0_DP
+    bigch_store = DZERO; bigchold = 5.0_DP; relaxold = 1.0_DP
+    active = [1]
+    xtemp = [0.0_DP]
+    x = [9.0_DP]
+    dxold = DZERO; wsave = DZERO; hchold = DZERO; deold = DZERO
+
+    call ims_nl_underrelax(2, 2, -3.0_DP, neq, active, x, xtemp, &
+                           gamma, theta, akappa, amomentum, &
+                           bigch_store, bigchold, relaxold, &
+                           dxold, wsave, hchold, deold)
+
+    relax_expect = 2.0_DP / 3.0_DP
+    call check(error, abs(relaxold - relax_expect) < tol, "relaxold = 2/3")
+    if (allocated(error)) return
+    ! x = xtemp + relax*delx = 0 + (2/3)*9 = 6.0
+    call check(error, abs(x(1) - 6.0_DP) < tol, "x(1) expected 6.0")
+    if (allocated(error)) return
+    call check(error, abs(dxold(1) - 9.0_DP) < tol, "dxold(1) expected 9.0")
+    if (allocated(error)) return
+    ! bigchold = (1-0.5)*(-3) + 0.5*5 = -1.5 + 2.5 = 1.0
+    call check(error, abs(bigchold - 1.0_DP) < tol, "bigchold expected 1.0")
+  end subroutine test_underrelax_cooley_relax
+
+  !> @brief DBD (nonmeth == 3) first iteration seeds wsave/hchold/deold.
+  !! akappa=0.1 => ww=min(1, 1+0.1)=1; x unchanged; state recorded.
+  !<
+  subroutine test_underrelax_dbd_kiter1(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), parameter :: neq = 1
+    integer(I4B) :: active(neq)
+    real(DP) :: x(neq), xtemp(neq), dxold(neq), wsave(neq), hchold(neq)
+    real(DP) :: deold(neq)
+    real(DP) :: bigch_store, bigchold, relaxold
+    real(DP) :: gamma, theta, akappa, amomentum
+
+    gamma = 0.5_DP; theta = 0.7_DP; akappa = 0.1_DP; amomentum = 0.0_DP
+    bigch_store = DZERO; bigchold = DZERO; relaxold = DZERO
+    active = [1]
+    xtemp = [1.0_DP]
+    x = [3.0_DP]
+    dxold = DZERO; wsave = DZERO; hchold = DZERO; deold = DZERO
+
+    call ims_nl_underrelax(3, 1, DONE, neq, active, x, xtemp, &
+                           gamma, theta, akappa, amomentum, &
+                           bigch_store, bigchold, relaxold, &
+                           dxold, wsave, hchold, deold)
+
+    ! delx = 2.0; ww capped at 1.0; x = xtemp + 2.0*1.0 = 3.0 (unchanged)
+    call check(error, abs(x(1) - 3.0_DP) < tol, "x(1) expected 3.0")
+    if (allocated(error)) return
+    call check(error, abs(wsave(1) - 1.0_DP) < tol, "wsave(1) expected 1.0")
+    if (allocated(error)) return
+    ! kiter==1: hchold = delx = 2.0
+    call check(error, abs(hchold(1) - 2.0_DP) < tol, "hchold(1) expected 2.0")
+    if (allocated(error)) return
+    call check(error, abs(deold(1) - 2.0_DP) < tol, "deold(1) expected 2.0")
+    if (allocated(error)) return
+    call check(error, abs(dxold(1) - 2.0_DP) < tol, "dxold(1) expected 2.0")
+  end subroutine test_underrelax_dbd_kiter1
+
+  !> @brief DBD flip-flop: opposite-sign change decreases the relaxation
+  !! factor via theta. State from a prior iteration: wsave=1, hchold=2, deold=2.
+  !<
+  subroutine test_underrelax_dbd_flipflop(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), parameter :: neq = 1
+    integer(I4B) :: active(neq)
+    real(DP) :: x(neq), xtemp(neq), dxold(neq), wsave(neq), hchold(neq)
+    real(DP) :: deold(neq)
+    real(DP) :: bigch_store, bigchold, relaxold
+    real(DP) :: gamma, theta, akappa, amomentum
+
+    gamma = 0.5_DP; theta = 0.7_DP; akappa = 0.1_DP; amomentum = 0.0_DP
+    bigch_store = DZERO; bigchold = DZERO; relaxold = DZERO
+    active = [1]
+    xtemp = [3.0_DP]
+    x = [1.0_DP]
+    dxold = DZERO
+    wsave = [1.0_DP]
+    hchold = [2.0_DP]
+    deold = [2.0_DP]
+
+    call ims_nl_underrelax(3, 2, -2.0_DP, neq, active, x, xtemp, &
+                           gamma, theta, akappa, amomentum, &
+                           bigch_store, bigchold, relaxold, &
+                           dxold, wsave, hchold, deold)
+
+    ! delx = -2.0; deold*delx = -4 < 0 (flip-flop) => ww = theta*1 = 0.7
+    call check(error, abs(wsave(1) - 0.7_DP) < tol, "wsave(1) expected 0.7")
+    if (allocated(error)) return
+    ! kiter>1: hchold = (1-0.5)*(-2) + 0.5*2 = 0.0
+    call check(error, abs(hchold(1) - 0.0_DP) < tol, "hchold(1) expected 0.0")
+    if (allocated(error)) return
+    ! amom = 0 (kiter<=4); delx = -2.0*0.7 + 0 = -1.4; x = 3.0 - 1.4 = 1.6
+    call check(error, abs(x(1) - 1.6_DP) < tol, "x(1) expected 1.6")
+    if (allocated(error)) return
+    call check(error, abs(deold(1) - (-2.0_DP)) < tol, "deold(1) expected -2.0")
+  end subroutine test_underrelax_dbd_flipflop
+
+  !> @brief maxval uses a normalized comparison to pick the largest magnitude
+  !<
+  subroutine test_maxval_normalized(error)
+    type(error_type), allocatable, intent(out) :: error
+    real(DP) :: vmax
+
+    ! vmax starts at 1.0; -3.0 has larger magnitude => vmax = -3.0;
+    ! 2.0 has smaller magnitude than 3.0 => vmax unchanged (signed result kept)
+    vmax = DZERO
+    call ims_nl_maxval(3, [1.0_DP, -3.0_DP, 2.0_DP], vmax)
+    call check(error, abs(vmax - (-3.0_DP)) < tol, "vmax expected -3.0")
+  end subroutine test_maxval_normalized
+
+  !> @brief maxval handles a zero running value without dividing by zero
+  !<
+  subroutine test_maxval_zero_denom(error)
+    type(error_type), allocatable, intent(out) :: error
+    real(DP) :: vmax
+
+    ! first value 0 => denom falls back to DPREC, so any nonzero later value wins
+    vmax = DZERO
+    call ims_nl_maxval(2, [0.0_DP, 0.5_DP], vmax)
+    call check(error, abs(vmax - 0.5_DP) < tol, "vmax expected 0.5")
+  end subroutine test_maxval_zero_denom
+
+  !> @brief calcdx returns x - xtemp for active cells, zero for inactive
+  !<
+  subroutine test_calcdx(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), parameter :: neq = 3
+    real(DP) :: dx(neq)
+
+    dx = -999.0_DP
+    call ims_nl_calcdx(neq, [1, 0, 1], [5.0_DP, 5.0_DP, 5.0_DP], &
+                       [1.0_DP, 1.0_DP, 1.0_DP], dx)
+    call check(error, abs(dx(1) - 4.0_DP) < tol, "dx(1) expected 4.0")
+    if (allocated(error)) return
+    call check(error, abs(dx(2) - 0.0_DP) < tol, "dx(2) inactive => 0.0")
+    if (allocated(error)) return
+    call check(error, abs(dx(3) - 4.0_DP) < tol, "dx(3) expected 4.0")
+  end subroutine test_calcdx
+
+  !> @brief dxmax returns the largest-magnitude change and its location,
+  !! excluding inactive cells
+  !<
+  subroutine test_dxmax(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), parameter :: neq = 3
+    real(DP) :: dxmax
+    integer(I4B) :: loc
+
+    dxmax = DZERO
+    loc = 0
+    ! node 3 has the biggest change but is inactive => excluded
+    call ims_nl_dxmax(neq, [1, 1, 0], [2.0_DP, 5.0_DP, 100.0_DP], &
+                      [1.0_DP, 1.0_DP, 1.0_DP], dxmax, loc)
+    call check(error, abs(dxmax - 4.0_DP) < tol, "dxmax expected 4.0")
+    if (allocated(error)) return
+    call check(error, loc == 2, "loc expected 2")
+  end subroutine test_dxmax
+
+  !> @brief dxmax preserves the sign of the maximum change
+  !<
+  subroutine test_dxmax_signed(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), parameter :: neq = 2
+    real(DP) :: dxmax
+    integer(I4B) :: loc
+
+    dxmax = DZERO
+    loc = 0
+    call ims_nl_dxmax(neq, [1, 1], [1.0_DP, 1.0_DP], &
+                      [5.0_DP, 1.0_DP], dxmax, loc)
+    call check(error, abs(dxmax - (-4.0_DP)) < tol, "dxmax expected -4.0")
+    if (allocated(error)) return
+    call check(error, loc == 1, "loc expected 1")
+  end subroutine test_dxmax_signed
+
+  !> @brief backtracking flag set when reduced max change exceeds closure;
+  !! inactive cells excluded from the max
+  !<
+  subroutine test_backtrack_flag_on(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B) :: bt_flag
+
+    ! active max change = 9 (node 3 inactive, ignored); 0.5*9 = 4.5 >= 1.0
+    bt_flag = ims_nl_backtrack_flag(3, [1, 1, 0], &
+                                    [2.0_DP, 10.0_DP, 1000.0_DP], &
+                                    [1.0_DP, 1.0_DP, 1.0_DP], 0.5_DP, 1.0_DP)
+    call check(error, bt_flag == 1, "bt_flag expected 1")
+  end subroutine test_backtrack_flag_on
+
+  !> @brief backtracking flag stays off when reduced max change is below closure
+  !<
+  subroutine test_backtrack_flag_off(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B) :: bt_flag
+
+    ! 0.05*9 = 0.45 < 1.0
+    bt_flag = ims_nl_backtrack_flag(3, [1, 1, 0], &
+                                    [2.0_DP, 10.0_DP, 1000.0_DP], &
+                                    [1.0_DP, 1.0_DP, 1.0_DP], 0.05_DP, 1.0_DP)
+    call check(error, bt_flag == 0, "bt_flag expected 0")
+  end subroutine test_backtrack_flag_off
+
+  !> @brief apply_backtrack scales the change by breduc for active cells only
+  !<
+  subroutine test_apply_backtrack(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), parameter :: neq = 2
+    real(DP) :: x(neq)
+
+    x = [10.0_DP, 10.0_DP]
+    call ims_nl_apply_backtrack(neq, [1, 0], x, [0.0_DP, 0.0_DP], 0.25_DP)
+    ! active: x = 0 + 0.25*10 = 2.5
+    call check(error, abs(x(1) - 2.5_DP) < tol, "x(1) expected 2.5")
+    if (allocated(error)) return
+    ! inactive: unchanged
+    call check(error, abs(x(2) - 10.0_DP) < tol, "x(2) inactive unchanged")
+  end subroutine test_apply_backtrack
+
+  !> @brief convergence when |max_dvc| <= dvclose (sign-independent)
+  !<
+  subroutine test_has_converged(error)
+    type(error_type), allocatable, intent(out) :: error
+
+    call check(error, ims_nl_has_converged(0.0005_DP, 0.001_DP), &
+               "0.0005 within 0.001 => converged")
+    if (allocated(error)) return
+    call check(error, ims_nl_has_converged(-0.0005_DP, 0.001_DP), &
+               "-0.0005 within 0.001 => converged")
+    if (allocated(error)) return
+    call check(error, ims_nl_has_converged(0.001_DP, 0.001_DP), &
+               "boundary equal => converged")
+    if (allocated(error)) return
+    call check(error,.not. ims_nl_has_converged(0.01_DP, 0.001_DP), &
+               "0.01 exceeds 0.001 => not converged")
+  end subroutine test_has_converged
+
+  !> @brief NUR convergence requires BOTH changes within closure
+  !<
+  subroutine test_nur_has_converged(error)
+    type(error_type), allocatable, intent(out) :: error
+
+    call check(error, &
+               ims_nl_nur_has_converged(0.0005_DP, 0.0005_DP, 0.001_DP), &
+               "both within => converged")
+    if (allocated(error)) return
+    call check(error, &
+               .not. ims_nl_nur_has_converged(0.0005_DP, 0.01_DP, 0.001_DP), &
+               "hncg exceeds => not converged")
+    if (allocated(error)) return
+    call check(error, &
+               .not. ims_nl_nur_has_converged(0.01_DP, 0.0005_DP, 0.001_DP), &
+               "dxold_max exceeds => not converged")
+  end subroutine test_nur_has_converged
+
+end module TestImsNonlinearBase

--- a/autotest/TestImsNonlinearBase.f90
+++ b/autotest/TestImsNonlinearBase.f90
@@ -8,7 +8,11 @@ module TestImsNonlinearBase
                                     ims_nl_backtrack_flag, &
                                     ims_nl_apply_backtrack, &
                                     ims_nl_has_converged, &
-                                    ims_nl_nur_has_converged
+                                    ims_nl_nur_has_converged, &
+                                    ims_nl_residual, ims_nl_l2norm
+  use VectorBaseModule, only: VectorBaseType
+  use SparseMatrixModule, only: SparseMatrixType
+  use SparseModule, only: sparsematrix
   implicit none
   private
   public :: collect_imsnonlinearbase
@@ -40,9 +44,55 @@ contains
                 new_unittest("backtrack_flag_off", test_backtrack_flag_off), &
                 new_unittest("apply_backtrack", test_apply_backtrack), &
                 new_unittest("has_converged", test_has_converged), &
-                new_unittest("nur_has_converged", test_nur_has_converged) &
+                new_unittest("nur_has_converged", test_nur_has_converged), &
+                new_unittest("residual", test_residual), &
+                new_unittest("l2norm", test_l2norm) &
                 ]
   end subroutine collect_imsnonlinearbase
+
+  !> @brief Build a 3x3 diagonal system A = diag(2,3,5), x = b = [1,1,1].
+  !! Helper (not a registered test).
+  !<
+  subroutine build_diag_system(matrix, vec_x, vec_rhs, mem_path)
+    type(SparseMatrixType), intent(inout) :: matrix
+    class(VectorBaseType), pointer :: vec_x
+    class(VectorBaseType), pointer :: vec_rhs
+    character(len=*), intent(in) :: mem_path
+    type(sparsematrix) :: sparse
+    integer(I4B) :: i
+
+    call sparse%init(3, 3, 1)
+    do i = 1, 3
+      call sparse%addconnection(i, i, 1)
+    end do
+    call matrix%init(sparse, mem_path)
+    call sparse%destroy()
+
+    call matrix%set_diag_value(1, 2.0_DP)
+    call matrix%set_diag_value(2, 3.0_DP)
+    call matrix%set_diag_value(3, 5.0_DP)
+
+    vec_x => matrix%create_vec(3)
+    vec_rhs => matrix%create_vec(3)
+    do i = 1, 3
+      call vec_x%set_value_local(i, 1.0_DP)
+      call vec_rhs%set_value_local(i, 1.0_DP)
+    end do
+  end subroutine build_diag_system
+
+  !> @brief Release a system built by build_diag_system. Helper.
+  !<
+  subroutine free_diag_system(matrix, vec_x, vec_rhs)
+    type(SparseMatrixType), intent(inout) :: matrix
+    class(VectorBaseType), pointer :: vec_x
+    class(VectorBaseType), pointer :: vec_rhs
+
+    call vec_x%destroy()
+    deallocate (vec_x)
+    call vec_rhs%destroy()
+    deallocate (vec_rhs)
+    call matrix%destroy()
+  end subroutine free_diag_system
 
   !> @brief SIMPLE dampening (nonmeth == 1): x = xtemp + gamma * (x - xtemp)
   !<
@@ -417,5 +467,64 @@ contains
                .not. ims_nl_nur_has_converged(0.01_DP, 0.0005_DP, 0.001_DP), &
                "dxold_max exceeds => not converged")
   end subroutine test_nur_has_converged
+
+  !> @brief residual r = A*x - b, zeroed for inactive cells.
+  !! A = diag(2,3,5), x = b = [1,1,1] => r = [1,2,4]
+  !<
+  subroutine test_residual(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(SparseMatrixType) :: matrix
+    class(VectorBaseType), pointer :: vec_x, vec_rhs, vec_resid
+    real(DP) :: r_all(3), r_inact(3)
+    integer(I4B) :: i
+
+    call build_diag_system(matrix, vec_x, vec_rhs, 'TEST/RESID')
+    vec_resid => matrix%create_vec(3)
+
+    ! all active: r = diag(2,3,5)*[1,1,1] - [1,1,1] = [1,2,4]
+    call ims_nl_residual(matrix, vec_x, vec_rhs, 3, [1, 1, 1], vec_resid)
+    do i = 1, 3
+      r_all(i) = vec_resid%get_value_local(i)
+    end do
+
+    ! middle cell inactive: r(2) forced to 0, others unchanged
+    call ims_nl_residual(matrix, vec_x, vec_rhs, 3, [1, 0, 1], vec_resid)
+    do i = 1, 3
+      r_inact(i) = vec_resid%get_value_local(i)
+    end do
+
+    ! free resources before asserting so a failure cannot leak
+    call vec_resid%destroy()
+    deallocate (vec_resid)
+    call free_diag_system(matrix, vec_x, vec_rhs)
+
+    call check(error, abs(r_all(1) - 1.0_DP) < tol, "r(1) expected 1")
+    if (allocated(error)) return
+    call check(error, abs(r_all(2) - 2.0_DP) < tol, "r(2) expected 2")
+    if (allocated(error)) return
+    call check(error, abs(r_all(3) - 4.0_DP) < tol, "r(3) expected 4")
+    if (allocated(error)) return
+    call check(error, abs(r_inact(2) - 0.0_DP) < tol, "r(2) inactive => 0")
+    if (allocated(error)) return
+    call check(error, abs(r_inact(1) - 1.0_DP) < tol, "r(1) unchanged")
+    if (allocated(error)) return
+    call check(error, abs(r_inact(3) - 4.0_DP) < tol, "r(3) unchanged")
+  end subroutine test_residual
+
+  !> @brief l2norm = || A*x - b ||_2. For r = [1,2,4], ||r|| = sqrt(21)
+  !<
+  subroutine test_l2norm(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(SparseMatrixType) :: matrix
+    class(VectorBaseType), pointer :: vec_x, vec_rhs
+    real(DP) :: l2
+
+    call build_diag_system(matrix, vec_x, vec_rhs, 'TEST/L2NORM')
+    l2 = -1.0_DP
+    call ims_nl_l2norm(matrix, vec_x, vec_rhs, 3, [1, 1, 1], l2)
+    call free_diag_system(matrix, vec_x, vec_rhs)
+
+    call check(error, abs(l2 - sqrt(21.0_DP)) < tol, "l2norm expected sqrt(21)")
+  end subroutine test_l2norm
 
 end module TestImsNonlinearBase

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -5,6 +5,7 @@ if test_drive.found() and not fc_id.contains('intel')
     'FeatureFlags',
     'GeomUtil',
     'HashTable',
+    'ImsNonlinearBase',
     'InputOutput',
     'KeyValueList',
     'List',

--- a/autotest/tester.f90
+++ b/autotest/tester.f90
@@ -6,6 +6,7 @@ program tester
   use TestFeatureFlags, only: collect_feature_flags
   use TestGeomUtil, only: collect_geomutil
   use TestHashTable, only: collect_hashtable
+  use TestImsNonlinearBase, only: collect_imsnonlinearbase
   use TestInputOutput, only: collect_inputoutput
   use TestKeyValueList, only: collect_keyvaluelist
   use TestList, only: collect_list
@@ -35,6 +36,7 @@ program tester
                new_testsuite("FeatureFlags", collect_feature_flags), &
                new_testsuite("GeomUtil", collect_geomutil), &
                new_testsuite("HashTable", collect_hashtable), &
+               new_testsuite("ImsNonlinearBase", collect_imsnonlinearbase), &
                new_testsuite("InputOutput", collect_inputoutput), &
                new_testsuite("KeyValueList", collect_keyvaluelist), &
                new_testsuite("List", collect_list), &

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -489,6 +489,7 @@
 					<File RelativePath="..\src\Solution\LinearMethods\ImsLinearMisc.f90"/>
 					<File RelativePath="..\src\Solution\LinearMethods\ImsLinearSettings.f90"/>
 					<File RelativePath="..\src\Solution\LinearMethods\ImsLinearSolver.f90"/>
+					<File RelativePath="..\src\Solution\LinearMethods\ImsNonlinearBase.f90"/>
 					<File RelativePath="..\src\Solution\LinearMethods\ImsReordering.f90"/>
 				</Filter>
 				<Filter Name="ParticleTracker">

--- a/src/Solution/LinearMethods/ImsNonlinearBase.f90
+++ b/src/Solution/LinearMethods/ImsNonlinearBase.f90
@@ -12,6 +12,8 @@ module ImsNonlinearBaseModule
   ! -- modules
   use KindModule, only: DP, I4B, LGP
   use ConstantsModule, only: DZERO, DHALF, DONE, DTHREE, DEM20, DPREC
+  use MatrixBaseModule, only: MatrixBaseType
+  use VectorBaseModule, only: VectorBaseType
 
   implicit none
   private
@@ -24,6 +26,8 @@ module ImsNonlinearBaseModule
   public :: ims_nl_apply_backtrack
   public :: ims_nl_has_converged
   public :: ims_nl_nur_has_converged
+  public :: ims_nl_residual
+  public :: ims_nl_l2norm
 
 contains
 
@@ -382,5 +386,64 @@ contains
     end if
 
   end function ims_nl_nur_has_converged
+
+  !> @ brief Calculate the residual vector r = A*x - b
+  !!
+  !!  Compute the residual and zero it for inactive cells. This is the local
+  !!  body of NumericalSolutionType%sln_calc_residual. The caller supplies the
+  !!  system matrix, the x and rhs vectors, and a residual vector to fill.
+  !<
+  subroutine ims_nl_residual(matrix, vec_x, vec_rhs, neq, active, vec_resid)
+    ! -- dummy variables
+    class(MatrixBaseType) :: matrix !< the system matrix A
+    class(VectorBaseType), pointer :: vec_x !< the dependent-variable vector x
+    class(VectorBaseType), pointer :: vec_rhs !< the right-hand side vector b
+    integer(I4B), intent(in) :: neq !< number of equations
+    integer(I4B), dimension(neq), intent(in) :: active !< active cell flag (1)
+    class(VectorBaseType), pointer :: vec_resid !< the residual vector to fill
+    ! -- local
+    integer(I4B) :: n
+
+    call matrix%multiply(vec_x, vec_resid) ! r = A*x
+
+    call vec_resid%axpy(-1.0_DP, vec_rhs) ! r = r - b
+
+    do n = 1, neq
+      if (active(n) < 1) then
+        call vec_resid%set_value_local(n, 0.0_DP) ! r_i = 0 if inactive
+      end if
+    end do
+
+  end subroutine ims_nl_residual
+
+  !> @ brief Calculate the L-2 norm of the residual for all active cells
+  !!
+  !!  L2norm = || A*x - b ||_2 with inactive cells zeroed. This is the local
+  !!  body of NumericalSolutionType%sln_l2norm; a temporary residual vector is
+  !!  created from the matrix and released here.
+  !<
+  subroutine ims_nl_l2norm(matrix, vec_x, vec_rhs, neq, active, l2norm)
+    ! -- dummy variables
+    class(MatrixBaseType) :: matrix !< the system matrix A
+    class(VectorBaseType), pointer :: vec_x !< the dependent-variable vector x
+    class(VectorBaseType), pointer :: vec_rhs !< the right-hand side vector b
+    integer(I4B), intent(in) :: neq !< number of equations
+    integer(I4B), dimension(neq), intent(in) :: active !< active cell flag (1)
+    real(DP), intent(inout) :: l2norm !< calculated L-2 norm
+    ! -- local
+    class(VectorBaseType), pointer :: vec_resid
+
+    ! calc. residual vector
+    vec_resid => matrix%create_vec(neq)
+    call ims_nl_residual(matrix, vec_x, vec_rhs, neq, active, vec_resid)
+
+    ! 2-norm
+    l2norm = vec_resid%norm2()
+
+    ! clean up temp. vector
+    call vec_resid%destroy()
+    deallocate (vec_resid)
+
+  end subroutine ims_nl_l2norm
 
 end module ImsNonlinearBaseModule

--- a/src/Solution/LinearMethods/ImsNonlinearBase.f90
+++ b/src/Solution/LinearMethods/ImsNonlinearBase.f90
@@ -1,0 +1,386 @@
+
+!> @brief This module contains the IMS nonlinear (outer) accelerator subroutines
+!!
+!! This module contains the stateless IMS nonlinear (outer-iteration)
+!! subroutines used by a MODFLOW 6 solution. The routines are free
+!! subroutines that take explicit arguments (mirroring IMSLinearBaseModule)
+!! so that they can be reused outside of NumericalSolutionType and unit
+!! tested directly. All computations are local; in parallel the caller is
+!! responsible for supplying already-reduced quantities (e.g. bigch).
+!<
+module ImsNonlinearBaseModule
+  ! -- modules
+  use KindModule, only: DP, I4B, LGP
+  use ConstantsModule, only: DZERO, DHALF, DONE, DTHREE, DEM20, DPREC
+
+  implicit none
+  private
+
+  public :: ims_nl_underrelax
+  public :: ims_nl_maxval
+  public :: ims_nl_calcdx
+  public :: ims_nl_dxmax
+  public :: ims_nl_backtrack_flag
+  public :: ims_nl_apply_backtrack
+  public :: ims_nl_has_converged
+  public :: ims_nl_nur_has_converged
+
+contains
+
+  !> @ brief Under-relaxation
+  !!
+  !!  Under relax using the simple, cooley, or delta-bar-delta methods.
+  !!  This is the local (stateless) body of NumericalSolutionType%sln_underrelax;
+  !!  the persistent under-relaxation state is passed in/out explicitly.
+  !<
+  subroutine ims_nl_underrelax(nonmeth, kiter, bigch, neq, active, x, xtemp, &
+                               gamma, theta, akappa, amomentum, &
+                               bigch_store, bigchold, relaxold, &
+                               dxold, wsave, hchold, deold)
+    ! -- dummy variables
+    integer(I4B), intent(in) :: nonmeth !< under-relaxation method used
+    integer(I4B), intent(in) :: kiter !< Picard iteration number
+    real(DP), intent(in) :: bigch !< maximum dependent-variable change
+    integer(I4B), intent(in) :: neq !< number of equations
+    integer(I4B), dimension(neq), intent(in) :: active !< active cell flag (1)
+    real(DP), dimension(neq), intent(inout) :: x !< current dependent-variable
+    real(DP), dimension(neq), intent(in) :: xtemp !< previous dependent-variable
+    real(DP), intent(in) :: gamma !< under-relaxation gamma
+    real(DP), intent(in) :: theta !< under-relaxation theta
+    real(DP), intent(in) :: akappa !< under-relaxation kappa
+    real(DP), intent(in) :: amomentum !< under-relaxation momentum term
+    real(DP), intent(inout) :: bigch_store !< stored maximum dependent-variable change
+    real(DP), intent(inout) :: bigchold !< cooley under-relaxation weight
+    real(DP), intent(inout) :: relaxold !< previous relaxation factor
+    real(DP), dimension(neq), intent(inout) :: dxold !< previous dependent-variable change
+    real(DP), dimension(neq), intent(inout) :: wsave !< DBD sign-change factor
+    real(DP), dimension(neq), intent(inout) :: hchold !< DBD weighted dependent-variable change
+    real(DP), dimension(neq), intent(inout) :: deold !< DBD dependent-variable change variable
+    ! -- local variables
+    integer(I4B) :: n
+    real(DP) :: ww
+    real(DP) :: delx
+    real(DP) :: relax
+    real(DP) :: es
+    real(DP) :: aes
+    real(DP) :: amom
+    !
+    ! -- option for using simple dampening (as done by MODFLOW-2005 PCG)
+    if (nonmeth == 1) then
+      do n = 1, neq
+        !
+        ! -- skip inactive nodes
+        if (active(n) < 1) cycle
+        !
+        ! -- compute step-size (delta x)
+        delx = x(n) - xtemp(n)
+        dxold(n) = delx
+
+        ! -- dampen dependent variable solution
+        x(n) = xtemp(n) + gamma * delx
+      end do
+      !
+      ! -- option for using cooley underrelaxation
+    else if (nonmeth == 2) then
+      !
+      ! -- set bigch
+      bigch_store = bigch
+      !
+      ! -- initialize values for first iteration
+      if (kiter == 1) then
+        relax = DONE
+        relaxold = DONE
+        bigchold = bigch
+      else
+        !
+        ! -- compute relaxation factor
+        es = bigch_store / (bigchold * relaxold)
+        aes = abs(es)
+        if (es < -DONE) then
+          relax = dhalf / aes
+        else
+          relax = (DTHREE + es) / (DTHREE + aes)
+        end if
+      end if
+      relaxold = relax
+      !
+      ! -- modify cooley to use weighted average of past changes
+      bigchold = (DONE - gamma) * bigch_store + gamma * &
+                 bigchold
+      !
+      ! -- compute new dependent variable after under-relaxation
+      if (relax < DONE) then
+        do n = 1, neq
+          !
+          ! -- skip inactive nodes
+          if (active(n) < 1) cycle
+          !
+          ! -- update dependent variable
+          delx = x(n) - xtemp(n)
+          dxold(n) = delx
+          x(n) = xtemp(n) + relax * delx
+        end do
+      end if
+      !
+      ! -- option for using delta-bar-delta scheme to under-relax for all equations
+    else if (nonmeth == 3) then
+      do n = 1, neq
+        !
+        ! -- skip inactive nodes
+        if (active(n) < 1) cycle
+        !
+        ! -- compute step-size (delta x) and initialize d-b-d parameters
+        delx = x(n) - xtemp(n)
+        !
+        ! -- initialize values for first iteration
+        if (kiter == 1) then
+          wsave(n) = DONE
+          hchold(n) = DEM20
+          deold(n) = DZERO
+        end if
+        !
+        ! -- compute new relaxation term as per delta-bar-delta
+        ww = wsave(n)
+        !
+        ! for flip-flop condition, decrease factor
+        if (deold(n) * delx < DZERO) then
+          ww = theta * wsave(n)
+          ! -- when change is of same sign, increase factor
+        else
+          ww = wsave(n) + akappa
+        end if
+        if (ww > DONE) ww = DONE
+        wsave(n) = ww
+        !
+        ! -- compute weighted average of past changes in hchold
+        if (kiter == 1) then
+          hchold(n) = delx
+        else
+          hchold(n) = (DONE - gamma) * delx + &
+                      gamma * hchold(n)
+        end if
+        !
+        ! -- store slope (change) term for next iteration
+        deold(n) = delx
+        dxold(n) = delx
+        !
+        ! -- compute accepted step-size and new dependent variable
+        amom = DZERO
+        if (kiter > 4) amom = amomentum
+        delx = delx * ww + amom * hchold(n)
+        x(n) = xtemp(n) + delx
+      end do
+      !
+    end if
+  end subroutine ims_nl_underrelax
+
+  !> @ brief Determine maximum value
+  !!
+  !!  Determine the maximum value in a vector using a normalized comparison.
+  !!  This is the local body of NumericalSolutionType%sln_maxval.
+  !<
+  subroutine ims_nl_maxval(nsize, v, vmax)
+    ! -- dummy variables
+    integer(I4B), intent(in) :: nsize !< length of vector
+    real(DP), dimension(nsize), intent(in) :: v !< input vector
+    real(DP), intent(inout) :: vmax !< maximum value
+    ! -- local variables
+    integer(I4B) :: n
+    real(DP) :: d
+    real(DP) :: denom
+    real(DP) :: dnorm
+    !
+    ! -- determine maximum value
+    vmax = v(1)
+    do n = 2, nsize
+      d = v(n)
+      denom = abs(vmax)
+      if (denom == DZERO) then
+        denom = DPREC
+      end if
+      !
+      ! -- calculate normalized value
+      dnorm = abs(d) / denom
+      if (dnorm > DONE) then
+        vmax = d
+      end if
+    end do
+  end subroutine ims_nl_maxval
+
+  !> @ brief Calculate dependent-variable change
+  !!
+  !!  Calculate the dependent-variable change for every cell. This is the
+  !!  local body of NumericalSolutionType%sln_calcdx.
+  !<
+  subroutine ims_nl_calcdx(neq, active, x, xtemp, dx)
+    ! -- dummy variables
+    integer(I4B), intent(in) :: neq !< number of equations
+    integer(I4B), dimension(neq), intent(in) :: active !< active cell flag (1)
+    real(DP), dimension(neq), intent(in) :: x !< current dependent-variable
+    real(DP), dimension(neq), intent(in) :: xtemp !< previous dependent-variable
+    real(DP), dimension(neq), intent(inout) :: dx !< dependent-variable change
+    ! -- local
+    integer(I4B) :: n
+    !
+    ! -- calculate dependent-variable change
+    do n = 1, neq
+      ! -- skip inactive nodes
+      if (active(n) < 1) then
+        dx(n) = DZERO
+      else
+        dx(n) = x(n) - xtemp(n)
+      end if
+    end do
+  end subroutine ims_nl_calcdx
+
+  !> @ brief Determine maximum dependent-variable change
+  !!
+  !!  Determine the maximum dependent-variable change and its location.
+  !!  This is the local body of NumericalSolutionType%sln_get_dxmax.
+  !<
+  subroutine ims_nl_dxmax(neq, active, x, xtemp, dxmax, loc)
+    ! -- dummy variables
+    integer(I4B), intent(in) :: neq !< number of equations
+    integer(I4B), dimension(neq), intent(in) :: active !< active cell flag (1)
+    real(DP), dimension(neq), intent(in) :: x !< current dependent-variable
+    real(DP), dimension(neq), intent(in) :: xtemp !< previous dependent-variable
+    real(DP), intent(inout) :: dxmax !< maximum dependent-variable change
+    integer(I4B), intent(inout) :: loc !< location of the maximum change
+    ! -- local variables
+    integer(I4B) :: nb
+    real(DP) :: bigch
+    real(DP) :: abigch
+    integer(I4B) :: n
+    real(DP) :: hdif
+    real(DP) :: ahdif
+    !
+    ! -- determine the maximum change
+    nb = 0
+    bigch = DZERO
+    abigch = DZERO
+    do n = 1, neq
+      if (active(n) < 1) cycle
+      hdif = x(n) - xtemp(n)
+      ahdif = abs(hdif)
+      if (ahdif > abigch) then
+        bigch = hdif
+        abigch = ahdif
+        nb = n
+      end if
+    end do
+    !
+    !-----store maximum change value and location
+    dxmax = bigch
+    loc = nb
+  end subroutine ims_nl_dxmax
+
+  !> @ brief Determine the backtracking flag
+  !!
+  !!  Return 1 when the maximum dependent-variable change scaled by the
+  !!  reduction factor still exceeds the closure criterion. This is the
+  !!  local body of NumericalSolutionType%get_backtracking_flag.
+  !<
+  function ims_nl_backtrack_flag(neq, active, x, xtemp, breduc, dvclose) &
+    result(bt_flag)
+    ! -- dummy variables
+    integer(I4B), intent(in) :: neq !< number of equations
+    integer(I4B), dimension(neq), intent(in) :: active !< active cell flag (1)
+    real(DP), dimension(neq), intent(in) :: x !< current dependent-variable
+    real(DP), dimension(neq), intent(in) :: xtemp !< previous dependent-variable
+    real(DP), intent(in) :: breduc !< backtracking reduction factor
+    real(DP), intent(in) :: dvclose !< dependent-variable closure criterion
+    ! -- return
+    integer(I4B) :: bt_flag !< (1) backtracking performed (0) not performed
+    ! -- local
+    integer(I4B) :: n
+    real(DP) :: dx
+    real(DP) :: dx_abs
+    real(DP) :: dx_abs_max
+
+    ! default is off
+    bt_flag = 0
+
+    ! find max. change
+    dx_abs_max = 0.0
+    do n = 1, neq
+      if (active(n) < 1) cycle
+      dx = x(n) - xtemp(n)
+      dx_abs = abs(dx)
+      if (dx_abs > dx_abs_max) dx_abs_max = dx_abs
+    end do
+
+    ! if backtracking, set flag
+    if (breduc * dx_abs_max >= dvclose) then
+      bt_flag = 1
+    end if
+
+  end function ims_nl_backtrack_flag
+
+  !> @ brief Update x with backtracking
+  !!
+  !!  Scale the dependent-variable change by the reduction factor. This is
+  !!  the local body of NumericalSolutionType%apply_backtracking.
+  !<
+  subroutine ims_nl_apply_backtrack(neq, active, x, xtemp, breduc)
+    ! -- dummy variables
+    integer(I4B), intent(in) :: neq !< number of equations
+    integer(I4B), dimension(neq), intent(in) :: active !< active cell flag (1)
+    real(DP), dimension(neq), intent(inout) :: x !< current dependent-variable
+    real(DP), dimension(neq), intent(in) :: xtemp !< previous dependent-variable
+    real(DP), intent(in) :: breduc !< backtracking reduction factor
+    ! -- local
+    integer(I4B) :: n
+    real(DP) :: delx
+
+    do n = 1, neq
+      if (active(n) < 1) cycle
+      delx = breduc * (x(n) - xtemp(n))
+      x(n) = xtemp(n) + delx
+    end do
+
+  end subroutine ims_nl_apply_backtrack
+
+  !> @ brief Convergence check
+  !!
+  !!  True when the maximum dependent-variable change is within the closure
+  !!  criterion. This is the local body of
+  !!  NumericalSolutionType%sln_has_converged.
+  !<
+  function ims_nl_has_converged(max_dvc, dvclose) result(has_converged)
+    ! -- dummy variables
+    real(DP), intent(in) :: max_dvc !< the maximum dependent variable change
+    real(DP), intent(in) :: dvclose !< dependent-variable closure criterion
+    ! -- return
+    logical(LGP) :: has_converged !< True, when converged
+
+    has_converged = .false.
+    if (abs(max_dvc) <= dvclose) then
+      has_converged = .true.
+    end if
+
+  end function ims_nl_has_converged
+
+  !> @ brief Convergence check after Newton under-relaxation
+  !!
+  !!  True when both the unrelaxed maximum change and the largest change at
+  !!  the end of the Picard iteration are within the closure criterion. This
+  !!  is the local body of NumericalSolutionType%sln_nur_has_converged.
+  !<
+  function ims_nl_nur_has_converged(dxold_max, hncg, dvclose) &
+    result(has_converged)
+    ! -- dummy variables
+    real(DP), intent(in) :: dxold_max !< maximum change for unrelaxed cells
+    real(DP), intent(in) :: hncg !< largest change at end of Picard iteration
+    real(DP), intent(in) :: dvclose !< dependent-variable closure criterion
+    ! -- return
+    logical(LGP) :: has_converged !< True, when converged
+
+    has_converged = .false.
+    if (abs(dxold_max) <= dvclose .and. &
+        abs(hncg) <= dvclose) then
+      has_converged = .true.
+    end if
+
+  end function ims_nl_nur_has_converged
+
+end module ImsNonlinearBaseModule

--- a/src/Solution/NumericalSolution.f90
+++ b/src/Solution/NumericalSolution.f90
@@ -45,7 +45,8 @@ module NumericalSolutionModule
                                     ims_nl_backtrack_flag, &
                                     ims_nl_apply_backtrack, &
                                     ims_nl_has_converged, &
-                                    ims_nl_nur_has_converged
+                                    ims_nl_nur_has_converged, &
+                                    ims_nl_residual, ims_nl_l2norm
   use LinearSolverFactory, only: create_linear_solver
   use MatrixBaseModule
   use ConvergenceSummaryModule
@@ -2901,19 +2902,10 @@ contains
   subroutine sln_l2norm(this, l2norm)
     class(NumericalSolutionType) :: this !< NumericalSolutionType instance
     real(DP) :: l2norm !< calculated L-2 norm
-    ! local
-    class(VectorBaseType), pointer :: vec_resid
 
-    ! calc. residual vector
-    vec_resid => this%system_matrix%create_vec(this%neq)
-    call this%sln_calc_residual(vec_resid)
-
-    ! 2-norm
-    l2norm = vec_resid%norm2()
-
-    ! clean up temp. vector
-    call vec_resid%destroy()
-    deallocate (vec_resid)
+    ! -- delegate to the stateless kernel
+    call ims_nl_l2norm(this%system_matrix, this%vec_x, this%vec_rhs, &
+                       this%neq, this%active, l2norm)
   end subroutine sln_l2norm
 
   !> @ brief Get the maximum value from a vector
@@ -2985,18 +2977,10 @@ contains
   subroutine sln_calc_residual(this, vec_resid)
     class(NumericalSolutionType) :: this !< NumericalSolutionType instance
     class(VectorBaseType), pointer :: vec_resid !< the residual vector
-    ! local
-    integer(I4B) :: n
 
-    call this%system_matrix%multiply(this%vec_x, vec_resid) ! r = A*x
-
-    call vec_resid%axpy(-1.0_DP, this%vec_rhs) ! r = r - b
-
-    do n = 1, this%neq
-      if (this%active(n) < 1) then
-        call vec_resid%set_value_local(n, 0.0_DP) ! r_i = 0 if inactive
-      end if
-    end do
+    ! -- delegate to the stateless kernel
+    call ims_nl_residual(this%system_matrix, this%vec_x, this%vec_rhs, &
+                         this%neq, this%active, vec_resid)
 
   end subroutine sln_calc_residual
 

--- a/src/Solution/NumericalSolution.f90
+++ b/src/Solution/NumericalSolution.f90
@@ -40,6 +40,12 @@ module NumericalSolutionModule
   use LinearSolverBaseModule
   use ImsLinearSettingsModule
   use IMSLinearMisc, only: ims_misc_dvscale
+  use ImsNonlinearBaseModule, only: ims_nl_underrelax, ims_nl_maxval, &
+                                    ims_nl_calcdx, ims_nl_dxmax, &
+                                    ims_nl_backtrack_flag, &
+                                    ims_nl_apply_backtrack, &
+                                    ims_nl_has_converged, &
+                                    ims_nl_nur_has_converged
   use LinearSolverFactory, only: create_linear_solver
   use MatrixBaseModule
   use ConvergenceSummaryModule
@@ -2840,28 +2846,10 @@ contains
   function get_backtracking_flag(this) result(bt_flag)
     class(NumericalSolutionType) :: this !< NumericalSolutionType instance
     integer(I4B) :: bt_flag !< backtracking flag (1) backtracking performed (0) backtracking not performed
-    ! local
-    integer(I4B) :: n
-    real(DP) :: dx
-    real(DP) :: dx_abs
-    real(DP) :: dx_abs_max
 
-    ! default is off
-    bt_flag = 0
-
-    ! find max. change
-    dx_abs_max = 0.0
-    do n = 1, this%neq
-      if (this%active(n) < 1) cycle
-      dx = this%x(n) - this%xtemp(n)
-      dx_abs = abs(dx)
-      if (dx_abs > dx_abs_max) dx_abs_max = dx_abs
-    end do
-
-    ! if backtracking, set flag
-    if (this%breduc * dx_abs_max >= this%dvclose) then
-      bt_flag = 1
-    end if
+    ! -- delegate to the stateless kernel
+    bt_flag = ims_nl_backtrack_flag(this%neq, this%active, this%x, &
+                                    this%xtemp, this%breduc, this%dvclose)
 
   end function get_backtracking_flag
 
@@ -2892,15 +2880,10 @@ contains
   !<
   subroutine apply_backtracking(this)
     class(NumericalSolutionType) :: this !< NumericalSolutionType instance
-    ! local
-    integer(I4B) :: n
-    real(DP) :: delx
 
-    do n = 1, this%neq
-      if (this%active(n) < 1) cycle
-      delx = this%breduc * (this%x(n) - this%xtemp(n))
-      this%x(n) = this%xtemp(n) + delx
-    end do
+    ! -- delegate to the stateless kernel
+    call ims_nl_apply_backtrack(this%neq, this%active, this%x, this%xtemp, &
+                                this%breduc)
 
   end subroutine
 
@@ -2944,27 +2927,9 @@ contains
     integer(I4B), intent(in) :: nsize !< length of vector
     real(DP), dimension(nsize), intent(in) :: v !< input vector
     real(DP), intent(inout) :: vmax !< maximum value
-    ! -- local variables
-    integer(I4B) :: n
-    real(DP) :: d
-    real(DP) :: denom
-    real(DP) :: dnorm
     !
-    ! -- determine maximum value
-    vmax = v(1)
-    do n = 2, nsize
-      d = v(n)
-      denom = abs(vmax)
-      if (denom == DZERO) then
-        denom = DPREC
-      end if
-      !
-      ! -- calculate normalized value
-      dnorm = abs(d) / denom
-      if (dnorm > DONE) then
-        vmax = d
-      end if
-    end do
+    ! -- delegate to the stateless kernel
+    call ims_nl_maxval(nsize, v, vmax)
   end subroutine sln_maxval
 
   !> @ brief Calculate dependent-variable change
@@ -2980,18 +2945,9 @@ contains
     real(DP), dimension(neq), intent(in) :: x !< current dependent-variable
     real(DP), dimension(neq), intent(in) :: xtemp !< previous dependent-variable
     real(DP), dimension(neq), intent(inout) :: dx !< dependent-variable change
-    ! -- local
-    integer(I4B) :: n
     !
-    ! -- calculate dependent-variable change
-    do n = 1, neq
-      ! -- skip inactive nodes
-      if (active(n) < 1) then
-        dx(n) = DZERO
-      else
-        dx(n) = x(n) - xtemp(n)
-      end if
-    end do
+    ! -- delegate to the stateless kernel
+    call ims_nl_calcdx(neq, active, x, xtemp, dx)
   end subroutine sln_calcdx
 
   !> @brief Calculate pseudo-transient continuation factor
@@ -3058,122 +3014,12 @@ contains
     integer(I4B), dimension(neq), intent(in) :: active !< active cell flag (1)
     real(DP), dimension(neq), intent(inout) :: x !< current dependent-variable
     real(DP), dimension(neq), intent(in) :: xtemp !< previous dependent-variable
-    ! -- local variables
-    integer(I4B) :: n
-    real(DP) :: ww
-    real(DP) :: delx
-    real(DP) :: relax
-    real(DP) :: es
-    real(DP) :: aes
-    real(DP) :: amom
     !
-    ! -- option for using simple dampening (as done by MODFLOW-2005 PCG)
-    if (this%nonmeth == 1) then
-      do n = 1, neq
-        !
-        ! -- skip inactive nodes
-        if (active(n) < 1) cycle
-        !
-        ! -- compute step-size (delta x)
-        delx = x(n) - xtemp(n)
-        this%dxold(n) = delx
-
-        ! -- dampen dependent variable solution
-        x(n) = xtemp(n) + this%gamma * delx
-      end do
-      !
-      ! -- option for using cooley underrelaxation
-    else if (this%nonmeth == 2) then
-      !
-      ! -- set bigch
-      this%bigch = bigch
-      !
-      ! -- initialize values for first iteration
-      if (kiter == 1) then
-        relax = DONE
-        this%relaxold = DONE
-        this%bigchold = bigch
-      else
-        !
-        ! -- compute relaxation factor
-        es = this%bigch / (this%bigchold * this%relaxold)
-        aes = abs(es)
-        if (es < -DONE) then
-          relax = dhalf / aes
-        else
-          relax = (DTHREE + es) / (DTHREE + aes)
-        end if
-      end if
-      this%relaxold = relax
-      !
-      ! -- modify cooley to use weighted average of past changes
-      this%bigchold = (DONE - this%gamma) * this%bigch + this%gamma * &
-                      this%bigchold
-      !
-      ! -- compute new dependent variable after under-relaxation
-      if (relax < DONE) then
-        do n = 1, neq
-          !
-          ! -- skip inactive nodes
-          if (active(n) < 1) cycle
-          !
-          ! -- update dependent variable
-          delx = x(n) - xtemp(n)
-          this%dxold(n) = delx
-          x(n) = xtemp(n) + relax * delx
-        end do
-      end if
-      !
-      ! -- option for using delta-bar-delta scheme to under-relax for all equations
-    else if (this%nonmeth == 3) then
-      do n = 1, neq
-        !
-        ! -- skip inactive nodes
-        if (active(n) < 1) cycle
-        !
-        ! -- compute step-size (delta x) and initialize d-b-d parameters
-        delx = x(n) - xtemp(n)
-        !
-        ! -- initialize values for first iteration
-        if (kiter == 1) then
-          this%wsave(n) = DONE
-          this%hchold(n) = DEM20
-          this%deold(n) = DZERO
-        end if
-        !
-        ! -- compute new relaxation term as per delta-bar-delta
-        ww = this%wsave(n)
-        !
-        ! for flip-flop condition, decrease factor
-        if (this%deold(n) * delx < DZERO) then
-          ww = this%theta * this%wsave(n)
-          ! -- when change is of same sign, increase factor
-        else
-          ww = this%wsave(n) + this%akappa
-        end if
-        if (ww > DONE) ww = DONE
-        this%wsave(n) = ww
-        !
-        ! -- compute weighted average of past changes in hchold
-        if (kiter == 1) then
-          this%hchold(n) = delx
-        else
-          this%hchold(n) = (DONE - this%gamma) * delx + &
-                           this%gamma * this%hchold(n)
-        end if
-        !
-        ! -- store slope (change) term for next iteration
-        this%deold(n) = delx
-        this%dxold(n) = delx
-        !
-        ! -- compute accepted step-size and new dependent variable
-        amom = DZERO
-        if (kiter > 4) amom = this%amomentum
-        delx = delx * ww + amom * this%hchold(n)
-        x(n) = xtemp(n) + delx
-      end do
-      !
-    end if
+    ! -- delegate to the stateless kernel, passing persistent state explicitly
+    call ims_nl_underrelax(this%nonmeth, kiter, bigch, neq, active, x, xtemp, &
+                           this%gamma, this%theta, this%akappa, this%amomentum, &
+                           this%bigch, this%bigchold, this%relaxold, &
+                           this%dxold, this%wsave, this%hchold, this%deold)
   end subroutine sln_underrelax
 
   !> @ brief Determine maximum dependent-variable change
@@ -3187,32 +3033,9 @@ contains
     class(NumericalSolutionType), intent(inout) :: this !< NumericalSolutionType instance
     real(DP), intent(inout) :: hncg !< maximum dependent-variable change
     integer(I4B), intent(inout) :: lrch !< location of the maximum dependent-variable change
-    ! -- local variables
-    integer(I4B) :: nb
-    real(DP) :: bigch
-    real(DP) :: abigch
-    integer(I4B) :: n
-    real(DP) :: hdif
-    real(DP) :: ahdif
     !
-    ! -- determine the maximum change
-    nb = 0
-    bigch = DZERO
-    abigch = DZERO
-    do n = 1, this%neq
-      if (this%active(n) < 1) cycle
-      hdif = this%x(n) - this%xtemp(n)
-      ahdif = abs(hdif)
-      if (ahdif > abigch) then
-        bigch = hdif
-        abigch = ahdif
-        nb = n
-      end if
-    end do
-    !
-    !-----store maximum change value and location
-    hncg = bigch
-    lrch = nb
+    ! -- delegate to the stateless kernel
+    call ims_nl_dxmax(this%neq, this%active, this%x, this%xtemp, hncg, lrch)
   end subroutine sln_get_dxmax
 
   function sln_has_converged(this, max_dvc) result(has_converged)
@@ -3220,10 +3043,8 @@ contains
     real(DP) :: max_dvc !< the maximum dependent variable change
     logical(LGP) :: has_converged !< True, when converged
 
-    has_converged = .false.
-    if (abs(max_dvc) <= this%dvclose) then
-      has_converged = .true.
-    end if
+    ! -- delegate to the stateless kernel
+    has_converged = ims_nl_has_converged(max_dvc, this%dvclose)
 
   end function sln_has_converged
 
@@ -3272,11 +3093,8 @@ contains
     real(DP), intent(in) :: hncg !< largest dep. var. change at end of Picard iteration
     logical(LGP) :: has_converged !< True, when converged
 
-    has_converged = .false.
-    if (abs(dxold_max) <= this%dvclose .and. &
-        abs(hncg) <= this%dvclose) then
-      has_converged = .true.
-    end if
+    ! -- delegate to the stateless kernel
+    has_converged = ims_nl_nur_has_converged(dxold_max, hncg, this%dvclose)
 
   end function sln_nur_has_converged
 

--- a/src/Solution/ParallelSolution.f90
+++ b/src/Solution/ParallelSolution.f90
@@ -3,6 +3,7 @@ module ParallelSolutionModule
   use ConstantsModule, only: LENPAKLOC, DONE, DZERO
   use ProfilerModule
   use NumericalSolutionModule, only: NumericalSolutionType
+  use ImsNonlinearBaseModule, only: ims_nl_has_converged
   use mpi
   use MpiWorldModule
   implicit none
@@ -51,14 +52,13 @@ contains
 
     mpi_world => get_mpi_world()
 
-    has_converged = .false.
     abs_max_dvc = abs(max_dvc)
     call MPI_Allreduce(abs_max_dvc, global_max_dvc, 1, MPI_DOUBLE_PRECISION, &
                        MPI_MAX, mpi_world%comm, ierr)
     call CHECK_MPI(ierr)
-    if (global_max_dvc <= this%dvclose) then
-      has_converged = .true.
-    end if
+    ! -- compare the globally-reduced change through the shared kernel so the
+    !    parallel path cannot diverge from the serial convergence criterion
+    has_converged = ims_nl_has_converged(global_max_dvc, this%dvclose)
 
     call g_prof%stop(this%tmr_convergence)
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -326,6 +326,7 @@ modflow_sources = files(
     'Solution' / 'ConvergenceSummary.f90',
     'Solution' / 'LinearMethods' / 'ImsLinearSettings.f90',
     'Solution' / 'LinearMethods' / 'ImsLinearBase.f90',
+    'Solution' / 'LinearMethods' / 'ImsNonlinearBase.f90',
     'Solution' / 'LinearMethods' / 'ImsLinear.f90',
     'Solution' / 'LinearMethods' / 'ImsReordering.f90',
     'Solution' / 'LinearMethods' / 'ImsLinearMisc.f90',


### PR DESCRIPTION
## Description

First refactor step toward exposing the IMS solver through the MODFLOW API: extract the stateless bodies of the IMS **nonlinear (outer-iteration)** routines out of `NumericalSolutionType` into free subroutines in a new `ImsNonlinearBaseModule`, mirroring the existing `ImsLinearBase` pattern. `NumericalSolutionType` methods become thin delegating wrappers, so **behavior is unchanged** and the reusable kernels can be unit tested directly and reused outside the solution object.

This is a behavior-preserving, independently-mergeable move — no numerical results should change.

### Extracted kernels (verbatim transforms; `this%<member>` → explicit args)

| Free subroutine | Extracted from |
|---|---|
| `ims_nl_underrelax` | `sln_underrelax` (SIMPLE/COOLEY/DBD) |
| `ims_nl_maxval` | `sln_maxval` |
| `ims_nl_calcdx` | `sln_calcdx` |
| `ims_nl_dxmax` | `sln_get_dxmax` |
| `ims_nl_backtrack_flag` | `get_backtracking_flag` |
| `ims_nl_apply_backtrack` | `apply_backtracking` |
| `ims_nl_has_converged` | `sln_has_converged` |
| `ims_nl_nur_has_converged` | `sln_nur_has_converged` |
| `ims_nl_residual` | `sln_calc_residual` (r = A*x − b, zeroed for inactive) |
| `ims_nl_l2norm` | `sln_l2norm` (‖r‖₂) |

### Parallel seam

The overridable type-bound procedures keep their signatures, and `ParallelSolution`'s reduce-then-delegate overrides are preserved. The one override that did **not** delegate to the base — `par_has_converged`, which re-implemented the `dvclose` check — is now routed through the shared `ims_nl_has_converged` after its `MPI_Allreduce`, so the serial and parallel convergence criteria cannot diverge. Behavior is identical today (the reduced value is already non-negative, so the kernel's `abs()` is a no-op).

### Tests

Adds `autotest/TestImsNonlinearBase.f90` — 18 `test-drive` unit tests exercising the free kernels against hand-computed values (all three under-relaxation methods, inactive-cell skips, backtracking thresholds, convergence boundaries, signed dxmax, and a small diagonal system for residual / l2norm).

### Local verification

- Serial and extended (PETSc/MPI/NetCDF) builds link cleanly.
- All unit suites pass in both builds; `mf6` runs the outer loop to normal termination.
- `fprettify` clean on all changed/new files.

## Status

The matrix-coupled `sln_calc_residual` / `sln_l2norm` extraction (originally deferred) is now **included** in this PR. The full nonlinear outer-loop kernel is extracted. Still marked **draft** pending final review.

## Checklist

- [x] Added new test or modified an existing test
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated meson files for new source files
- [ ] Updated `develop.toml` release notes — N/A (internal refactor, no user-facing change)
