### PR TITLE
fix(uzf): correct five defects in the kinematic wave and evapotranspiration routines

### DIFF
--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -210,3 +210,28 @@ description = "The Skeletal Storage, Compaction, and Subsidence (CSUB) Package t
 section = "fixes"
 subsection = "basic"
 description = "The BMI get\\_version, get\\_component\\_name, and get\\_grid\\_type functions assigned the converted C string to a character array longer than the string itself. The assignment is not conforming, which left the amount of the caller's buffer that is written up to the compiler. The assignments were corrected to write only the string and its null terminator."
+
+[[items]]
+section = "fixes"
+subsection = "advanced"
+description = "In the Unsaturated Zone Flow (UZF) Package, the branch of the trailing-wave routine taken when the water content behind the leading wave is already at or below the value implied by the applied infiltration rate indexed the wave arrays with the array holding the wave count of every UZF cell, instead of the wave count of the cell being solved. In Fortran this is a vector subscript rather than a single element, so wave depth, water content, and flux were reset at wave positions belonging to other cells, corrupting the wave train of the cell being solved. The routine now indexes the cell being solved. The branch is reached whenever the applied infiltration rate decreases, so simulated recharge, unsaturated zone evapotranspiration, water content, and unsaturated zone storage can change in any transient simulation. The corrupted wave train created spurious unsaturated zone storage: in one of the UZF test problems the largest UZF budget percent discrepancy falls from 4.9e-3 to 4e-6 percent. Simulated heads change very little in that problem, but models in which the number of waves differs between UZF cells, which is typical where infiltration varies in space, are affected more than models in which it does not."
+
+[[items]]
+section = "fixes"
+subsection = "advanced"
+description = "The Unsaturated Zone Flow (UZF) Package wave speed routine assigned its working variable only when the water content behind the wave exceeded the residual water content, and then read that variable regardless. Where the water content was at the residual value, which occurs wherever a wave is reset, the wave speed was computed from whatever the variable happened to contain. Simulated results were therefore dependent on the compiler and on the state of memory, and were not necessarily reproducible between builds of the same program. The variable is now initialized before use."
+
+[[items]]
+section = "fixes"
+subsection = "advanced"
+description = "The Unsaturated Zone Flow (UZF) Package evapotranspiration routine created a new wave one position beyond the current number of waves and only then compared the number of waves with the number allocated, which is NTRAILWAVES multiplied by NWAVESETS. A cell that was already at capacity therefore wrote past the end of its wave storage and into the wave storage of the next UZF cell before the error was detected. The capacity is now checked before the wave is created, so the condition is reported as an error asking for NWAVESETS to be increased, as intended."
+
+[[items]]
+section = "fixes"
+subsection = "advanced"
+description = "The Unsaturated Zone Flow (UZF) Package reset only the first six waves of a UZF cell that no longer contains an unsaturated zone. Any waves beyond the sixth kept the water content, depth, flux, and speed they had before the water table rose above the top of the cell, and were reused if an unsaturated zone formed again. All waves in the cell are now reset. Simulated results can change for cells that carry more than six waves."
+
+[[items]]
+section = "fixes"
+subsection = "advanced"
+description = "The Unsaturated Zone Flow (UZF) Package accepted NTRAILWAVES of 1, which caused a division by zero when trailing waves were created. NTRAILWAVES is now required to be greater than 1, and the error message recommends a value of 7."

--- a/src/Model/GroundWaterFlow/gwf-uzf.f90
+++ b/src/Model/GroundWaterFlow/gwf-uzf.f90
@@ -581,9 +581,9 @@ contains
       call store_error(errmsg)
     end if
 
-    if (this%ntrail_pvar <= 0) then
+    if (this%ntrail_pvar <= 1) then
       write (errmsg, '(a)') &
-        'NTRAILWAVES was not specified or was specified incorrectly.'
+        'NTRAILWAVES must be greater than 1. A value of 7 is recommended.'
       call store_error(errmsg)
     end if
     !

--- a/src/Model/ModelUtilities/UzfCellGroup.f90
+++ b/src/Model/ModelUtilities/UzfCellGroup.f90
@@ -655,7 +655,11 @@ contains
     if (this%celtop(icell) - test > DEM15) then
       if (issflag == 0) then
         call this%routewaves(totfluxtot, delt, ietflag, icell, ierr)
-        if (ierr > 0) return
+        if (ierr > 0) then
+          if (reset_state) &
+            call this%wave_shift(thiswork, icell, 1, 0, 1, thiswork%nwavst(1), 1)
+          return
+        end if
         call this%uz_rise(icell, totfluxtot)
         this%totflux(icell) = totfluxtot
         if (this%ivertcon(icell) > 0) then
@@ -930,13 +934,13 @@ contains
     !
     ! -- no uz, clear waves
     if (thickold < DZERO) then
