### PR TITLE
refactor(prt): move exit calculation/selection to private helpers

### DIFF
--- a/src/Solution/ParticleTracker/Method/Method.f90
+++ b/src/Solution/ParticleTracker/Method/Method.f90
@@ -21,7 +21,6 @@ module MethodModule
   use CellDefnModule, only: CellDefnType
   use TimeSelectModule, only: TimeSelectType
   use MathUtilModule, only: is_close
-  use DomainModule, only: DomainType
   use ExitSolutionModule, only: ExitSolutionType
   use ListModule, only: ListType
   implicit none
@@ -76,8 +75,6 @@ module MethodModule
     ! Overridden in subtypes that delegate
     procedure :: pass !< pass the particle to the next subdomain
     procedure :: load !< load the subdomain tracking method
-    procedure :: find_exits !< find domain exit solutions
-    procedure :: pick_exit
     ! Implemented here
     procedure :: init
     procedure :: track
@@ -209,27 +206,6 @@ contains
     type(ParticleType), pointer, intent(inout) :: particle
     call pstop(1, "pass must be overridden")
   end subroutine pass
-
-  !> @brief Compute candidate exit solutions.
-  subroutine find_exits(this, particle, domain)
-    class(MethodType), intent(inout) :: this
-    type(ParticleType), pointer, intent(inout) :: particle
-    class(DomainType), intent(in) :: domain
-    if (.not. this%delegates) &
-      call pstop(1, "find_exits called on non-delegating method")
-    call pstop(1, "find_exits must be overridden in delegating methods")
-  end subroutine find_exits
-
-  !> @brief Choose an exit solution among candidates.
-  function pick_exit(this, particle) result(exit_soln)
-    class(MethodType), intent(inout) :: this
-    type(ParticleType), pointer, intent(inout) :: particle
-    integer(I4B) :: exit_soln
-    exit_soln = 0 ! suppress compiler warning
-    if (.not. this%delegates) &
-      call pstop(1, "pick_exit called on non-delegating method")
-    call pstop(1, "pick_exit must be overridden in delegating methods")
-  end function pick_exit
 
   !> @brief A particle is released.
   subroutine release(this, particle)

--- a/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
@@ -26,10 +26,7 @@ module MethodSubcellPollockModule
   type, extends(MethodSubcellType) :: MethodSubcellPollockType
     private
     real(DP), allocatable, public :: qextl1(:), qextl2(:), qintl(:) !< external and internal subcell flows
-    type(LinearExitSolutionType), public :: exit_solutions(3) !< candidate exit solutions
   contains
-    procedure, public :: find_exits
-    procedure, public :: pick_exit
     procedure, public :: apply => apply_msp
     procedure, public :: deallocate
     procedure, private :: track_subcell
@@ -107,27 +104,25 @@ contains
     real(DP) :: t, x, y, z
     real(DP) :: t0, x0, y0, z0
     integer(I4B) :: i, exit_face, exit_soln
+    type(LinearExitSolutionType) :: exit_solutions(3)
     type(LinearExitSolutionType) :: exit_x, exit_y, exit_z
 
     t0 = particle%ttrack
-    x0 = particle%x / subcell%dx
-    y0 = particle%y / subcell%dy
-    z0 = particle%z / subcell%dz
 
     ! Find exit solution in each direction
-    call this%find_exits(particle, subcell)
-    exit_x = this%exit_solutions(1)
-    exit_y = this%exit_solutions(2)
-    exit_z = this%exit_solutions(3)
+    call find_exits(particle, subcell, exit_solutions, x0, y0, z0)
+    exit_x = exit_solutions(1)
+    exit_y = exit_solutions(2)
+    exit_z = exit_solutions(3)
 
     ! Set solution, face, & travel time
-    exit_soln = this%pick_exit(particle)
+    exit_soln = pick_exit(exit_solutions)
     if (exit_soln == 0) then
       exit_face = 0
       dtexit = 1.0d+30
     else
