### PR TITLE
chore(release): update release history

### DIFF
--- a/distribution/README.md
+++ b/distribution/README.md
@@ -184,7 +184,11 @@ This is the approved USGS MODFLOW <semver> release.
 Visit the USGS "MODFLOW and Related Programs" site for information on MODFLOW 6 and related software: https://doi.org/10.5066/F76Q1VQV
 ```
 
-Update the DOI link in the citation if necessary. The DOI on the last line is the original and stays the same.
+The citation string can be rendered with `pixi run update-version -c`. Pass the
+release DOI link via `--doi` (`-d`), e.g.
+`pixi run update-version -c -d https://doi.org/10.5066/P1PGE9XW`; without it the
+umbrella MODFLOW software DOI is used. The DOI on the last line is the original
+and stays the same.
 
 Publish the release.
 

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -128,8 +128,17 @@ def get_disclaimer(developmode: bool = False, formatted: bool = False) -> str:
     return _approved_fmtdisclaimer if formatted else _approved_disclaimer
 
 
+# Umbrella DOI for the "MODFLOW and Related Programs" software release page.
+# Used as the software citation DOI when a release-specific one isn't passed
+# via --doi.
+_default_doi = "https://doi.org/10.5066/F76Q1VQV"
+
+
 def get_software_citation(
-    timestamp: datetime, version: Version, developmode: bool = False
+    timestamp: datetime,
+    version: Version,
+    doi: str = _default_doi,
+    developmode: bool = False,
 ) -> str:
     # get data Software/Code citation for FloPy
     citation = yaml.safe_load((project_root_path / "CITATION.cff").read_text())
@@ -163,7 +172,7 @@ def get_software_citation(
         f", {timestamp.year}, "
         f"MODFLOW 6 Modular Hydrologic Model version {version}: "
         f"U.S. Geological Survey Software Release, {timestamp:%-d %B %Y}, "
-        "https://doi.org/10.5066/P9FL1JCC"
+        f"{doi}"
     )
 
     return line
@@ -454,7 +463,10 @@ The version number is read from version.txt in the project root.
 Use `--releasemode` to control whether IDEVELOPMODE is set to 0 instead
 of 1, and to alter mf6's output and disclaimer text reflecting approval.
 
-Use `--citation` (`-c`) to render the current software citation.
+Use `--citation` (`-c`) to render the current software citation. Pass the
+release DOI link via `--doi` (`-d`), e.g.
+`--doi https://doi.org/10.5066/P1PGE9XW`; if omitted, the umbrella MODFLOW
+software DOI is used.
             """
         ),
     )
@@ -471,6 +483,15 @@ Use `--citation` (`-c`) to render the current software citation.
         required=False,
         action="store_true",
         help="Show the version, don't update anything. Defaults to false",
+    )
+    parser.add_argument(
+        "-d",
+        "--doi",
+        required=False,
+        default=_default_doi,
+        help="DOI link (e.g. https://doi.org/10.5066/P1PGE9XW) to substitute "
+        "into the software citation rendered by --citation. Defaults to the "
+        f"umbrella MODFLOW software DOI ({_default_doi}).",
     )
     parser.add_argument(
         "-a",
@@ -499,7 +520,10 @@ Use `--citation` (`-c`) to render the current software citation.
     elif citation:
         print(
             get_software_citation(
-                timestamp=datetime.now(), version=version, developmode=developmode
+                timestamp=datetime.now(),
+                version=version,
+                doi=args.doi,
+                developmode=developmode,
             )
         )
     else:

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -184,7 +184,7 @@ A list of all previous MODFLOW 6 releases is shown in table \ref{tab:releases}. 
 6.6.1 & February 7, 2025 & \url{https://doi.org/10.5066/P1DXFBUR} \\
 6.6.2 & May 12, 2025 & \url{https://doi.org/10.5066/P1DXFBUR} \\
 6.6.3 & September 29, 2025 & \url{https://doi.org/10.5066/P1DXFBUR} \\
-6.7.0 & February 5, 2026 & \url{https://doi.org/10.5066/P1IJAXDZ} \\
+6.7.0 & February 6, 2026 & \url{https://doi.org/10.5066/P1IJAXDZ} \\
 6.8.0 & September 2, 2026 & \url{https://doi.org/10.5066/P1PGE9XW} \\
 \hline
 \label{tab:releases}

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -185,6 +185,7 @@ A list of all previous MODFLOW 6 releases is shown in table \ref{tab:releases}. 
 6.6.2 & May 12, 2025 & \url{https://doi.org/10.5066/P1DXFBUR} \\
 6.6.3 & September 29, 2025 & \url{https://doi.org/10.5066/P1DXFBUR} \\
 6.7.0 & February 5, 2026 & \url{https://doi.org/10.5066/P1IJAXDZ} \\
+6.8.0 & September 2, 2026 & \url{https://doi.org/10.5066/P1PGE9XW} \\
 \hline
 \label{tab:releases}
 \end{tabular*}


### PR DESCRIPTION
Add a new entry for 6.8.0 to the release notes, fix the date for 6.7.0, and add a `--doi` parameter to `update_version.py` so a new DOI can be substituted into the citation generated with `-c`