### PR TITLE
refactor(ims): setup for option to change linear settings

### DIFF
--- a/src/Solution/LinearMethods/ImsLinear.f90
+++ b/src/Solution/LinearMethods/ImsLinear.f90
@@ -529,6 +529,10 @@ CONTAINS
     ! -- local variables
     integer(I4B) :: n
     !
+    ! -- release any existing preconditioner arrays so this routine is
+    !    idempotent and can be called again to reallocate at runtime
+    if (associated(this%IAPC)) call precond_destroy(this)
+    !
     ! -- determine dimensions for preconditioning arrays
     call ims_calc_pcdims(this%NEQ, this%NJA, this%IA, this%LEVEL, this%IPC, &
                          this%NIAPC, this%NJAPC, this%NJLU, this%NJW, this%NWLU)
@@ -566,18 +570,30 @@ CONTAINS
   !! disturbing the solver work arrays.
   !<
   subroutine precond_destroy(this)
-    use MemoryManagerModule, only: mem_deallocate
+    use MemoryManagerExtModule, only: memorystore_release
     ! -- dummy variables
     class(ImsLinearDataType), intent(inout) :: this !< ImsLinearDataType instance
     !
-    call mem_deallocate(this%iapc)
-    call mem_deallocate(this%japc)
-    call mem_deallocate(this%apc)
-    call mem_deallocate(this%iw)
-    call mem_deallocate(this%w)
-    call mem_deallocate(this%jlu)
-    call mem_deallocate(this%jw)
-    call mem_deallocate(this%wlu)
+    ! -- mem_deallocate is a no-op in the memory manager, so releasing the named
+    !    store entries (and nullifying the aliases below) is what actually frees
+    !    these arrays and lets the preconditioner be reallocated at runtime
+    call memorystore_release('IAPC', trim(this%memoryPath))
+    call memorystore_release('JAPC', trim(this%memoryPath))
+    call memorystore_release('APC', trim(this%memoryPath))
+    call memorystore_release('IW', trim(this%memoryPath))
+    call memorystore_release('W', trim(this%memoryPath))
+    call memorystore_release('JLU', trim(this%memoryPath))
+    call memorystore_release('JW', trim(this%memoryPath))
+    call memorystore_release('WLU', trim(this%memoryPath))
+    !
+    nullify (this%IAPC)
+    nullify (this%JAPC)
+    nullify (this%APC)
+    nullify (this%IW)
+    nullify (this%W)
+    nullify (this%JLU)
+    nullify (this%JW)
+    nullify (this%WLU)
   end subroutine precond_destroy
 
   !> @ brief Set default settings

--- a/src/Solution/LinearMethods/ImsLinear.f90
+++ b/src/Solution/LinearMethods/ImsLinear.f90
@@ -166,7 +166,7 @@ CONTAINS
     this%iout = iout
     !
     ! -- DEFAULT VALUES
-    this%IPC = 0
+    this%IPC = IPC_UNKNOWN
     !
     this%IACPC = 0
     !
@@ -176,14 +176,7 @@ CONTAINS
            ' PACKAGE, VERSION 8, 04/28/2017')
     !
     ! -- DETERMINE PRECONDITIONER
-    IF (this%LEVEL > 0) THEN
-      this%IPC = 3
-    ELSE
-      this%IPC = 1
-    END IF
-    IF (this%RELAX > DZERO) THEN
-      this%IPC = this%IPC + 1
-    END IF
+    this%IPC = resolve_ipc(this%LEVEL, this%RELAX)
     !
     ! -- ERROR CHECKING FOR OPTIONS
     IF (this%ISCL < 0) this%ISCL = 0
@@ -224,29 +217,8 @@ CONTAINS
     CALL mem_allocate(this%DSCALE, iscllen, 'DSCALE', TRIM(this%memoryPath))
     CALL mem_allocate(this%DSCALE2, iscllen, 'DSCALE2', TRIM(this%memoryPath))
     !