-      exit_face = this%exit_solutions(exit_soln)%iboundary
-      dtexit = this%exit_solutions(exit_soln)%dt
+      exit_face = exit_solutions(exit_soln)%iboundary
+      dtexit = exit_solutions(exit_soln)%dt
     end if
     texit = particle%ttrack + dtexit
 
@@ -142,7 +137,7 @@ contains
     ! remain active under this circumstance, though.
     ! While we may consider that someday, we simply
     ! terminate and sidestep the complexity for now.
-    if (all([this%exit_solutions%status] >= NO_EXIT_STATIONARY)) then
+    if (all([exit_solutions%status] >= NO_EXIT_STATIONARY)) then
       call this%terminate(particle, status=TERM_NO_EXITS_SUB)
       return
     end if
@@ -236,9 +231,8 @@ contains
   end subroutine track_subcell
 
   !> @brief Pick the exit solution with the shortest travel time
-  function pick_exit(this, particle) result(exit_soln)
-    class(MethodSubcellPollockType), intent(inout) :: this
-    type(ParticleType), pointer, intent(inout) :: particle
+  function pick_exit(exit_solutions) result(exit_soln)
+    type(LinearExitSolutionType), intent(in) :: exit_solutions(3)
     integer(I4B) :: exit_soln
     ! local
     real(DP) :: dtmin
@@ -246,29 +240,28 @@ contains
     exit_soln = 0
     dtmin = 1.0d+30
 
-    if (this%exit_solutions(1)%status < 2) then
+    if (exit_solutions(1)%status < 2) then
       exit_soln = 1 ! x
-      dtmin = this%exit_solutions(1)%dt
+      dtmin = exit_solutions(1)%dt
     end if
-    if (this%exit_solutions(2)%status < 2 .and. &
-        this%exit_solutions(2)%dt < dtmin) then
+    if (exit_solutions(2)%status < 2 .and. &
+        exit_solutions(2)%dt < dtmin) then
       exit_soln = 2 ! y
-      dtmin = this%exit_solutions(2)%dt
+      dtmin = exit_solutions(2)%dt
     end if
-    if (this%exit_solutions(3)%status < 2 .and. &
-        this%exit_solutions(3)%dt < dtmin) then
+    if (exit_solutions(3)%status < 2 .and. &
+        exit_solutions(3)%dt < dtmin) then
       exit_soln = 3 ! z
     end if
 
   end function pick_exit
 
   !> @brief Compute candidate exit solutions
-  subroutine find_exits(this, particle, domain)
-    class(MethodSubcellPollockType), intent(inout) :: this
+  subroutine find_exits(particle, domain, exit_solutions, x0, y0, z0)
     type(ParticleType), pointer, intent(inout) :: particle
     class(DomainType), intent(in) :: domain
-    ! local
-    real(DP) :: x0, y0, z0
+    type(LinearExitSolutionType), intent(out) :: exit_solutions(3)
+    real(DP), intent(out) :: x0, y0, z0
 
     select type (domain)
     type is (SubcellRectType)
@@ -278,27 +271,27 @@ contains
       z0 = particle%z / domain%dz
 
       ! Calculate exit solutions for each coordinate direction
-      this%exit_solutions = [ &
-                            find_exit(domain%vx1, domain%vx2, domain%dx, x0), &
-                            find_exit(domain%vy1, domain%vy2, domain%dy, y0), &
-                            find_exit(domain%vz1, domain%vz2, domain%dz, z0) &
-                            ]
+      exit_solutions = [ &
+                       find_exit(domain%vx1, domain%vx2, domain%dx, x0), &
+                       find_exit(domain%vy1, domain%vy2, domain%dy, y0), &
+                       find_exit(domain%vz1, domain%vz2, domain%dz, z0) &
+                       ]
 
       ! Set exit faces
-      if (this%exit_solutions(1)%v < DZERO) then
-        this%exit_solutions(1)%iboundary = 1
-      else if (this%exit_solutions(1)%v > DZERO) then
-        this%exit_solutions(1)%iboundary = 2
+      if (exit_solutions(1)%v < DZERO) then
+        exit_solutions(1)%iboundary = 1
+      else if (exit_solutions(1)%v > DZERO) then
+        exit_solutions(1)%iboundary = 2
       end if
