### PR TITLE
docs(dfns): define the development options of four packages

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwf-lak.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-lak.dfn
@@ -279,6 +279,30 @@ longname
 description REPLACE mover {'{#1}': 'LAK'}
 
 block options
+name dev_force_fallback
+type keyword
+reader urword
+optional true
+longname force the substitution fallback solution
+description keyword that solves every active lake with the substitution fallback under the implicit formulation, instead of only those lakes that are too poorly conditioned to solve as a matrix unknown.  This development option is not supported.
+
+block options
+name dev_groundwater_head_conductance
+type keyword
+reader urword
+optional true
+longname use the groundwater head to calculate horizontal conductance
+description keyword that calculates the conductance for horizontal connections using the groundwater head instead of the lake stage.  This development option is not supported.
+
+block options
+name dev_maximum_outlet_depth
+type double precision
+reader urword
+optional true
+longname maximum outlet depth
+description real number value that defines the maximum depth used to calculate outlet flow.  This development option is not supported.
+
+block options
 name surfdep
 type double precision
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/gwf-maw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-maw.dfn
@@ -328,8 +328,6 @@ longname
 description REPLACE mover {'{#1}': 'MAW'}
 
 
-# --------------------- gwf maw dimensions ---------------------
-
 block options
 name dev_peaceman_effective_radius
 type keyword
@@ -337,6 +335,8 @@ reader urword
 optional true
 longname use the Peaceman effective radius
 description keyword that calculates the effective radius for structured grids using the approach of Peaceman (1983) instead of the default approach.  This development option is not supported.
+
+# --------------------- gwf maw dimensions ---------------------
 
 block dimensions
 name nmawwells

--- a/doc/mf6io/mf6ivar/dfn/gwf-maw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-maw.dfn
@@ -330,6 +330,14 @@ description REPLACE mover {'{#1}': 'MAW'}
 
 # --------------------- gwf maw dimensions ---------------------
 
+block options
+name dev_peaceman_effective_radius
+type keyword
+reader urword
+optional true
+longname use the Peaceman effective radius
+description keyword that calculates the effective radius for structured grids using the approach of Peaceman (1983) instead of the default approach.  This development option is not supported.
+
 block dimensions
 name nmawwells
 type integer

--- a/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
@@ -344,8 +344,6 @@ longname reach storage time weighting
 description real number value that defines the time weighting factor used to calculate the change in channel storage. STORAGE\_WEIGHT must have a value between 0.5 and 1. Default STORAGE\_WEIGHT value is 1.
 
 
-# --------------------- gwf sfr dimensions ---------------------
-
 block options
 name dev_no_check
 type keyword
@@ -353,6 +351,8 @@ reader urword
 optional true
 longname do not check reach geometry and parameters
 description keyword that deactivates the checks of reach geometry relative to the model grid and of reach parameters for reasonable values.  This development option is not supported.
+
+# --------------------- gwf sfr dimensions ---------------------
 
 block dimensions
 name nreaches

--- a/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
@@ -346,6 +346,14 @@ description real number value that defines the time weighting factor used to cal
 
 # --------------------- gwf sfr dimensions ---------------------
 
+block options
+name dev_no_check
+type keyword
+reader urword
+optional true
+longname do not check reach geometry and parameters
+description keyword that deactivates the checks of reach geometry relative to the model grid and of reach parameters for reasonable values.  This development option is not supported.
+
 block dimensions
 name nreaches
 type integer

--- a/doc/mf6io/mf6ivar/dfn/gwf-uzf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-uzf.dfn
@@ -280,6 +280,14 @@ longname
 description REPLACE mover {'{#1}': 'UZF'}
 
 block options
+name dev_no_final_check
+type keyword
+reader urword
+optional true
+longname do not check final convergence
+description keyword that deactivates the final convergence check of the change in UZF recharge.  This development option is not supported.
+
+block options
 name simulate_et
 type keyword
 tagged true


### PR DESCRIPTION
Development options parsed by the SFR, UZF, MAW, and LAK packages were absent from their definition files, so they have no flopy keyword argument and cannot be exercised by a test. Packages loaded through the input data model must define every option in the definition file to parse it at all; these four parse their options directly, so the entries were never required and were never written. The mf6ivar script excludes variables whose name begins with dev_ from the documentation, so none of these appear in the input and output guide.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