-      do iwav = 1, 6
+      do iwav = 1, this%nwavst(icell)
         this%uzthst(iwav, icell) = this%thtr(icell)
         this%uzdpst(iwav, icell) = DZERO
         this%uzspst(iwav, icell) = DZERO
         this%uzflst(iwav, icell) = DZERO
-        this%nwavst(icell) = 1
       end do
+      this%nwavst(icell) = 1
     end if
     idelt = 1
     do ik = 1, idelt
@@ -1159,11 +1163,11 @@ contains
         return
       end if
     else
-      this%uzdpst(this%nwavst, icell) = DZERO
-      this%uzflst(this%nwavst, icell) = &
-        this%vks(icell) * (((this%uzthst(this%nwavst, icell) - &
+      this%uzdpst(this%nwavst(icell), icell) = DZERO
+      this%uzflst(this%nwavst(icell), icell) = &
+        this%vks(icell) * (((this%uzthst(this%nwavst(icell), icell) - &
                              this%thtr(icell)) * thtsrinv)**this%eps(icell))
-      this%uzthst(this%nwavst, icell) = smoist
+      this%uzthst(this%nwavst(icell), icell) = smoist
       theta2 = this%uzthst(this%nwavst(icell) - 1, icell)
       flux2 = this%uzflst(this%nwavst(icell) - 1, icell)
       flux1 = this%uzflst(this%nwavst(icell), icell)
@@ -1401,6 +1405,7 @@ contains
     comp3 = theta1 - thtr
     if (comp2 < DEM15) flux2 = flux1 + DEM15
     if (abs(comp1) < DEM30) then
+      fhold = DEM30
       if (comp3 > DEM30) fhold = (comp3 * thsrinv)**eps
       if (fhold < DEM30) fhold = DEM30
       leadspeed = epsfksths * (fhold**eps_m1)
@@ -1642,6 +1647,12 @@ contains
           hcap = this%caph(icell, tho)
           thetaout = this%rate_et_z(icell, factor, fktho, hcap)
         end if
+        if (this%nwavst(icell) + 1 > this%nwav(icell)) then
+          !
+          ! -- too many waves error
+          ierr = 1
+          goto 500
+        end if
         if (this%uzthst(this%nwavst(icell), icell) - thetaout > &
             this%thtr(icell) + extwc1) then
           this%uzthst(this%nwavst(icell) + 1, icell) = &
@@ -1678,6 +1689,12 @@ contains
         !
         ! -- one wave below extinction depth
       else if (this%nwavst(icell) == 1) then
+        if (this%nwavst(icell) + 1 > this%nwav(icell)) then
+          !
+          ! -- too many waves error
+          ierr = 1
+          goto 500
+        end if
         if (ietflag == 2) then
           tho = this%uzthst(1, icell)
           fktho = this%uzflst(1, icell)
@@ -1750,6 +1767,12 @@ contains
             !
             ! -- create a wave at extinction depth
             if (abs(diff) > DEM5) then
+              if (this%nwavst(icell) + 1 > this%nwav(icell)) then
+                !
+                ! -- too many waves error
+                ierr = 1
+                goto 500
+              end if
               call this%wave_shift(this, icell, icell, -1, &
                                    this%nwavst(icell) + 1, j, -1)
               this%uzdpst(j, icell) = this%extdpuz(icell)


### PR DESCRIPTION
Five defects in the UZF Package kinematic wave and evapotranspiration routines, found while refactoring the package for #2909 and reported in #2910. They are fixed here rather than in that pull request so they can be reviewed against the current code and released independently of the refactor.

The significant one is in the trailing-wave routine, which indexed the wave arrays with `this%nwavst`, the wave count of every UZF cell, where it meant `this%nwavst(icell)`. That is a vector subscript rather than a single element, so it corrupted the wave train of the cell being solved. It compiles without a diagnostic and stays in bounds, so neither the compiler nor a bounds-checked build reports it. The branch is reached whenever applied infiltration decreases.

The remaining four are an uninitialized read in the wave speed routine, a write past the end of a cell's wave storage in the evapotranspiration routine, a reset that covered only the first six waves of a cell, and an input check that accepted NTRAILWAVES of 1 and then divided by zero.

Simulated results change. Of the 45 UZF, UZT and UZE autotest workspaces one differs: heads move by at most 1.2e-12 over a range of 2.4 to 99.9, while the largest UZF budget percent discrepancy falls from 4.9e-3 to 4e-6 because the corrupted wave train had been creating spurious unsaturated zone storage. Models in which the number of waves differs between UZF cells, which is typical where infiltration varies in space, are affected more than the test problems. The full test suite has the same pass and fail set as develop.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Closed issue #2910
- [x] Referenced issue or pull request #2909
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