-      if (this%exit_solutions(2)%v < DZERO) then
-        this%exit_solutions(2)%iboundary = 3
-      else if (this%exit_solutions(2)%v > DZERO) then
-        this%exit_solutions(2)%iboundary = 4
+      if (exit_solutions(2)%v < DZERO) then
+        exit_solutions(2)%iboundary = 3
+      else if (exit_solutions(2)%v > DZERO) then
+        exit_solutions(2)%iboundary = 4
       end if
-      if (this%exit_solutions(3)%v < DZERO) then
-        this%exit_solutions(3)%iboundary = 5
-      else if (this%exit_solutions(3)%v > DZERO) then
-        this%exit_solutions(3)%iboundary = 6
+      if (exit_solutions(3)%v < DZERO) then
+        exit_solutions(3)%iboundary = 5
+      else if (exit_solutions(3)%v > DZERO) then
+        exit_solutions(3)%iboundary = 6
       end if
     end select
   end subroutine find_exits

--- a/src/Solution/ParticleTracker/Method/MethodSubcellTernary.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellTernary.f90
@@ -45,10 +45,7 @@ module MethodSubcellTernaryModule
   !> @brief Ternary triangular subcell tracking method.
   type, extends(MethodSubcellType) :: MethodSubcellTernaryType
     integer(I4B), public, pointer :: zeromethod
-    type(BarycentricExitSolutionType), public :: exit_solutions(2) !< candidate exit solutions
   contains
-    procedure, public :: find_exits
-    procedure, public :: pick_exit
     procedure, public :: apply => apply_mst
     procedure, public :: deallocate
     procedure, private :: track_subcell
@@ -101,6 +98,7 @@ contains
     real(DP) :: dt, dtexit, texit
     real(DP) :: t0, t, x, y, z0, z
     integer(I4B) :: exit_face, exit_soln, event_code, i, isolv
+    type(BarycentricExitSolutionType) :: exit_solutions(2)
     type(BarycentricExitSolutionType) :: exit_z, exit_lateral
 
     event_code = -1
@@ -113,10 +111,10 @@ contains
     z0 = particle%z
 
     ! Find exit solutions in lateral and vertical directions
-    call this%find_exits(particle, subcell)
+    call find_exits(particle, subcell, exit_solutions)
 
-    exit_z = this%exit_solutions(1)
-    exit_lateral = this%exit_solutions(2)
+    exit_z = exit_solutions(1)
+    exit_lateral = exit_solutions(2)
 
     ! If the subcell has no exit face, terminate the particle.
     ! TODO: consider ramifications
@@ -127,9 +125,9 @@ contains
     end if
 
     ! Determine exit solution, face, travel time, and time
-    exit_soln = this%pick_exit(particle)
-    exit_face = this%exit_solutions(exit_soln)%iboundary
-    dtexit = this%exit_solutions(exit_soln)%dt
+    exit_soln = pick_exit(exit_solutions)
+    exit_face = exit_solutions(exit_soln)%iboundary
+    dtexit = exit_solutions(exit_soln)%dt
     if (dtexit < DZERO) then
       call this%terminate(particle, status=TERM_NO_EXITS_SUB)
       return
@@ -208,15 +206,14 @@ contains
   end subroutine track_subcell
 
   !> @brief Determine earliest exit face
-  function pick_exit(this, particle) result(exit_soln)
-    class(MethodSubcellTernaryType), intent(inout) :: this
-    type(ParticleType), pointer, intent(inout) :: particle
+  function pick_exit(exit_solutions) result(exit_soln)
+    type(BarycentricExitSolutionType), intent(in) :: exit_solutions(2)
     integer(I4B) :: exit_soln
 
-    if (this%exit_solutions(1)%itopbotexit == 0) then
+    if (exit_solutions(1)%itopbotexit == 0) then
       exit_soln = 2 ! lateral
