### PR TITLE
fix(drn, wel): report options errors for the correct input file

### DIFF
--- a/autotest/test_gwf_errors.py
+++ b/autotest/test_gwf_errors.py
@@ -242,6 +242,78 @@ def test_disu_errors(function_tmpdir, targets):
         run_mf6_error(str(function_tmpdir), mf6, err_str)
 
 
+def test_drn_options_error_file(function_tmpdir, targets):
+    """Errors in DRN options are reported for the DRN input file."""
+    mf6 = targets["mf6"]
+
+    sim = get_minimal_gwf_simulation(str(function_tmpdir), exe=mf6)
+    gwf = sim.get_model("test")
+    flopy.mf6.ModflowGwfdrn(
+        gwf,
+        auxiliary=["depth"],
+        auxdepthname="not_an_aux",
+        stress_period_data={0: [[(0, 1, 1), 0.0, 1.0, 0.0]]},
+    )
+    # sourced after DRN; its file name was reported before the fix
+    flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data={0: [[(0, 2, 2), 0.0, 1.0]]},
+    )
+    sim.write_simulation()
+
+    returncode, buff = run_mf6([mf6], str(function_tmpdir))
+    assert returncode != 0, "mf6 should have failed on an unknown AUXDEPTHNAME"
+
+    output = "\n".join(buff)
+    assert "AUXDEPTHNAME was specified as" in output
+    assert "ERROR OCCURRED WHILE READING FILE 'test.drn'" in output
+    assert "test.ghb" not in output
+
+
+def test_wel_options_error_file(function_tmpdir, targets):
+    """Errors in WEL options are reported for the WEL input file."""
+    mf6 = targets["mf6"]
+
+    sim = get_minimal_gwf_simulation(str(function_tmpdir), exe=mf6)
+    gwf = sim.get_model("test")
+    flopy.mf6.ModflowGwfwel(
+        gwf,
+        auxiliary=["afrlen"],
+        auto_flow_reduce=0.1,
+        stress_period_data={0: [[(0, 1, 1), -1.0, 0.5]]},
+    )
+    # sourced after WEL; its file name was reported before the fix
+    flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data={0: [[(0, 2, 2), 0.0, 1.0]]},
+    )
+    sim.write_simulation()
+
+    # written by hand, AUTO_FLOW_REDUCE_AUXNAME is not in released flopy
+    with open(function_tmpdir / "test.wel", "w") as f:
+        f.write("BEGIN options\n")
+        f.write("  AUXILIARY  afrlen\n")
+        f.write("  AUTO_FLOW_REDUCE  0.1\n")
+        f.write("  AUTO_FLOW_REDUCE_AUXNAME  not_an_aux\n")
+        f.write("END options\n\n")
+        f.write("BEGIN dimensions\n")
+        f.write("  MAXBOUND  1\n")
+        f.write("END dimensions\n\n")
+        f.write("BEGIN period  1\n")
+        f.write("  1 2 2 -1.0 0.5\n")
+        f.write("END period  1\n")
+
+    returncode, buff = run_mf6([mf6], str(function_tmpdir))
+    assert returncode != 0, (
+        "mf6 should have failed on an unknown AUTO_FLOW_REDUCE_AUXNAME"
+    )
+
+    output = "\n".join(buff)
+    assert "AUTO_FLOW_REDUCE_AUXNAME was specified as" in output
+    assert "ERROR OCCURRED WHILE READING FILE 'test.wel'" in output
+    assert "test.ghb" not in output
+
+
 def test_solver_fail(function_tmpdir, targets):
     mf6 = targets["mf6"]
 

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -36,6 +36,11 @@ description = "For the Well (WEL) Package, when AUTO\\_FLOW\\_REDUCE is active a
 
 [[items]]
 section = "fixes"
+subsection = "stress"
+description = "Errors detected while reading the OPTIONS block of the Drain (DRN) and Well (WEL) Packages, such as an AUXDEPTHNAME or AUTO\\_FLOW\\_REDUCE\\_AUXNAME that names an auxiliary variable that does not exist, were reported for the input file of the next package read rather than for the file that contained the error. These errors are now reported for the DRN or WEL input file."
+
+[[items]]
+section = "fixes"
 subsection = "internal"
 description = "Resolved mass-balance errors in the Central and UTVD numerical schemes caused by inconsistent interpretation of cell-to-interface distances (cl1/cl2)."
 

--- a/src/Model/GroundWaterFlow/gwf-drn.f90
+++ b/src/Model/GroundWaterFlow/gwf-drn.f90
@@ -234,6 +234,11 @@ contains
     !
     ! -- log DRN specific options
     call this%log_drn_options(found)
+    !
+    ! -- terminate if errors were detected
+    if (count_errors() > 0) then
+      call store_error_filename(this%input_fname)
+    end if
   end subroutine drn_options
 
   !> @ brief Log DRN specific package options

--- a/src/Model/GroundWaterFlow/gwf-wel.f90
+++ b/src/Model/GroundWaterFlow/gwf-wel.f90
@@ -18,7 +18,8 @@ module WelModule
   use ConstantsModule, only: DZERO, DEM1, DONE, LENFTYPE, DNODATA, LINELENGTH, &
                              LENAUXNAME
   use SimVariablesModule, only: errmsg, warnmsg
-  use SimModule, only: store_error, store_error_filename, store_warning
+  use SimModule, only: count_errors, store_error, store_error_filename, &
+                       store_warning
   use MemoryHelperModule, only: create_mem_path
   use BndModule, only: BndType
   use BndExtModule, only: BndExtType
@@ -297,6 +298,11 @@ contains
 
     ! -- log WEL specific options
     call this%log_wel_options(found)
+    !
+    ! -- terminate if errors were detected
+    if (count_errors() > 0) then
+      call store_error_filename(this%input_fname)
+    end if
   end subroutine wel_options
 
   !> @ brief Log WEL specific package options


### PR DESCRIPTION
Errors detected while reading the OPTIONS block of the Drain (DRN) and Well (WEL) Packages, such as an AUXDEPTHNAME that names an auxiliary variable that does not exist, were left in the error buffer and reported for the input file of the next package read. The DRN and WEL option routines now flush pending errors against their own input file, so the error is reported for the file that contains it.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Closed issue #2903
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
