### PR TITLE
fix(apt): set the groundwater cell number for inactive features

### DIFF
--- a/autotest/test_gwt_mwt_inactive.py
+++ b/autotest/test_gwt_mwt_inactive.py
@@ -1,0 +1,195 @@
+"""
+Tests MWT budget output when every well is inactive in the first stress period.
+
+The GWF node number written to the advanced package budget was only assigned for
+active features, so an inactive feature wrote whatever the uninitialized local
+held. An idomain hole makes the node numbering reduced, so a stale node number is
+converted through the user-node lookup on output.
+
+Cases:
+  - mwt_inactive : all wells INACTIVE in period 1 and ACTIVE afterwards; the GWF
+                   budget entries must carry the connected cells in every period,
+                   with zero flow while the wells are inactive.
+"""
+
+import os
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = ["mwt_inactive"]
+
+nlay, nrow, ncol, nper = 3, 1, 5, 3
+well_cols = (1, 3)
+
+# user node numbers of the well connections, which are what the budget file holds
+expected_nodes = sorted(k * nrow * ncol + j + 1 for j in well_cols for k in range(nlay))
+
+
+def build_models(idx, test):
+    name = cases[idx]
+    gwfname, gwtname = "gwf_" + name, "gwt_" + name
+    botm = [-1.0, -2.0, -3.0]
+
+    # the idomain hole gives the model a reduced node numbering
+    idomain = np.ones((nlay, nrow, ncol), dtype=int)
+    idomain[nlay - 1, 0, 2] = 0
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
+    )
+    flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=nper, perioddata=[(10.0, 5, 1.0)] * nper
+    )
+
+    imsgwf = flopy.mf6.ModflowIms(
+        sim,
+        complexity="moderate",
+        outer_dvclose=1e-8,
+        inner_dvclose=1e-9,
+        linear_acceleration="bicgstab",
+        filename=f"{gwfname}.ims",
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True)
+    sim.register_ims_package(imsgwf, [gwfname])
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=1.0,
+        delc=1.0,
+        top=0.0,
+        botm=botm,
+        idomain=idomain,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=0.0)
+    flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=0, k=10.0)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=0, ss=1e-5, sy=0.1, transient={0: True})
+    flopy.mf6.ModflowGwfchd(
+        gwf,
+        stress_period_data=[
+            [(0, 0, 0), 0.0, 0.0],
+            [(0, 0, ncol - 1), 0.0, 0.0],
+        ],
+        auxiliary="CONCENTRATION",
+        pname="CHD-1",
+    )
+
+    packagedata, conndata, perdata = [], [], []
+    for iw, jcol in enumerate(well_cols):
+        packagedata.append([iw, 0.1, -3.0, 0.0, "THIEM", nlay])
+        for k in range(nlay):
+            conndata.append(
+                [
+                    iw,
+                    k,
+                    (k, 0, jcol),
+                    0.0 if k == 0 else -float(k),
+                    -float(k + 1),
+                    1.0,
+                    0.1,
+                ]
+            )
+        perdata.append([iw, "rate", -0.5])
+    flopy.mf6.ModflowGwfmaw(
+        gwf,
+        save_flows=True,
+        packagedata=packagedata,
+        connectiondata=conndata,
+        perioddata=perdata,
+        pname="MAW-1",
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=f"{gwfname}.cbc",
+        head_filerecord=f"{gwfname}.hds",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
+    gwt = flopy.mf6.ModflowGwt(sim, modelname=gwtname, save_flows=True)
+    imsgwt = flopy.mf6.ModflowIms(
+        sim,
+        complexity="moderate",
+        outer_dvclose=1e-8,
+        inner_dvclose=1e-9,
+        linear_acceleration="bicgstab",
+        filename=f"{gwtname}.ims",
+    )
+    sim.register_ims_package(imsgwt, [gwtname])
+    flopy.mf6.ModflowGwtdis(
+        gwt,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=1.0,
+        delc=1.0,
+        top=0.0,
+        botm=botm,
+        idomain=idomain,
+    )
+    flopy.mf6.ModflowGwtic(gwt, strt=100.0)
+    flopy.mf6.ModflowGwtmst(gwt, porosity=0.3)
+    flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM")
+    flopy.mf6.ModflowGwtdsp(gwt, alh=0.1, ath1=0.01)
+    flopy.mf6.ModflowGwtmwt(
+        gwt,
+        save_flows=True,
+        budget_filerecord=f"{gwtname}.mwt.bud",
+        concentration_filerecord=f"{gwtname}.mwt.bin",
+        packagedata=[(iw, 0.0) for iw in range(len(well_cols))],
+        mwtperioddata={
+            0: [(iw, "STATUS", "INACTIVE") for iw in range(len(well_cols))],
+            1: [(iw, "STATUS", "ACTIVE") for iw in range(len(well_cols))],
+        },
+        pname="MAW-1",
+    )
+    flopy.mf6.ModflowGwtssm(gwt, sources=[["CHD-1", "AUX", "CONCENTRATION"]])
+    flopy.mf6.ModflowGwtoc(
+        gwt,
+        budget_filerecord=f"{gwtname}.cbc",
+        concentration_filerecord=f"{gwtname}.ucn",
+        saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
+    )
+    flopy.mf6.ModflowGwfgwt(
+        sim,
+        exgtype="GWF6-GWT6",
+        exgmnamea=gwfname,
+        exgmnameb=gwtname,
+        filename=f"{name}.gwfgwt",
+    )
+    return sim, None
+
+
+def check_output(idx, test):
+    gwtname = "gwt_" + cases[idx]
+    fpth = os.path.join(test.workspace, f"{gwtname}.mwt.bud")
+    assert os.path.isfile(fpth)
+
+    cbc = flopy.utils.CellBudgetFile(fpth, precision="double")
+    for kstpkper in cbc.get_kstpkper():
+        rec = cbc.get_data(kstpkper=kstpkper, text="GWF")[0]
+        nodes = sorted(int(n) for n in rec["node2"])
+        assert nodes == expected_nodes, (
+            f"GWF budget nodes {nodes} at {kstpkper} do not match the well "
+            f"connections {expected_nodes}"
+        )
+        # the wells are inactive for the whole of the first stress period
+        if kstpkper[1] == 0:
+            assert np.allclose(rec["q"], 0.0), (
+                f"nonzero MWT-GWF flow {rec['q']} at {kstpkper} while inactive"
+            )
+
+
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -250,3 +250,8 @@ description = "The definition file sln-pts.dfn has been removed. It described an
 section = "fixes"
 subsection = "basic"
 description = "The script that builds the table of deprecations and removals for the release notes accumulated the deprecated and removed versions of a variable under two different keys, so a variable carrying both attributes lost its deprecation version and was reported as having been deprecated in the version in which it was removed. The table was correct until now only because every previous removal was made in the same version as its deprecation."
+
+[[items]]
+section = "fixes"
+subsection = "advanced"
+description = "The groundwater cell number written to the binary budget file for the GWF flow term of the advanced transport and energy transport packages, and for the lakebed and well-aquifer conduction terms of the Lake (LKE) and Multi-Aquifer Well (MWE) Energy Transport Packages, was only evaluated for features with an ACTIVE status. A feature with an INACTIVE status was written with the cell number left over from the last active feature, or with an undefined value if no feature had been active since the package was set up, which was the case when every feature was inactive in the first stress period. Budget entries for inactive features were therefore attributed to the wrong groundwater cell, and an undefined value could terminate the simulation with an out-of-bounds error in a model with a reduced node numbering, or be dropped from the budget file entirely. The cell number is now evaluated for every feature regardless of its status; the flow rate written for an inactive feature is zero, as before."

--- a/src/Model/GroundWaterEnergy/gwe-lke.f90
+++ b/src/Model/GroundWaterEnergy/gwe-lke.f90
@@ -685,8 +685,8 @@ contains
     do j = 1, this%flowbudptr%budterm(this%idxbudlbcd)%nlist
       q = DZERO
       n1 = this%flowbudptr%budterm(this%idxbudlbcd)%id1(j)
+      igwfnode = this%flowbudptr%budterm(this%idxbudlbcd)%id2(j)
       if (this%iboundpak(n1) /= 0) then
-        igwfnode = this%flowbudptr%budterm(this%idxbudlbcd)%id2(j)
         auxpos = this%flowbudptr%budterm(this%idxbudgwf)%naux ! for now there is only 1 aux variable under 'GWF'
         wa = this%flowbudptr%budterm(this%idxbudgwf)%auxvar(auxpos, j)
         ktf = this%ktf(n1)

--- a/src/Model/GroundWaterEnergy/gwe-mwe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-mwe.f90
@@ -598,8 +598,8 @@ contains
     do j = 1, this%flowbudptr%budterm(this%idxbudmwcd)%nlist
       q = DZERO
       n1 = this%flowbudptr%budterm(this%idxbudmwcd)%id1(j)
+      igwfnode = this%flowbudptr%budterm(this%idxbudmwcd)%id2(j)
       if (this%iboundpak(n1) /= 0) then
-        igwfnode = this%flowbudptr%budterm(this%idxbudmwcd)%id2(j)
         auxpos = this%flowbudptr%budterm(this%idxbudgwf)%naux
         wa = this%flowbudptr%budterm(this%idxbudgwf)%auxvar(auxpos, j)
         ktf = this%ktf(n1)

--- a/src/Model/TransportModel/tsp-apt.f90
+++ b/src/Model/TransportModel/tsp-apt.f90
@@ -2150,8 +2150,8 @@ contains
     do j = 1, this%flowbudptr%budterm(this%idxbudgwf)%nlist
       q = DZERO
       n1 = this%flowbudptr%budterm(this%idxbudgwf)%id1(j)
+      igwfnode = this%flowbudptr%budterm(this%idxbudgwf)%id2(j)
       if (this%iboundpak(n1) /= 0) then
-        igwfnode = this%flowbudptr%budterm(this%idxbudgwf)%id2(j)
         q = this%hcof(j) * x(igwfnode) - this%rhs(j)
         q = -q ! flip sign so relative to advanced package feature
       end if


### PR DESCRIPTION
The groundwater cell number written to the advanced package budget file was assigned only for features with an ACTIVE status, but was written for every feature, so an inactive feature was recorded against the cell of the last active feature. When every feature is inactive in the first stress period the cell number is undefined, which drops the entry from the budget file or terminates the simulation with an out-of-bounds error in a model with a reduced node numbering. The cell number is now assigned for every feature regardless of status, and the same pattern in the LKE and MWE conduction terms is fixed alongside it.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
