### PR TITLE
feat(ims): define and enforce the pseudo-transient continuation development options

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/sln-ims.dfn
+++ b/doc/mf6io/mf6ivar/dfn/sln-ims.dfn
@@ -167,6 +167,71 @@ longname fraction of outer maximum used with ats
 description real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ.
 
 
+block options
+name dev_ptc
+type keyword
+reader urword
+optional true
+longname activate pseudo-transient continuation
+description keyword that activates pseudo-transient continuation (PTC).  PTC is active by default, so this keyword has an effect only when it follows NO\_PTC in the OPTIONS block.  This development option is not supported.
+
+block options
+name dev_ptc_output_filerecord
+type record dev_ptc_output fileout dev_ptcfile
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name dev_ptc_output
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname pseudo-transient continuation output keyword
+description keyword to specify that the record corresponds to the pseudo-transient continuation output file.  Specifying the record also activates pseudo-transient continuation.  This development option is not supported.
+
+block options
+name dev_ptcfile
+type string
+preserve_case true
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the ascii output file to write pseudo-transient continuation information.
+
+block options
+name dev_ptc_option
+type keyword
+reader urword
+optional true
+longname use the norms to set the initial pseudo-transient continuation value
+description keyword that uses the norm of the right-hand side and the L2 norm of the residual to set the initial pseudo-transient continuation value, instead of the default approach.  Specifying the keyword also activates pseudo-transient continuation.  This development option is not supported.
+
+block options
+name dev_ptc_exponent
+type double precision
+reader urword
+optional true
+longname pseudo-transient continuation exponent
+description real number value that defines the exponent used to reduce the pseudo-transient continuation value between outer iterations.  The value must be greater than zero and is 1 by default.  Specifying the value also activates pseudo-transient continuation.  This development option is not supported.
+
+block options
+name dev_ptc_del0
+type double precision
+reader urword
+optional true
+longname initial pseudo-transient continuation value
+description real number value that defines the initial pseudo-transient continuation value, which is equivalent to an initial time step length.  The value must be greater than zero.  Specifying the value also activates pseudo-transient continuation.  This development option is not supported.
+
 # --------------------- sln ims nonlinear ---------------------
 
 block nonlinear

--- a/src/Solution/NumericalSolution.f90
+++ b/src/Solution/NumericalSolution.f90
@@ -734,7 +734,7 @@ contains
         case ('DEV_PTC_EXPONENT')
           call this%parser%DevOpt()
           rval = this%parser%GetDouble()
-          if (rval < DZERO) then
+          if (rval <= DZERO) then
             write (errmsg, '(a)') 'PTC_EXPONENT must be > 0.'
             call store_error(errmsg)
           else
@@ -746,7 +746,7 @@ contains
         case ('DEV_PTC_DEL0')
           call this%parser%DevOpt()
           rval = this%parser%GetDouble()
-          if (rval < DZERO) then
+          if (rval <= DZERO) then
             write (errmsg, '(a)') 'IMS sln_ar: PTC_DEL0 must be > 0.'
             call store_error(errmsg)
           else


### PR DESCRIPTION
Five development options that control pseudo-transient continuation are parsed by the solution but were absent from the definition file, so they have no flopy keyword argument and cannot be exercised by a test. This completes the definitions for the development options that are parsed directly rather than through the input data model, following #2906 and #2907.

Pseudo-transient continuation is active by default, as the description of NO\_PTC states, so DEV\_PTC sets a flag that already has that value and has an effect only when it follows NO\_PTC in the OPTIONS block. The other four also set the flag, so specifying any of them activates pseudo-transient continuation. The descriptions say so rather than implying that the options turn on something that is off. The mf6ivar script excludes variables whose name begins with dev\_ from the documentation, so none of these appear in the input and output guide.

Writing the definitions exposed a mismatch in the code they describe. DEV\_PTC\_EXPONENT and DEV\_PTC\_DEL0 were validated with `rval < DZERO`, so zero was accepted, while the error message raised by that same test reads `PTC_EXPONENT must be > 0.` A zero exponent applies no reduction between outer iterations and a zero initial value is not a time step length, so both checks now reject zero and agree with the error message and the new definitions. No model in the repository sets either option.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
