### PR TITLE
docs(dfns): define the development option of the advanced transport packages

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwe-lke.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-lke.dfn
@@ -258,6 +258,14 @@ description REPLACE obs6_filename {'{#1}': 'LKE', '{#2}': '\\ref{table:gwe-obsty
 
 # --------------------- gwe lke packagedata ---------------------
 
+block options
+name dev_nonexpanding_matrix
+type keyword
+reader urword
+optional true
+longname do not add rows to the solution matrix
+description keyword that solves the feature temperature with a general mixing equation and adds the result to the right-hand side of the GWE equations, instead of adding a row to the solution matrix for each feature.  This development option is not supported.
+
 block packagedata
 name packagedata
 type recarray lakeno strt ktf rbthcnd aux boundname

--- a/doc/mf6io/mf6ivar/dfn/gwe-mwe.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-mwe.dfn
@@ -258,6 +258,14 @@ description REPLACE obs6_filename {'{#1}': 'MWE', '{#2}': '\\ref{table:gwe-obsty
 
 # --------------------- gwe mwe packagedata ---------------------
 
+block options
+name dev_nonexpanding_matrix
+type keyword
+reader urword
+optional true
+longname do not add rows to the solution matrix
+description keyword that solves the feature temperature with a general mixing equation and adds the result to the right-hand side of the GWE equations, instead of adding a row to the solution matrix for each feature.  This development option is not supported.
+
 block packagedata
 name packagedata
 type recarray mawno strt ktf fthk aux boundname

--- a/doc/mf6io/mf6ivar/dfn/gwe-sfe.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-sfe.dfn
@@ -258,6 +258,14 @@ description REPLACE obs6_filename {'{#1}': 'SFE', '{#2}': '\\ref{table:gwe-obsty
 
 # --------------------- gwe sfe packagedata ---------------------
 
+block options
+name dev_nonexpanding_matrix
+type keyword
+reader urword
+optional true
+longname do not add rows to the solution matrix
+description keyword that solves the feature temperature with a general mixing equation and adds the result to the right-hand side of the GWE equations, instead of adding a row to the solution matrix for each feature.  This development option is not supported.
+
 block packagedata
 name packagedata
 type recarray rno strt ktf rbthcnd aux boundname

--- a/doc/mf6io/mf6ivar/dfn/gwe-uze.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-uze.dfn
@@ -258,6 +258,14 @@ description REPLACE obs6_filename {'{#1}': 'UZE', '{#2}': '\\ref{table:gwe-obsty
 
 # --------------------- gwe uze packagedata ---------------------
 
+block options
+name dev_nonexpanding_matrix
+type keyword
+reader urword
+optional true
+longname do not add rows to the solution matrix
+description keyword that solves the feature temperature with a general mixing equation and adds the result to the right-hand side of the GWE equations, instead of adding a row to the solution matrix for each feature.  This development option is not supported.
+
 block packagedata
 name packagedata
 type recarray uzfno strt aux boundname

--- a/doc/mf6io/mf6ivar/dfn/gwt-lkt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-lkt.dfn
@@ -258,6 +258,14 @@ description REPLACE obs6_filename {'{#1}': 'LKT', '{#2}': '\\ref{table:gwt-obsty
 
 # --------------------- gwt lkt packagedata ---------------------
 
+block options
+name dev_nonexpanding_matrix
+type keyword
+reader urword
+optional true
+longname do not add rows to the solution matrix
+description keyword that solves the feature concentration with a general mixing equation and adds the result to the right-hand side of the GWT equations, instead of adding a row to the solution matrix for each feature.  This development option is not supported.
+
 block packagedata
 name packagedata
 type recarray ifno strt aux boundname

--- a/doc/mf6io/mf6ivar/dfn/gwt-mwt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-mwt.dfn
@@ -258,6 +258,14 @@ description REPLACE obs6_filename {'{#1}': 'MWT', '{#2}': '\\ref{table:gwt-obsty
 
 # --------------------- gwt mwt packagedata ---------------------
 
+block options
+name dev_nonexpanding_matrix
+type keyword
+reader urword
+optional true
+longname do not add rows to the solution matrix
+description keyword that solves the feature concentration with a general mixing equation and adds the result to the right-hand side of the GWT equations, instead of adding a row to the solution matrix for each feature.  This development option is not supported.
+
 block packagedata
 name packagedata
 type recarray ifno strt aux boundname

--- a/doc/mf6io/mf6ivar/dfn/gwt-sft.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-sft.dfn
@@ -258,6 +258,14 @@ description REPLACE obs6_filename {'{#1}': 'SFT', '{#2}': '\\ref{table:gwt-obsty
 
 # --------------------- gwt sft packagedata ---------------------
 
+block options
+name dev_nonexpanding_matrix
+type keyword
+reader urword
+optional true
+longname do not add rows to the solution matrix
+description keyword that solves the feature concentration with a general mixing equation and adds the result to the right-hand side of the GWT equations, instead of adding a row to the solution matrix for each feature.  This development option is not supported.
+
 block packagedata
 name packagedata
 type recarray ifno strt aux boundname

--- a/doc/mf6io/mf6ivar/dfn/gwt-uzt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-uzt.dfn
@@ -258,6 +258,14 @@ description REPLACE obs6_filename {'{#1}': 'UZT', '{#2}': '\\ref{table:gwt-obsty
 
 # --------------------- gwt uzt packagedata ---------------------
 
+block options
+name dev_nonexpanding_matrix
+type keyword
+reader urword
+optional true
+longname do not add rows to the solution matrix
+description keyword that solves the feature concentration with a general mixing equation and adds the result to the right-hand side of the GWT equations, instead of adding a row to the solution matrix for each feature.  This development option is not supported.
+
 block packagedata
 name packagedata
 type recarray ifno strt aux boundname


### PR DESCRIPTION
The DEV_NONEXPANDING_MATRIX option is parsed by the advanced package transport base but was absent from the definition files of the eight packages that derive from it, so it has no flopy keyword argument and cannot be exercised by a test. The option is defined in each derived definition file because the base options are repeated in each of them. The mf6ivar script excludes variables whose name begins with dev_ from the documentation, so the option does not appear in the input and output guide.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
