### PR TITLE
fix(netcdf):  structured layer variable type should be NF90_INT

### DIFF
--- a/autotest/test_netcdf_conventions.py
+++ b/autotest/test_netcdf_conventions.py
@@ -280,6 +280,9 @@ def _check_layer_coord(ds, label=""):
     ctx = f" [{label}]" if label else ""
     assert "layer" in ds.variables, f"layer coordinate variable missing{ctx}"
     layer = ds.variables["layer"]
+    assert layer.dtype == "int32", (
+        f"layer must be stored as a 32-bit integer (NC_INT){ctx}, got {layer.dtype}"
+    )
     assert layer.getncattr("axis") == "Z", f"layer axis must be 'Z'{ctx}"
     assert layer.getncattr("positive") == "down", f"layer positive must be 'down'{ctx}"
     assert layer.getncattr("units") == "1", f"layer units must be '1'{ctx}"

--- a/doc/mf6io/mf6ivar/dfn/utl-ncf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-ncf.dfn
@@ -60,8 +60,8 @@ name chunk_z
 type integer
 reader urword
 optional true
-longname chunking parameter for structured z
-description is the chunk size for the z dimension in a NETCDF\_STRUCTURED output file. Must be used in combination with the chunk\_time, chunk\_x, and chunk\_y parameters to have an effect.
+longname chunking parameter for the layer dimension
+description is the chunk size for the layer (vertical) dimension in a NETCDF\_STRUCTURED output file. Must be used in combination with the chunk\_time, chunk\_x, and chunk\_y parameters to have an effect.
 
 block options
 name chunk_y

--- a/src/Idm/utl-ncfidm.f90
+++ b/src/Idm/utl-ncfidm.f90
@@ -159,7 +159,7 @@ module UtlNcfInputModule
     'CHUNK_Z', & ! fortran variable
     'INTEGER', & ! type
     '', & ! shape
-    'chunking parameter for structured z', & ! longname
+    'chunking parameter for the layer dimension', & ! longname
     .false., & ! required
     .false., & ! developmode
     .false., & ! multi-record

--- a/src/Utilities/Export/DisNCMesh.f90
+++ b/src/Utilities/Export/DisNCMesh.f90
@@ -649,7 +649,10 @@ contains
                                     (/axis_dim/), var_id(1)), &
                        nc_fname)
 
-        ! NROW/NCOL shapes use default chunking
+        ! apply chunking for face-indexed variables; NROW/NCOL use default
+        if (axis_dim == dim_ids%nmesh_face) then
+          call ncvar_chunk(ncid, var_id(1), chunk_face, nc_fname)
+        end if
         call ncvar_deflate(ncid, var_id(1), deflate, shuffle, nc_fname)
 
         ! put attr
@@ -657,6 +660,11 @@ contains
                                     (/NF90_FILL_INT/)), nc_fname)
         call nf_verify(nf90_put_att(ncid, var_id(1), 'long_name', &
                                     longname), nc_fname)
+
+        ! add grid mapping for face-indexed variables
+        if (axis_dim == dim_ids%nmesh_face) then
+          call ncvar_gridmap(ncid, var_id(1), gridmap_name, nc_fname)
+        end if
 
         ! add mf6 attr
         call ncvar_mf6attr(ncid, var_id(1), 0, 0, nc_tag, nc_fname)
@@ -923,7 +931,10 @@ contains
                                     (/axis_dim/), var_id(1)), &
                        nc_fname)
 
-        ! NROW/NCOL shapes use default chunking
+        ! apply chunking for face-indexed variables; NROW/NCOL use default
+        if (axis_dim == dim_ids%nmesh_face) then
+          call ncvar_chunk(ncid, var_id(1), chunk_face, nc_fname)
+        end if
         call ncvar_deflate(ncid, var_id(1), deflate, shuffle, nc_fname)
 
         ! put attr
@@ -931,6 +942,11 @@ contains
                                     (/NF90_FILL_DOUBLE/)), nc_fname)
         call nf_verify(nf90_put_att(ncid, var_id(1), 'long_name', &
                                     longname), nc_fname)
+
+        ! add grid mapping for face-indexed variables
+        if (axis_dim == dim_ids%nmesh_face) then
+          call ncvar_gridmap(ncid, var_id(1), gridmap_name, nc_fname)
+        end if
 
         ! add mf6 attr
         call ncvar_mf6attr(ncid, var_id(1), 0, iaux, nc_tag, nc_fname)

--- a/src/Utilities/Export/DisNCMesh.f90
+++ b/src/Utilities/Export/DisNCMesh.f90
@@ -897,7 +897,7 @@ contains
     real(DP), dimension(:, :, :), pointer, contiguous :: dbl3d
     real(DP), dimension(:), pointer, contiguous :: dbl1d
     integer(I4B) :: axis_dim, nvals, k
-    integer(NF90_INT), dimension(:), allocatable :: var_id
+    integer(I4B), dimension(:), allocatable :: var_id
     character(len=LINELENGTH) :: longname, varname
 
     if (idt%shape == 'NROW' .or. &

--- a/src/Utilities/Export/DisNCStructured.f90
+++ b/src/Utilities/Export/DisNCStructured.f90
@@ -785,7 +785,7 @@ contains
     ! Z dimension
     call nf_verify(nf90_def_dim(this%ncid, 'layer', this%dis%nlay, &
                                 this%dim_ids%z), this%nc_fname)
-    call nf_verify(nf90_def_var(this%ncid, 'layer', NF90_DOUBLE, this%dim_ids%z, &
+    call nf_verify(nf90_def_var(this%ncid, 'layer', NF90_INT, this%dim_ids%z, &
                                 this%var_ids%z), this%nc_fname)
     call nf_verify(nf90_put_att(this%ncid, this%var_ids%z, 'units', '1'), &
                    this%nc_fname)


### PR DESCRIPTION
Cleanup following #2812:
  - fix structured `layer` variable type
  - update dfn `chunk_z` desciption
  - add `grid mapping` and `chunking`` for DIS mesh face-indexed 1D variables

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