-    ! -- determine dimensions for preconditing arrays
-    call ims_calc_pcdims(this%NEQ, this%NJA, this%IA, this%LEVEL, this%IPC, &
-                         this%NIAPC, this%NJAPC, this%NJLU, this%NJW, this%NWLU)
-    !
-    ! -- ALLOCATE BASE PRECONDITIONER VECTORS
-    CALL mem_allocate(this%IAPC, this%NIAPC + 1, 'IAPC', TRIM(this%memoryPath))
-    CALL mem_allocate(this%JAPC, this%NJAPC, 'JAPC', TRIM(this%memoryPath))
-    CALL mem_allocate(this%APC, this%NJAPC, 'APC', TRIM(this%memoryPath))
-    !
-    ! -- ALLOCATE MEMORY FOR ILU0 AND MILU0 NON-ZERO ROW ENTRY VECTOR
-    CALL mem_allocate(this%IW, this%NIAPC, 'IW', TRIM(this%memoryPath))
-    CALL mem_allocate(this%W, this%NIAPC, 'W', TRIM(this%memoryPath))
-    !
-    ! -- ALLOCATE MEMORY FOR ILUT VECTORS
-    CALL mem_allocate(this%JLU, this%NJLU, 'JLU', TRIM(this%memoryPath))
-    CALL mem_allocate(this%JW, this%NJW, 'JW', TRIM(this%memoryPath))
-    CALL mem_allocate(this%WLU, this%NWLU, 'WLU', TRIM(this%memoryPath))
-    !
-    ! -- GENERATE IAPC AND JAPC FOR ILU0 AND MILU0
-    IF (this%IPC == 1 .OR. this%IPC == 2) THEN
-      CALL ims_base_pccrs(this%NEQ, this%NJA, this%IA, this%JA, &
-                          this%IAPC, this%JAPC)
-    END IF
+    ! -- allocate and initialize the preconditioner work arrays
+    call precond_allocate(this)
     !
     ! -- ALLOCATE SPACE FOR PERMUTATION VECTOR
     i0 = 1
@@ -283,9 +255,6 @@ CONTAINS
     DO n = 1, iscllen
       this%DSCALE(n) = DONE
       this%DSCALE2(n) = DONE
-    END DO
-    DO n = 1, this%NJAPC
-      this%APC(n) = DZERO
     END DO
     !
     ! -- WORKING VECTORS
@@ -502,14 +471,7 @@ CONTAINS
     ! -- arrays
     call mem_deallocate(this%dscale)
     call mem_deallocate(this%dscale2)
-    call mem_deallocate(this%iapc)
-    call mem_deallocate(this%japc)
-    call mem_deallocate(this%apc)
-    call mem_deallocate(this%iw)
-    call mem_deallocate(this%w)
-    call mem_deallocate(this%jlu)
-    call mem_deallocate(this%jw)
-    call mem_deallocate(this%wlu)
+    call precond_destroy(this)
     call mem_deallocate(this%lorder)
     call mem_deallocate(this%iorder)
     call mem_deallocate(this%iaro)
@@ -552,6 +514,72 @@ CONTAINS
     nullify (this%x)
   end subroutine imslinear_da
 
+  !> @brief Allocate and initialize the preconditioner work arrays
+  !!
+  !! Determines the preconditioner array dimensions from the current
+  !! NEQ/NJA/LEVEL/IPC and allocates the ILU-family work arrays
+  !! (IAPC/JAPC/APC/IW/W/JLU/JW/WLU); for ILU0/MILU0 the IAPC/JAPC sparsity is
+  !! generated. Separated from imslinear_ar so the preconditioner can be
+  !! (re)allocated at runtime.
+  !<
+  subroutine precond_allocate(this)
+    use MemoryManagerModule, only: mem_allocate
+    ! -- dummy variables
+    class(ImsLinearDataType), intent(inout) :: this !< ImsLinearDataType instance
+    ! -- local variables
+    integer(I4B) :: n
+    !
+    ! -- determine dimensions for preconditioning arrays
+    call ims_calc_pcdims(this%NEQ, this%NJA, this%IA, this%LEVEL, this%IPC, &
+                         this%NIAPC, this%NJAPC, this%NJLU, this%NJW, this%NWLU)
+    !
+    ! -- allocate base preconditioner vectors
+    call mem_allocate(this%IAPC, this%NIAPC + 1, 'IAPC', trim(this%memoryPath))
+    call mem_allocate(this%JAPC, this%NJAPC, 'JAPC', trim(this%memoryPath))
+    call mem_allocate(this%APC, this%NJAPC, 'APC', trim(this%memoryPath))
+    !
+    ! -- allocate ILU0/MILU0 non-zero row entry vectors
+    call mem_allocate(this%IW, this%NIAPC, 'IW', trim(this%memoryPath))
+    call mem_allocate(this%W, this%NIAPC, 'W', trim(this%memoryPath))
+    !
+    ! -- allocate ILUT vectors
+    call mem_allocate(this%JLU, this%NJLU, 'JLU', trim(this%memoryPath))
+    call mem_allocate(this%JW, this%NJW, 'JW', trim(this%memoryPath))
+    call mem_allocate(this%WLU, this%NWLU, 'WLU', trim(this%memoryPath))
+    !
+    ! -- generate IAPC and JAPC for ILU0 and MILU0
+    if (this%IPC == IPC_ILU0 .or. this%IPC == IPC_MILU0) then
+      call ims_base_pccrs(this%NEQ, this%NJA, this%IA, this%JA, &
+                          this%IAPC, this%JAPC)
+    end if
+    !
+    ! -- initialize preconditioner values
+    do n = 1, this%NJAPC
+      this%APC(n) = DZERO
+    end do
+  end subroutine precond_allocate
+
+  !> @brief Deallocate the preconditioner work arrays
+  !!
+  !! Preconditioner-only teardown, separated from imslinear_da so the
+  !! preconditioner can be destroyed and reallocated at runtime without
+  !! disturbing the solver work arrays.
+  !<
+  subroutine precond_destroy(this)
+    use MemoryManagerModule, only: mem_deallocate
+    ! -- dummy variables
+    class(ImsLinearDataType), intent(inout) :: this !< ImsLinearDataType instance
+    !
+    call mem_deallocate(this%iapc)
+    call mem_deallocate(this%japc)
+    call mem_deallocate(this%apc)
+    call mem_deallocate(this%iw)
+    call mem_deallocate(this%w)
+    call mem_deallocate(this%jlu)
+    call mem_deallocate(this%jw)
+    call mem_deallocate(this%wlu)
+  end subroutine precond_destroy
+
   !> @ brief Set default settings
     !!
     !!  Set default linear accelerator settings.
