### PR TITLE
fix(sfr): make ats_courant argument mandatory

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
@@ -16,7 +16,7 @@ type double precision
 reader urword
 optional true
 longname target Courant number for adaptive time stepping
-description real number value that defines the target Courant number submitted by the SFR Package to the adaptive time stepping (ATS) package.  If ATS\_COURANT is specified without a value, the target Courant number defaults to 1.0.  If ATS\_COURANT is specified and the ATS Package is active, the SFR Package will compute the time step that achieves the target Courant number for the most constraining reach (the reach with the highest wave celerity-to-length ratio) and submit that time step to the ATS Package.  The STORAGE option must be active when ATS\_COURANT is specified.  ATS\_COURANT must be greater than zero.  A value of 1.0 targets unit Courant number; values between 0.5 and 2.0 are generally acceptable for kinematic wave routing.
+description real number value that defines the target Courant number submitted by the SFR Package to the adaptive time stepping (ATS) package.  If ATS\_COURANT is specified and the ATS Package is active, the SFR Package will compute the time step that achieves the target Courant number for the most constraining reach (the reach with the highest wave celerity-to-length ratio) and submit that time step to the ATS Package.  The STORAGE option must be active when ATS\_COURANT is specified.  ATS\_COURANT must be greater than zero.  A recommended baseline value is 1.0, which targets unit Courant number; values between 0.5 and 2.0 are generally acceptable for kinematic wave routing.
 
 block options
 name auxiliary

--- a/src/Model/GroundWaterFlow/gwf-sfr.f90
+++ b/src/Model/GroundWaterFlow/gwf-sfr.f90
@@ -758,11 +758,9 @@ contains
     character(len=*), intent(inout) :: option !< option keyword string
     logical(LGP), intent(inout) :: found !< boolean indicating if option found
     ! -- local
-    integer(I4B) :: istat
     real(DP) :: r
     character(len=MAXCHARLEN) :: fname
     character(len=MAXCHARLEN) :: keyword
-    character(len=:), allocatable :: remaining_line
     ! -- formats
     character(len=*), parameter :: fmttimeconv = &
       &"(4x, 'TIME CONVERSION VALUE (',g0,') SPECIFIED.')"
@@ -879,22 +877,17 @@ contains
       !    These options are only available when IDEVELOPMODE in
       !    constants module is set to 1
     case ('ATS_COURANT')
-      call this%parser%GetRemainingLine(remaining_line)
-      keyword = trim(adjustl(remaining_line))
-      if (len_trim(keyword) == 0) then
-        this%ats_courant = DONE
+      this%ats_courant = this%parser%GetDouble()
+      if (this%ats_courant <= DZERO) then
+        write (errmsg, '(a,g0,a)') &
+          "ATS_COURANT SPECIFIED TO BE '", this%ats_courant, &
+          "' BUT MUST BE GREATER THAN ZERO"
+        call store_error(errmsg)
       else
-        read (keyword, *, iostat=istat) this%ats_courant
-        if (istat /= 0 .or. this%ats_courant <= DZERO) then
-          write (errmsg, '(a,g0,a)') &
-            "ATS_COURANT SPECIFIED TO BE '", this%ats_courant, &
-            "' BUT MUST BE GREATER THAN ZERO"
-          call store_error(errmsg)
-        end if
+        write (this%iout, '(4x,a,1pg15.6)') &
+          'TARGET COURANT NUMBER FOR ADAPTIVE TIME STEPS: ', &
+          this%ats_courant
       end if
-      write (this%iout, '(4x,a,1pg15.6)') &
-        'TARGET COURANT NUMBER FOR ADAPTIVE TIME STEPS: ', &
-        this%ats_courant
     case ('DEV_NO_CHECK')
       call this%parser%DevOpt()
       this%icheck = 0


### PR DESCRIPTION
ATS_COURANT currently accepts an optional trailing value. If omitted, the target Courant number implicitly defaults to 1.0. This PR removes that special case and always requires an explicit value; the .dfn description is updated accordingly:
 - Not an existing pattern. Double options expect the keyword followed by a float.
 - Not currently supported by FloPy (see below).
 - Neccesitates IDM framework updates to tolerate when integrated

Example
```
ATS_COURANT with no trailing value:
BEGIN options
  STORAGE
  ATS_COURANT
END options
```
FloPy load:
```
>>> flopy.mf6.MFSimulation.load(sim_ws=ws)
...
MFDataException: An error occurred in data element "ats_courant" ...
(1) Error reading variable "ats_courant".  Expected data after label "ats_courant" not found
    at line "  ATS_COURANT".
```
FloPy write:
```
>>> flopy.mf6.ModflowGwfsfr(gwf, storage=True, ats_courant="", ...)
...
IndexError: list index out of range
```

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [definition files](/MODFLOW-ORG/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Updated [input and output guide](/MODFLOW-ORG/modflow6/doc/mf6io)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