-    else if (this%exit_solutions(2)%itrifaceexit == 0 .or. &
-             this%exit_solutions(1)%dt < this%exit_solutions(2)%dt) then
+    else if (exit_solutions(2)%itrifaceexit == 0 .or. &
+             exit_solutions(1)%dt < exit_solutions(2)%dt) then
       exit_soln = 1 ! top/bottom
     else
       exit_soln = 2 ! lateral
@@ -225,10 +222,10 @@ contains
   end function pick_exit
 
   !> @brief Calculate exit solutions for each coordinate direction
-  subroutine find_exits(this, particle, domain)
-    class(MethodSubcellTernaryType), intent(inout) :: this
+  subroutine find_exits(particle, domain, exit_solutions)
     type(ParticleType), pointer, intent(inout) :: particle
     class(DomainType), intent(in) :: domain
+    type(BarycentricExitSolutionType), intent(out) :: exit_solutions(2)
     ! local
     integer(I4B) :: ntmax
     real(DP) :: tol
@@ -298,36 +295,36 @@ contains
       else if (zirel < DZERO) then
         zirel = DZERO
       end if
-      this%exit_solutions(1) = find_vertical_exit(subcell%vzbot, subcell%vztop, &
-                                                  subcell%dz, zirel)
+      exit_solutions(1) = find_vertical_exit(subcell%vzbot, subcell%vztop, &
+                                             subcell%dz, zirel)
 
       ! Calculate a semi-analytical lateral exit solution
       itrifaceenter = particle%iboundary(LEVEL_SUBFEATURE) - 1
       if (itrifaceenter == -1) itrifaceenter = 999
-      this%exit_solutions(2) = find_lateral_exit(isolv, tol, &
-                                                 itrifaceenter, &
-                                                 alp1, bet1, alp2, &
-                                                 bet2, alpi, beti)
-      this%exit_solutions(2)%rxx = rxx
-      this%exit_solutions(2)%rxy = rxy
-      this%exit_solutions(2)%ryx = ryx
-      this%exit_solutions(2)%ryy = ryy
-      this%exit_solutions(2)%sxx = sxx
-      this%exit_solutions(2)%sxy = sxy
-      this%exit_solutions(2)%syy = syy
+      exit_solutions(2) = find_lateral_exit(isolv, tol, &
+                                            itrifaceenter, &
+                                            alp1, bet1, alp2, &
+                                            bet2, alpi, beti)
+      exit_solutions(2)%rxx = rxx
+      exit_solutions(2)%rxy = rxy
+      exit_solutions(2)%ryx = ryx
+      exit_solutions(2)%ryy = ryy
+      exit_solutions(2)%sxx = sxx
+      exit_solutions(2)%sxy = sxy
+      exit_solutions(2)%syy = syy
 
       ! Set vertical solution exit face
-      if (this%exit_solutions(1)%itopbotexit /= 0) then
-        if (this%exit_solutions(1)%itopbotexit == -1) then
-          this%exit_solutions(1)%iboundary = 4
+      if (exit_solutions(1)%itopbotexit /= 0) then
+        if (exit_solutions(1)%itopbotexit == -1) then
+          exit_solutions(1)%iboundary = 4
         else
-          this%exit_solutions(1)%iboundary = 5
+          exit_solutions(1)%iboundary = 5
         end if
       end if
 
       ! Set lateral solution exit face
-      if (this%exit_solutions(2)%itrifaceexit /= 0) &
-        this%exit_solutions(2)%iboundary = this%exit_solutions(2)%itrifaceexit
+      if (exit_solutions(2)%itrifaceexit /= 0) &
+        exit_solutions(2)%iboundary = exit_solutions(2)%itrifaceexit
     end select
   end subroutine find_exits
 


### PR DESCRIPTION
The `find_exits`/`pick_exit` contract in the base `MethodType` was never called polymorphically. Overeager abstraction on my part. Move these to private helpers in Pollock and ternary subcell methods. Allows adjusting the `find_exits` signature in Pollock's subcell method to return the initial cell-local coordinates so we don't have to recompute them twice.