### PR TITLE
fix(sim):  initialize get_filename ipos variable

### DIFF
--- a/src/Utilities/Sim.f90
+++ b/src/Utilities/Sim.f90
@@ -130,6 +130,7 @@ contains
     integer(I4B) :: ilen
     !
     ! -- get file name from unit number
+    ipos = 0
     inquire (unit=iunit, name=fname)
     !
     ! -- determine the operating system


### PR DESCRIPTION
Initialize ipos in get_filename to avoid reading it uninitialized on Windows

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-ORG/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-ORG/modflow6/.github/DEVELOPER.md).
