### PR TITLE
fix(test): stop FeatureFlags unit test from terminating the process

### DIFF
--- a/autotest/TestFeatureFlags.f90
+++ b/autotest/TestFeatureFlags.f90
@@ -1,7 +1,6 @@
 module TestFeatureFlags
   use testdrive, only: error_type, unittest_type, new_unittest, check
-  use FeatureFlagsModule, only: developmode
-  use ConstantsModule, only: LINELENGTH
+  use FeatureFlagsModule, only: is_release_mode
   use VersionModule, only: IDEVELOPMODE
 
   implicit none
@@ -13,16 +12,13 @@ contains
   subroutine collect_feature_flags(testsuite)
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
     testsuite = [ &
-                ! expect failure if in release mode, otherwise pass
-                new_unittest("developmode", test_developmode, &
-                             should_fail=(IDEVELOPMODE == 0)) &
+                new_unittest("is_release_mode", test_is_release_mode) &
                 ]
   end subroutine collect_feature_flags
 
-  subroutine test_developmode(error)
+  subroutine test_is_release_mode(error)
     type(error_type), allocatable, intent(out) :: error
-    character(len=LINELENGTH) :: errmsg
-    call developmode(errmsg)
-  end subroutine test_developmode
+    call check(error, is_release_mode() .eqv. (IDEVELOPMODE == 0))
+  end subroutine test_is_release_mode
 
 end module TestFeatureFlags

--- a/src/Utilities/FeatureFlags.f90
+++ b/src/Utilities/FeatureFlags.f90
@@ -5,9 +5,14 @@ module FeatureFlagsModule
   use SimModule, only: store_error, store_error_unit
   implicit none
   private
-  public :: developmode
+  public :: developmode, is_release_mode
 
 contains
+
+  !> @brief True if development features should be disabled
+  pure logical function is_release_mode()
+    is_release_mode = (IDEVELOPMODE == 0)
+  end function is_release_mode
 
   !> @brief Terminate if in release mode (guard development features)
   !!
@@ -23,7 +28,7 @@ contains
     integer(I4B), intent(in), optional :: iunit
 
     ! -- store error and terminate if in release mode
-    if (IDEVELOPMODE == 0) then
+    if (is_release_mode()) then
       if (present(iunit)) then
         call store_error(errmsg, terminate=.false.)
         call store_error_unit(iunit, terminate=.true.)


### PR DESCRIPTION
`developmode()` calls `store_error(..., terminate=.true.)` in release mode, which hard-exits. We were testing this directly with testdrive's `should_fail`, but `should_fail` can't survive a process exit. Extract a function `is_release_mode()` for the feature flag mechanism to use and test that directly instead of invoking the terminating path.