### PR TITLE
fix(prt): clamp particle to subcell

### DIFF
--- a/autotest/test_prt_clamp.py
+++ b/autotest/test_prt_clamp.py
@@ -3,9 +3,8 @@ These test cases exercise cell "snap" or "clamp" behavior in lateral and
 vertical dimensions. There is currently no distance limit; particles may
 begin arbitrarily far outside the cell.
 
-For rectilinear cells using Pollock's method, a particle will be snapped
-to the point within the cell nearest to its original point outside it: a
-"box clamp", in other words.
+For rectilinear cells using Pollock's method, a particle will be clamped
+to the point within the cell nearest to the point outside: a "box clamp".
 
 For cells using the generalized (ternary) tracking method, a particle is
 not guaranteed to end up at the nearest point within the cell.
@@ -29,8 +28,8 @@ DISTANCES = {
 METHODS = {"p": "pollock", "n": "ternary"}
 DIRECTIONS = {"": "x", "z": "z"}
 
-cases_nudge = [
-    (f"nudge{dircode}{mcode}{dcode}", method, offset, direction)
+cases = [
+    (f"{dircode}{mcode}{dcode}", method, offset, direction)
     for dircode, direction in DIRECTIONS.items()
     for mcode, method in METHODS.items()
     for dcode, offset in DISTANCES.items()
@@ -75,7 +74,7 @@ def build_gwf_sim_disv(name, ws, mf6):
     return sim
 
 
-def build_prt_sim_nudge(name, gwf_ws, prt_ws, mf6, method, offset, direction):
+def build_prt_sim(name, gwf_ws, prt_ws, mf6, method, offset, direction):
     gridprops = get_gridprops_rect()
 
     sim = flopy.mf6.MFSimulation(
@@ -141,9 +140,9 @@ def build_prt_sim_nudge(name, gwf_ws, prt_ws, mf6, method, offset, direction):
     return sim
 
 
-def build_models_nudge(test, method, offset, direction):
+def build_models(test, method, offset, direction):
     gwf_sim = build_gwf_sim_disv(test.name, test.workspace, test.targets["mf6"])
-    prt_sim = build_prt_sim_nudge(
+    prt_sim = build_prt_sim(
         test.name,
         test.workspace,
         test.workspace / "prt",
@@ -155,7 +154,7 @@ def build_models_nudge(test, method, offset, direction):
     return gwf_sim, prt_sim
 
 
-def check_output_nudge(test, offset, direction):
+def check_output(test, offset, direction):
     prt_name = get_model_name(test.name, "prt")
     prt_ws = test.workspace / "prt"
     mf6_pls = pd.read_csv(prt_ws / f"{prt_name}.trk.csv", na_filter=False)
@@ -172,7 +171,7 @@ def check_output_nudge(test, offset, direction):
         assert release["y"] == pytest.approx(9.5)
         assert release["z"] == pytest.approx(FlopyReadmeCase.botm[0] - offset)
 
-    # subsequent events should report the "snapped" coordinates
+    # subsequent events should report the clamped coordinates
     ncol = FlopyReadmeCase.ncol
     nrow = FlopyReadmeCase.nrow
     top = FlopyReadmeCase.top
@@ -185,13 +184,13 @@ def check_output_nudge(test, offset, direction):
     assert (mf6_pls["t"].diff().dropna() >= -1e-9).all()
 
 
-@pytest.mark.parametrize("name, method, offset, direction", cases_nudge)
-def test_mf6model_nudge(name, method, offset, direction, function_tmpdir, targets):
+@pytest.mark.parametrize("name, method, offset, direction", cases)
+def test_mf6model(name, method, offset, direction, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
-        build=lambda t: build_models_nudge(t, method, offset, direction),
-        check=lambda t: check_output_nudge(t, offset, direction),
+        build=lambda t: build_models(t, method, offset, direction),
+        check=lambda t: check_output(t, offset, direction),
         targets=targets,
         compare=None,
     )

--- a/autotest/test_prt_clamp.py
+++ b/autotest/test_prt_clamp.py
@@ -1,14 +1,5 @@
 """
-Subcell tracking methods "snap" particles to whichever (sub)cell they're
-assigned to. This is both a separation of concerns (the tracking methods
-can be kept smaller/simpler, avoiding redundant logic to cross-check the
-cell ID against the particle's coordinates) and a user-facing feature: a
-particle released close to a cell boundary may be determined invalid due
-to floating point imprecision, by default, so the user may choose to set
-COORDINATE_CHECK_METHOD NONE to tolerate particles ending up outside the
-cells they are assigned to. This is effectively a "snap to cell" feature.
-
-These test cases exercise this "snap" or "clamp" behavior in lateral and
+These test cases exercise cell "snap" or "clamp" behavior in lateral and
 vertical dimensions. There is currently no distance limit; particles may
 begin arbitrarily far outside the cell.
 

--- a/autotest/test_prt_clamp.py
+++ b/autotest/test_prt_clamp.py
@@ -1,0 +1,207 @@
+"""
+Subcell tracking methods "snap" particles to whichever (sub)cell they're
+assigned to. This is both a separation of concerns (the tracking methods
+can be kept smaller/simpler, avoiding redundant logic to cross-check the
+cell ID against the particle's coordinates) and a user-facing feature: a
+particle released close to a cell boundary may be determined invalid due
+to floating point imprecision, by default, so the user may choose to set
+COORDINATE_CHECK_METHOD NONE to tolerate particles ending up outside the
+cells they are assigned to. This is effectively a "snap to cell" feature.
+
+These test cases exercise this "snap" or "clamp" behavior in lateral and
+vertical dimensions. There is currently no distance limit; particles may
+begin arbitrarily far outside the cell.
+
+For rectilinear cells using Pollock's method, a particle will be snapped
+to the point within the cell nearest to its original point outside it: a
+"box clamp", in other words.
+
+For cells using the generalized (ternary) tracking method, a particle is
+not guaranteed to end up at the nearest point within the cell.
+"""
+
+import flopy
+import pandas as pd
+import pytest
+from flopy.utils.gridutil import get_disv_kwargs
+from framework import TestFramework
+from prt_test_utils import FlopyReadmeCase, get_model_name
+
+DISTANCES = {
+    # comparable to the padding clamp_bary() applies (DSAME * DEP3)
+    "t": 1e-7,
+    # a fraction of a cell width
+    "m": 0.4,
+    # several cells away, similar in scale to the mismatch case above
+    "f": 4.5,
+}
+METHODS = {"p": "pollock", "n": "ternary"}
+DIRECTIONS = {"": "x", "z": "z"}
+
+cases_nudge = [
+    (f"nudge{dircode}{mcode}{dcode}", method, offset, direction)
+    for dircode, direction in DIRECTIONS.items()
+    for mcode, method in METHODS.items()
+    for dcode, offset in DISTANCES.items()
+]
+
+
+def get_gridprops_rect():
+    return get_disv_kwargs(
+        nlay=FlopyReadmeCase.nlay,
+        nrow=FlopyReadmeCase.nrow,
+        ncol=FlopyReadmeCase.ncol,
+        delr=1.0,
+        delc=1.0,
+        tp=FlopyReadmeCase.top,
+        botm=FlopyReadmeCase.botm,
+    )
+
+
+def build_gwf_sim_disv(name, ws, mf6):
+    gridprops = get_gridprops_rect()
+
+    sim = flopy.mf6.MFSimulation(sim_name=name, exe_name=mf6, version="mf6", sim_ws=ws)
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=1, perioddata=[(1.0, 1, 1.0)])
+
+    gwfname = get_model_name(name, "gwf")
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True)
+    flopy.mf6.ModflowGwfdisv(gwf, **gridprops)
+    flopy.mf6.ModflowGwfnpf(gwf, save_specific_discharge=True, save_saturation=True)
+    flopy.mf6.ModflowGwfic(gwf, strt=FlopyReadmeCase.top)
+
+    ncpl = gridprops["ncpl"]
+    chd_data = [[(0, 0), FlopyReadmeCase.top], [(0, ncpl - 1), 0.0]]
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd_data)
+
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=f"{gwfname}.bud",
+        head_filerecord=f"{gwfname}.hds",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+    flopy.mf6.ModflowIms(sim)
+    return sim
+
+
+def build_prt_sim_nudge(name, gwf_ws, prt_ws, mf6, method, offset, direction):
+    gridprops = get_gridprops_rect()
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, exe_name=mf6, version="mf6", sim_ws=prt_ws
+    )
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=1, perioddata=[(1.0, 1, 1.0)])
+
+    prt_name = get_model_name(name, "prt")
+    prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name)
+    flopy.mf6.ModflowPrtdisv(prt, **gridprops)
+    flopy.mf6.ModflowPrtmip(prt, porosity=FlopyReadmeCase.porosity)
+
+    if direction == "x":
+        release_x = 1.0 + offset
+        release_y = 9.5
+        release_z = 0.5
+    else:
+        release_x = 0.5
+        release_y = 9.5
+        release_z = FlopyReadmeCase.botm[0] - offset
+    releasepts = [[0, (0, 0), release_x, release_y, release_z]]
+
+    prp_track_file = f"{prt_name}.prp.trk"
+    prp_track_csv_file = f"{prt_name}.prp.trk.csv"
+    flopy.mf6.ModflowPrtprp(
+        prt,
+        pname="prp1",
+        filename=f"{prt_name}_1.prp",
+        nreleasepts=len(releasepts),
+        packagedata=releasepts,
+        perioddata={0: [("FIRST",)]},
+        track_filerecord=[prp_track_file],
+        trackcsv_filerecord=[prp_track_csv_file],
+        coordinate_check_method="none",
+        dev_forceternary=method == "ternary",
+        print_input=True,
+        extend_tracking=True,
+    )
+
+    prt_track_file = f"{prt_name}.trk"
+    prt_track_csv_file = f"{prt_name}.trk.csv"
+    flopy.mf6.ModflowPrtoc(
+        prt,
+        pname="oc",
+        track_filerecord=[prt_track_file],
+        trackcsv_filerecord=[prt_track_csv_file],
+    )
+
+    gwf_name = get_model_name(name, "gwf")
+    gwf_budget_file = gwf_ws / f"{gwf_name}.bud"
+    gwf_head_file = gwf_ws / f"{gwf_name}.hds"
+    flopy.mf6.ModflowPrtfmi(
+        prt,
+        packagedata=[
+            ("GWFHEAD", gwf_head_file),
+            ("GWFBUDGET", gwf_budget_file),
+        ],
+    )
+
+    ems = flopy.mf6.ModflowEms(sim, pname="ems", filename=f"{prt_name}.ems")
+    sim.register_solution_package(ems, [prt.name])
+
+    return sim
+
+
+def build_models_nudge(test, method, offset, direction):
+    gwf_sim = build_gwf_sim_disv(test.name, test.workspace, test.targets["mf6"])
+    prt_sim = build_prt_sim_nudge(
+        test.name,
+        test.workspace,
+        test.workspace / "prt",
+        test.targets["mf6"],
+        method,
+        offset,
+        direction,
+    )
+    return gwf_sim, prt_sim
+
+
+def check_output_nudge(test, offset, direction):
+    prt_name = get_model_name(test.name, "prt")
+    prt_ws = test.workspace / "prt"
+    mf6_pls = pd.read_csv(prt_ws / f"{prt_name}.trk.csv", na_filter=False)
+
+    assert len(mf6_pls) > 1
+
+    # the release event should report the raw release coordinates
+    release = mf6_pls.iloc[0]
+    if direction == "x":
+        assert release["x"] == pytest.approx(1.0 + offset)
+        assert release["y"] == pytest.approx(9.5)
+    else:
+        assert release["x"] == pytest.approx(0.5)
+        assert release["y"] == pytest.approx(9.5)
+        assert release["z"] == pytest.approx(FlopyReadmeCase.botm[0] - offset)
+
+    # subsequent events should report the "snapped" coordinates
+    ncol = FlopyReadmeCase.ncol
+    nrow = FlopyReadmeCase.nrow
+    top = FlopyReadmeCase.top
+    tracking = mf6_pls.iloc[1:]
+    assert tracking["x"].between(-1e-6, ncol + 1e-6).all()
+    assert tracking["y"].between(-1e-6, nrow + 1e-6).all()
+    assert tracking["z"].between(-1e-6, top + 1e-6).all()
+
+    # time should never decrease (texit should never be negative)
+    assert (mf6_pls["t"].diff().dropna() >= -1e-9).all()
+
+
+@pytest.mark.parametrize("name, method, offset, direction", cases_nudge)
+def test_mf6model_nudge(name, method, offset, direction, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models_nudge(t, method, offset, direction),
+        check=lambda t: check_output_nudge(t, offset, direction),
+        targets=targets,
+        compare=None,
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.toml
+++ b/doc/ReleaseNotes/develop.toml
@@ -253,5 +253,10 @@ description = "The groundwater cell number written to the binary budget file for
 
 [[items]]
 section = "fixes"
-subsection = "advanced"
+subsection = "model"
 description = "The PRT model's Particle Release Point (PRP) package performs release point validation using a point-in-polygon test that compares raw coordinates for exact floating point equality. This could incorrectly flag points close to a cell boundary as outside the cell, especially for rotated cells or cells with very large coordinate values. Add a small tolerance to the containment check, scaled to the cell's extent, to reduce the odds that a point will fail the check due to numerical inexactness."
+
+[[items]]
+section = "fixes"
+subsection = "model"
+description = "The PRT model did not consistently clamp particle coordinates to the extent of the cell before applying the tracking method. This could cause an incorrect exit face or travel time solution, for example due to roundoff in the coordinate transformations computed as the particle moves between cells. This has been corrected; coordinates will now be clamped to the cell boundary in all dimensions. Results may change slightly for models with particle positions lying close to cell boundaries."

--- a/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
@@ -79,6 +79,15 @@ contains
       sinrot = subcell%sinrot
       cosrot = subcell%cosrot
       call particle%transform(x_origin, y_origin)
+
+      ! Clamp the particle into the subcell in case roundoff in the
+      ! model-to-local coordinate transform (e.g. under grid rotation)
+      ! left it just outside, analogous to the nudge applied to the
+      ! ternary method's barycentric coordinates.
+      particle%x = min(max(particle%x, DZERO), subcell%dx)
+      particle%y = min(max(particle%y, DZERO), subcell%dy)
+      particle%z = min(max(particle%z, DZERO), subcell%dz)
+
       call this%track_subcell(subcell, particle, tmax)
       call particle%transform(x_origin, y_origin, invert=.true.)
     end select
@@ -109,7 +118,8 @@ contains
 
     t0 = particle%ttrack
 
-    ! Find exit solution in each direction
+    ! Find exit solution in each direction; also returns the
+    ! local subcell coordinates used, so we don't recompute them
     call find_exits(particle, subcell, exit_solutions, x0, y0, z0)
     exit_x = exit_solutions(1)
     exit_y = exit_solutions(2)
@@ -257,6 +267,11 @@ contains
   end function pick_exit
 
   !> @brief Compute candidate exit solutions
+  !!
+  !! Also returns the local subcell coordinates used (x0, y0, z0),
+  !! so track_subcell doesn't need to recompute them from the
+  !! particle's position.
+  !<
   subroutine find_exits(particle, domain, exit_solutions, x0, y0, z0)
     type(ParticleType), pointer, intent(inout) :: particle
     class(DomainType), intent(in) :: domain

--- a/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellPollock.f90
@@ -63,7 +63,6 @@ contains
     ! local
     real(DP) :: x_origin
     real(DP) :: y_origin
-    real(DP) :: z_origin
     real(DP) :: sinrot
     real(DP) :: cosrot
 
@@ -72,10 +71,11 @@ contains
       ! Transform particle position into local subcell coordinates,
       ! track particle across subcell, convert back to model coords
       ! (sinrot and cosrot should be 0 and 1, respectively, i.e. no
-      ! rotation, also no z translation; only x and y translations)
+      ! rotation, also no z translation; only x and y translations,
+      ! since subcell%zOrigin is always 0 -- z is translated once,
+      ! at the cell level, not again here)
       x_origin = subcell%xOrigin
       y_origin = subcell%yOrigin
-      z_origin = subcell%zOrigin
       sinrot = subcell%sinrot
       cosrot = subcell%cosrot
       call particle%transform(x_origin, y_origin)

--- a/src/Solution/ParticleTracker/Method/MethodSubcellTernary.f90
+++ b/src/Solution/ParticleTracker/Method/MethodSubcellTernary.f90
@@ -108,10 +108,12 @@ contains
       isolv = particle%iexmeth
     end if
     t0 = particle%ttrack
-    z0 = particle%z
 
-    ! Find exit solutions in lateral and vertical directions
-    call find_exits(particle, subcell, exit_solutions)
+    ! Find exit solutions in lateral and vertical directions. z0 comes
+    ! back clamped to [zbot, ztop] (mirroring the nudge clamp_bary applies
+    ! to the lateral coordinates), so it can safely anchor the position
+    ! update even if the raw particle%z lies outside the subcell.
+    call find_exits(particle, subcell, exit_solutions, z0)
 
     exit_z = exit_solutions(1)
     exit_lateral = exit_solutions(2)
@@ -222,10 +224,11 @@ contains
   end function pick_exit
 
   !> @brief Calculate exit solutions for each coordinate direction
-  subroutine find_exits(particle, domain, exit_solutions)
+  subroutine find_exits(particle, domain, exit_solutions, z0)
     type(ParticleType), pointer, intent(inout) :: particle
     class(DomainType), intent(in) :: domain
     type(BarycentricExitSolutionType), intent(out) :: exit_solutions(2)
+    real(DP), intent(out) :: z0
     ! local
     integer(I4B) :: ntmax
     real(DP) :: tol
@@ -288,13 +291,16 @@ contains
 
       ! Do calculations related to the analytical z solution.
       ! (TODO: just once for each cell? store at cell-level?)
-      ! Clamp the relative z coordinate to the unit interval.
+      ! Clamp the relative z coordinate to the unit interval, and nudge
+      ! the particle's z ever so slightly inside the subcell if needed,
+      ! analogous to the lateral clamp_bary nudge above.
       zirel = (particle%z - subcell%zbot) / subcell%dz
       if (zirel > DONE) then
         zirel = DONE
       else if (zirel < DZERO) then
         zirel = DZERO
       end if
+      z0 = subcell%zbot + zirel * subcell%dz
       exit_solutions(1) = find_vertical_exit(subcell%vzbot, subcell%vztop, &
                                              subcell%dz, zirel)
 


### PR DESCRIPTION
The PRT model did not consistently clamp particle coordinates to the extent of the cell before applying the tracking method. This could cause an incorrect exit face or travel time solution, for example due to roundoff in the coordinate transformations computed as the particle moves between cells. Coordinates will now be clamped to the cell boundary in all dimensions. Results may change slightly for models with particle positions lying close to cell boundaries.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.toml](/MODFLOW-ORG/modflow6/doc/ReleaseNotes/develop.toml) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request