### PR TITLE
docs: remove unneeded release note, add 6.7.0 to appendix

### DIFF
--- a/doc/ReleaseNotes/appendixA.tex
+++ b/doc/ReleaseNotes/appendixA.tex
@@ -1,5 +1,6 @@
 This appendix describes changes introduced into MODFLOW~6 in previous releases. These changes may substantially affect users.
 
+        \input{./previous/v6.7.0.tex}
         \input{./previous/v6.6.3.tex}
         \input{./previous/v6.6.2.tex}
         \input{./previous/v6.6.1.tex}

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -243,11 +243,6 @@ description = "Six Iterative Model Solution (IMS) input variables that were depr
 
 [[items]]
 section = "fixes"
-subsection = "solution"
-description = "The definition file sln-pts.dfn has been removed. It described an Iterative Model Solution style input file for a particle tracking solution that was never implemented; no MODFLOW 6 solution reads it, and it was not included in the input and output guide. The Particle Tracking (PRT) model uses the Explicit Model Solution, which is defined by sln-ems.dfn and has no input variables of its own."
-
-[[items]]
-section = "fixes"
 subsection = "basic"
 description = "The script that builds the table of deprecations and removals for the release notes accumulated the deprecated and removed versions of a variable under two different keys, so a variable carrying both attributes lost its deprecation version and was reported as having been deprecated in the version in which it was removed. The table was correct until now only because every previous removal was made in the same version as its deprecation."
 


### PR DESCRIPTION
Fix issues found in release candidate review

* DFN file additions/removals haven't been mentioned in release notes before
* add the version 6.7.0 release notes to the appendix 