### PR TITLE
fix(TimeSeriesManager): check hash table associated before using it

### DIFF
--- a/autotest/test_gwf_errors.py
+++ b/autotest/test_gwf_errors.py
@@ -314,6 +314,68 @@ def test_wel_options_error_file(function_tmpdir, targets):
     assert "test.ghb" not in output
 
 
+def test_lak_packagedata_bad_aux_error_no_crash(function_tmpdir, targets):
+    """A LAK PACKAGEDATA aux value that is neither numeric nor a defined
+    time-series name must be reported as a normal input error, not crash.
+
+    read_value_or_time_series_adv() falls back to treating a non-numeric
+    aux token as a time-series name and looks it up via
+    TimeSeriesManager%get_time_series(). That function's BndTsHashTable is
+    only allocated when the simulation has at least one TS6 file
+    (tsmanager_df() calls HashBndTimeSeries() only if numtsfiles > 0), so
+    with none present here, the hash table pointer stays unassociated. Before
+    the fix, get_time_series() dereferenced it unconditionally and crashed
+    with SIGSEGV instead of falling through to the intended
+    "Expected numeric value or time-series name" error.
+
+    A caller ending up with a non-numeric aux value like this is easy in
+    practice: e.g. mis-ordering a packagedata row so a boundname lands in
+    the aux position (aux is written before boundname in PACKAGEDATA).
+    """
+    mf6 = targets["mf6"]
+
+    sim = get_minimal_gwf_simulation(str(function_tmpdir), exe=mf6)
+    gwf = sim.get_model("test")
+    flopy.mf6.ModflowGwflak(
+        gwf,
+        auxiliary=["concentration"],
+        boundnames=True,
+        nlakes=1,
+        noutlets=0,
+        packagedata=[(0, -0.4, 1, 0.0, "mylake")],
+        connectiondata=[(0, 0, (0, 0, 1), "VERTICAL", 0.0, 10.0, 10.0, 0.5, 0.5)],
+    )
+    sim.write_simulation()
+
+    # rewrite the PACKAGEDATA row with aux and boundname swapped -- "mylake"
+    # (not numeric, not a TS6 name) ends up in the aux column. No TS6 files
+    # are referenced anywhere in this simulation, so BndTsHashTable is never
+    # allocated.
+    lak_file = function_tmpdir / "test.lak"
+    lines = lak_file.read_text().splitlines(keepends=True)
+    in_packagedata = False
+    for i, line in enumerate(lines):
+        stripped = line.strip().lower()
+        if stripped.startswith("begin packagedata"):
+            in_packagedata = True
+            continue
+        if stripped.startswith("end packagedata"):
+            break
+        if in_packagedata and stripped:
+            lines[i] = "  1  -0.4  1  mylake  100.0\n"
+    lak_file.write_text("".join(lines))
+
+    returncode, buff = run_mf6([mf6], str(function_tmpdir))
+    output = "\n".join(buff)
+
+    assert returncode != 0, "mf6 should have failed on a non-numeric LAK aux value"
+    assert "SIGSEGV" not in output, f"mf6 crashed instead of reporting an error:\n{output}"
+    # mf6 wraps this message across lines, so check the two halves separately
+    assert "Expected numeric value or time-series name, but" in output, output
+    assert "found 'mylake'." in output, output
+    assert "Error occurred while reading file 'test.lak'" in output
+
+
 def test_solver_fail(function_tmpdir, targets):
     mf6 = targets["mf6"]
 

--- a/autotest/test_gwf_errors.py
+++ b/autotest/test_gwf_errors.py
@@ -369,7 +369,9 @@ def test_lak_packagedata_bad_aux_error_no_crash(function_tmpdir, targets):
     output = "\n".join(buff)
 
     assert returncode != 0, "mf6 should have failed on a non-numeric LAK aux value"
-    assert "SIGSEGV" not in output, f"mf6 crashed instead of reporting an error:\n{output}"
+    assert "SIGSEGV" not in output, (
+        f"mf6 crashed instead of reporting an error:\n{output}"
+    )
     # mf6 wraps this message across lines, so check the two halves separately
     assert "Expected numeric value or time-series name, but" in output, output
     assert "found 'mylake'." in output, output

--- a/src/Utilities/Sim.f90
+++ b/src/Utilities/Sim.f90
@@ -181,7 +181,7 @@ contains
     end if
     !
     ! -- store error unit
-    inquire (unit=iunit, name=fname)
+    call get_filename(iunit, fname)
     write (errmsg, '(3a)') &
       "Error occurred while reading file '", trim(adjustl(fname)), "'"
     call sim_uniterrors%store(errmsg)

--- a/src/Utilities/TimeSeries/TimeSeriesManager.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesManager.f90
@@ -463,11 +463,10 @@ contains
     ! Get index from hash table, get time series from TsContainers,
     !     and assign result to time series contained in link.
     res => null()
-    if (associated(this%BndTsHashTable)) then
-      indx = this%BndTsHashTable%get(name)
-      if (indx > 0) then
-        res => this%TsContainers(indx)%timeSeries
-      end if
+    if (.not. associated(this%BndTsHashTable)) return
+    indx = this%BndTsHashTable%get(name)
+    if (indx > 0) then
+      res => this%TsContainers(indx)%timeSeries
     end if
   end function get_time_series
 

--- a/src/Utilities/TimeSeries/TimeSeriesManager.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesManager.f90
@@ -463,9 +463,11 @@ contains
     ! Get index from hash table, get time series from TsContainers,
     !     and assign result to time series contained in link.
     res => null()
-    indx = this%BndTsHashTable%get(name)
-    if (indx > 0) then
-      res => this%TsContainers(indx)%timeSeries
+    if (associated(this%BndTsHashTable)) then
+      indx = this%BndTsHashTable%get(name)
+      if (indx > 0) then
+        res => this%TsContainers(indx)%timeSeries
+      end if
     end if
   end function get_time_series
 


### PR DESCRIPTION
If a value that can be a number or a timeseries name fails to parse in a simulation with no timeseries, an unassociated hash table will be dereferenced as a null pointer and MF6 will crash instead of falling through to the intended "Expected numeric value or time-series name, but found ..." error. The hash table is only allocated if the simulation has any time series files. Guard its use with an `associated()` check, matching the existing pattern in the `GetLink()` function.

Also use `get_filename` in `get_time_series` for consistent cross-platform file path handling.