### PR TITLE
docs(hfb): describe the barrier adjacency check as it now behaves

### DIFF
--- a/autotest/test_gwf_vhfb.py
+++ b/autotest/test_gwf_vhfb.py
@@ -1,6 +1,15 @@
 """
-Test the dependent_variable_scale option for gwt for a one-dimensional model grid
-of square cells.
+Tests a vertical hydraulic flow barrier against the vertical hydraulic
+conductivity that represents the same resistance.
+
+A barrier is placed on every connection between the two layers of an 11 by 11
+grid, and the heads are compared against a model in which that resistance is
+entered as vertical hydraulic conductivity instead.
+
+Cases:
+  - vhfb00, vhfb01 : standard conductance, without and with Newton.
+  - vhfb02, vhfb03 : XT3D, without and with Newton.
+  - vhfb04, vhfb05 : logarithmic cell averaging, without and with Newton.
 """
 
 import flopy

--- a/src/Model/GroundWaterFlow/gwf-hfb.f90
+++ b/src/Model/GroundWaterFlow/gwf-hfb.f90
@@ -711,8 +711,6 @@ contains
     ! -- formats
     character(len=*), parameter :: fmterr = "(1x, 'HFB no. ',i0, &
       &' is between two unconnected cells: ', a, ' and ', a)"
-    character(len=*), parameter :: fmtverr = "(1x, 'HFB no. ',i0, &
-      &' is between two cells not horizontally connected: ', a, ' and ', a)"
     !
     do ihfb = 1, this%nhfb
       n = this%noden(ihfb)


### PR DESCRIPTION
Vertical flow barriers were added in #2443, and the check that a barrier lies between two cells has since tested adjacency rather than horizontal adjacency. The error format for a barrier between cells that are not horizontally connected has not been raised since then and is removed, and the test of a vertical barrier is given a docstring for the model it builds rather than the one it was copied from.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #2443
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