@@ -568,7 +596,7 @@ CONTAINS
     CASE (1)
       this%ITER1 = 50
       this%ILINMETH = 1
-      this%IPC = 1
+      this%IPC = IPC_ILU0
       this%ISCL = 0
       this%IORD = 0
       this%DVCLOSE = DEM3
@@ -582,7 +610,7 @@ CONTAINS
     CASE (2)
       this%ITER1 = 100
       this%ILINMETH = 2
-      this%IPC = 2
+      this%IPC = IPC_MILU0
       this%ISCL = 0
       this%IORD = 0
       this%DVCLOSE = DEM2
@@ -596,7 +624,7 @@ CONTAINS
     CASE (3)
       this%ITER1 = 500
       this%ILINMETH = 2
-      this%IPC = 3
+      this%IPC = IPC_ILUT
       this%ISCL = 0
       this%IORD = 0
       this%DVCLOSE = DEM1

--- a/src/Solution/LinearMethods/ImsLinearBase.f90
+++ b/src/Solution/LinearMethods/ImsLinearBase.f90
@@ -13,6 +13,7 @@ MODULE IMSLinearBaseModule
   use BlockParserModule, only: BlockParserType
   use IMSReorderingModule, only: ims_odrv
   use ConvergenceSummaryModule
+  use ImsLinearSettingsModule, only: IPC_ILU0, IPC_MILU0, IPC_ILUT, IPC_MILUT
 
   IMPLICIT NONE
 
@@ -105,11 +106,11 @@ contains
       SELECT CASE (IPC)
         !
         ! -- ILU0 AND MILU0
-      CASE (1, 2)
+      CASE (IPC_ILU0, IPC_MILU0)
         CALL ims_base_ilu0a(NJA, NEQ, APC, IAPC, JAPC, D, Z)
         !
         ! -- ILUT AND MILUT
-      CASE (3, 4)
+      CASE (IPC_ILUT, IPC_MILUT)
         CALL lusol(NEQ, D, Z, APC, JLU, IW)
       END SELECT
       rho = ddot(NEQ, D, 1, Z, 1)
@@ -358,11 +359,11 @@ contains
       SELECT CASE (IPC)
         !
         ! -- ILU0 AND MILU0
-      CASE (1, 2)
+      CASE (IPC_ILU0, IPC_MILU0)
         CALL ims_base_ilu0a(NJA, NEQ, APC, IAPC, JAPC, P, PHAT)
         !
         ! -- ILUT AND MILUT
-      CASE (3, 4)
+      CASE (IPC_ILUT, IPC_MILUT)
         CALL lusol(NEQ, P, PHAT, APC, JLU, IW)
       END SELECT
       !
@@ -409,11 +410,11 @@ contains
       SELECT CASE (IPC)
         !
         ! -- ILU0 AND MILU0
-      CASE (1, 2)
+      CASE (IPC_ILU0, IPC_MILU0)
         CALL ims_base_ilu0a(NJA, NEQ, APC, IAPC, JAPC, Q, QHAT)
         !
         ! -- ILUT AND MILUT
