### PR TITLE
test(prt): mark test_prt_clamp.py developmode

### DIFF
--- a/autotest/test_prt_clamp.py
+++ b/autotest/test_prt_clamp.py
@@ -184,6 +184,7 @@ def check_output(test, offset, direction):
     assert (mf6_pls["t"].diff().dropna() >= -1e-9).all()
 
 
+@pytest.mark.developmode
 @pytest.mark.parametrize("name, method, offset, direction", cases)
 def test_mf6model(name, method, offset, direction, function_tmpdir, targets):
     test = TestFramework(


### PR DESCRIPTION
This test uses the `dev_forceternary` option so must be marked `developmode`