-      CASE (3, 4)
+      CASE (IPC_ILUT, IPC_MILUT)
         CALL lusol(NEQ, Q, QHAT, APC, JLU, IW)
       END SELECT
       !
@@ -813,13 +814,13 @@ contains
       SELECT CASE (IPC)
         !
         ! -- ILU0 AND MILU0
-      CASE (1, 2)
+      CASE (IPC_ILU0, IPC_MILU0)
         CALL ims_base_pcilu0(NJA, NEQ, AMAT, IA, JA, &
                              APC, IAPC, JAPC, IW, W, &
                              RELAX, ipcflag, delta)
         !
         ! -- ILUT AND MILUT
-      CASE (3, 4)
+      CASE (IPC_ILUT, IPC_MILUT)
         ierr = 0
         CALL ilut(NEQ, AMAT, JA, IA, LEVEL, DROPTOL, &
                   APC, JLU, IW, NJAPC, WLU, JW, ierr, &

--- a/src/Solution/LinearMethods/ImsLinearSettings.f90
+++ b/src/Solution/LinearMethods/ImsLinearSettings.f90
@@ -313,13 +313,20 @@ contains
     real(DP), intent(in) :: relax !< relaxation factor (> 0 selects the modified ILU)
     integer(I4B) :: ipc !< resolved preconditioner enum (IPC_*)
     !
+    ! -- map explicitly to the target enum (do not rely on IPC_* being
+    !    consecutive); relax > 0 selects the modified variant
     if (level > 0) then
-      ipc = IPC_ILUT
+      if (relax > DZERO) then
+        ipc = IPC_MILUT
+      else
+        ipc = IPC_ILUT
+      end if
     else
-      ipc = IPC_ILU0
-    end if
-    if (relax > DZERO) then
-      ipc = ipc + 1
+      if (relax > DZERO) then
+        ipc = IPC_MILU0
+      else
+        ipc = IPC_ILU0
+      end if
     end if
   end function resolve_ipc
 

--- a/src/Solution/LinearMethods/ImsLinearSettings.f90
+++ b/src/Solution/LinearMethods/ImsLinearSettings.f90
@@ -10,6 +10,18 @@ module ImsLinearSettingsModule
   integer(I4B), public, parameter :: CG_METHOD = 1
   integer(I4B), public, parameter :: BCGS_METHOD = 2
 
+  !> @brief IMS linear preconditioner types
+  !<
+  enum, bind(C)
+    enumerator :: IPC_UNKNOWN = 0 !< preconditioner type not set
+    enumerator :: IPC_ILU0 = 1 !< ILU0 (incomplete LU, zero fill)
+    enumerator :: IPC_MILU0 = 2 !< modified ILU0
+    enumerator :: IPC_ILUT = 3 !< ILUT (incomplete LU with threshold)
+    enumerator :: IPC_MILUT = 4 !< modified ILUT
+  end enum
+  public :: IPC_UNKNOWN, IPC_ILU0, IPC_MILU0, IPC_ILUT, IPC_MILUT
+  public :: resolve_ipc
+
   type, public :: ImsLinearSettingsType
     character(len=LENMEMPATH) :: memory_path
     real(DP), pointer :: dvclose => null() !< dependent variable closure criterion
@@ -285,5 +297,30 @@ contains
     call mem_deallocate(this%ifdparam)
 
   end subroutine destroy
+
+  !> @brief Resolve the preconditioner enum from the ILU controls
+  !!
+  !! Maps the ILU fill level and relaxation factor to a specific IPC_*
+  !! preconditioner:
+  !!   level > 0   -> IPC_ILUT  (-> IPC_MILUT when relax > 0)
+  !!   level == 0  -> IPC_ILU0  (-> IPC_MILU0 when relax > 0)
+  !!
+  !! Extracted into a pure function so the same resolution can be reused when
+  !! preconditioner settings change at runtime (e.g. by stress period).
+  !<
+  pure function resolve_ipc(level, relax) result(ipc)
+    integer(I4B), intent(in) :: level !< ILU fill level
+    real(DP), intent(in) :: relax !< relaxation factor (> 0 selects the modified ILU)
+    integer(I4B) :: ipc !< resolved preconditioner enum (IPC_*)
+    !
+    if (level > 0) then
+      ipc = IPC_ILUT
+    else
+      ipc = IPC_ILU0
+    end if
+    if (relax > DZERO) then
+      ipc = ipc + 1
+    end if
+  end function resolve_ipc
 
 end module


### PR DESCRIPTION
Refactoring to support updating ims linear settings for specific stress periods.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
