### PR TITLE
ci(release): automate post-release tasks

### DIFF
--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   set_options:
     name: Set release options
-    if: github.ref_name != 'master'
+    if: github.event_name != 'release' && github.ref_name != 'master'
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -284,3 +284,79 @@ jobs:
           Visit the USGS "MODFLOW and Related Programs" site for information on MODFLOW 6 and related software: https://doi.org/10.5066/F76Q1VQV
           '
           gh release create "$version" ../mf*/mf*.zip ../release_notes/release.pdf --target master --title "$title" --notes "$notes" --draft --latest
+
+  reset:
+    name: Reset develop
+    # runs after a release is published. opens a PR to merge master back
+    # into develop with the version string updated for the next cycle
+    if: github.event_name == 'release'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Checkout modflow6
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.repository_owner }}/modflow6
+          ref: master
+          fetch-depth: 0
+
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v3
+        with:
+          environment-file: environment.yml
+          cache-downloads: true
+          cache-environment: true
+
+      - name: Archive release notes
+        working-directory: doc/ReleaseNotes
+        run: |
+          # the released version, since we branched from master (and this runs
+          # before the version bump below)
+          ver=$(cat ../../version.txt)
+
+          # a non-zero patch number means a patch release: archive and clear
+          # only the fix items, the rest carry to the next minor release
+          patch=""
+          [ "$(echo "$ver" | cut -d. -f3)" != "0" ] && patch="--patch"
+
+          # archive this version's notes to previous/v$ver.tex, register them
+          # in appendixA.tex, and clear the archived items from develop.toml
+          python reset_releasenotes.py $patch
+
+      - name: Update version and open PR
+        working-directory: distribution
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # the released version, since we branched from master
+          ver=$(cat ../version.txt)
+          branch="post-release-$ver-reset"
+
+          # bump minor and add '.dev0' suffix
+          next=$(python update_version.py --post-release)
+
+          # lint the generated source
+          fprettify -c ../.fprettify.yaml ../src/Utilities/version.f90
+
+          # commit and push
+          git config core.sharedRepository true
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add -A
+          git commit -m "ci(release): update version to $next, archive release notes"
+          git push origin "$branch"
+
+          # create PR
+          body='
+          # Reset `develop` after release '$ver'
+
+          Merge (do not squash) this pull request to bring `master` back into `develop`,
+          set the development version to `'$next'`, and archive the `'$ver'` release notes.
+          '
+          gh pr create -B "develop" -H "$branch" --title "Post release $ver reset" --body "$body"

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -194,38 +194,7 @@ Publish the release.
 
 ### Reset the develop branch
 
-Make a new branch from `master`:
-
-```shell
-git checkout master
-git switch -c post-6.x.y-release-reset
-```
-
-#### Update version strings
-
-Update the version number for the next development cycle:
-
-```shell
-pixi run update-version -v 6.x.y.dev0
-```
-
-This will substitute the new version number into the necessary files and set `IDEVELOPMODE` back to 1.
-
-#### Archive release notes
-
-Generate LaTeX for archiving this version's release notes.
-
-```shell
-pixi run make-release-notes --archive
-```
-
-Move/rename the generated `develop.tex` to `doc/ReleaseNotes/previous/vx.y.z.tex` (where `x.y.z` is the version just released), then insert a new line `\input{./previous/vx.y.z.tex}` at the top of `doc/ReleaseNotes/appendixA.tex`.
-
-**Note**: in `--archive` mode the version and date in the `\subsection{Version mf...}` header are taken from the last row of the Release History table in `ReleaseNotes.tex`, which should have been added as a pre-release step (see the note under [Review release notes](#review-release-notes)).
-
-Then reset `doc/ReleaseNotes/develop.toml` for the next development cycle by removing every `[[items]]` entry. Keep the `[sections]` and `[subsections]` tables intact &mdash; clear only the `[[items]]`. For a minor release, remove all items. For a patch release, remove only the fix items that the release included; the rest carry forward to the next minor release.
-
-Create and merge (don't squash) a pull request from this branch into `develop`.
+When a release is published, the `reset` job in `.github/workflows/release_dispatch.yml` creates a branch called `post-release-<version>-reset` from `master`, with several changes: updating version strings (bump minor number, add `.dev0` suffix), setting `IDEVELOPMODE = 1`, and archiving/clearing the release notes. The job then creates a PR from this branch into `develop`. Merge (do not squash) the PR.
 
 ### Release downstream repos
 

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -36,6 +36,7 @@ Otherwise the language reflects preliminary/provisional status.
 import argparse
 import json
 import os
+import sys
 import textwrap
 from collections import OrderedDict
 from datetime import datetime
@@ -180,7 +181,7 @@ def get_software_citation(
 
 
 def log_update(path, version: Version):
-    print(f"Updated {path} with version {version}")
+    print(f"Updated {path} with version {version}", file=sys.stderr)
 
 
 def update_version_txt_and_py(version: Version, timestamp: datetime):
@@ -388,6 +389,17 @@ _initial_version = Version("0.0.1")
 _current_version = Version(version_file_path.read_text().strip())
 
 
+def release_version() -> Version:
+    """Current development version, any development segment (e.g. '.dev0') removed."""
+    return Version(_current_version.base_version)
+
+
+def post_release_version() -> Version:
+    """Development version for the next cycle: minor incremented, '.dev0' suffix."""
+    version = Version(_current_version.base_version)
+    return Version(f"{version.major}.{version.minor + 1}.0.dev0")
+
+
 @no_parallel
 @pytest.mark.skip(reason="reverts repo files on cleanup, treat carefully")
 @pytest.mark.parametrize(
@@ -460,11 +472,19 @@ text, text indicating whether the release is provisional or approved, source
 code setting the variable IDEVELOPMODE to either 0 or 1, and other data.
 
 Provide a `--version` string following semantic versioning conventions.
-If --version is not provided, the version number will not be changed,
-just timestamps.
+If none of --version, --release or --post-release is provided, the version
+number will not be changed, just timestamps.
 
-Use `--get` (`-g`) to show the current version without making changes.
-The version number is read from version.txt in the project root.
+Use `--release` (`-r`) to use the current development version with any
+development segment (e.g. '.dev0') removed. Use `--post-release` (`-p`) to
+use the next development version, with the minor version incremented and a
+'.dev0' suffix re-added; this is the version the post-release reset sets on
+the develop branch.
+
+Use `--get` (`-g`) or `--dry-run` to print the resolved version without
+making changes. The resolved version is printed on the last line in every
+mode, so `--post-release` alone both updates the files and reports the new
+version.
 
 Use `--releasemode` to control whether IDEVELOPMODE is set to 0 instead
 of 1, and to alter mf6's output and disclaimer text reflecting approval.
@@ -514,16 +534,44 @@ software DOI is used.
         required=False,
         help="Specify the release version. Value must follow PEP 440.",
     )
+    parser.add_argument(
+        "-r",
+        "--release",
+        required=False,
+        action="store_true",
+        help="Use the current development version with any development segment "
+        "(e.g. '.dev0') removed. Defaults to false.",
+    )
+    parser.add_argument(
+        "-p",
+        "--post-release",
+        required=False,
+        action="store_true",
+        help="Use the next development version, with the minor version "
+        "incremented and a '.dev0' suffix re-added. Defaults to false.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        required=False,
+        action="store_true",
+        help="Print the resolved version and exit without updating anything. "
+        "Defaults to false.",
+    )
 
     args = parser.parse_args()
-    get = args.get
     citation = args.citation
     developmode = not args.releasemode
-    version = Version(args.version) if args.version else _current_version
 
-    if get:
-        print(Version((project_root_path / "version.txt").read_text().strip()))
-    elif citation:
+    if args.post_release:
+        version = post_release_version()
+    elif args.release:
+        version = release_version()
+    elif args.version:
+        version = Version(args.version)
+    else:
+        version = _current_version
+
+    if citation:
         print(
             get_software_citation(
                 timestamp=datetime.now(),
@@ -532,9 +580,12 @@ software DOI is used.
                 developmode=developmode,
             )
         )
+    elif args.get or args.dry_run:
+        print(version)
     else:
         mode = "develop" if developmode else "release"
-        print(f"Updating to version {version} in {mode} mode")
+        print(f"Updating to version {version} in {mode} mode", file=sys.stderr)
         update_version(
             version=version, timestamp=datetime.now(), developmode=developmode
         )
+        print(version)

--- a/doc/ReleaseNotes/mk_releasenotes.py
+++ b/doc/ReleaseNotes/mk_releasenotes.py
@@ -5,14 +5,20 @@ archive section of the release notes document, and has a leading version string
 header (read from the last row of the releases table in ReleaseNotes.tex). The
 default format, for the release notes document section, omits that header and
 uses more widely spaced section headers.
+
+See reset_releasenotes.py for the post-release archive-and-clear step.
 """
 
 import argparse
 import datetime
 import re
-import sys
 from pathlib import Path
 from warnings import warn
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib
 
 notes_dir = Path(__file__).parent
 version_file = Path(__file__).parents[2] / "version.txt"
@@ -36,8 +42,81 @@ def latest_release():
     return rows[-1]
 
 
+def render(
+    toml_path: Path,
+    tex_path: Path,
+    *,
+    template_name: str = "develop.tex.jinja",
+    patch: bool = False,
+    archive: bool = False,
+    version: str = version,
+    date: str = date,
+) -> bool:
+    """Render a release notes TOML file to a LaTeX file.
+
+    Returns True if a file was written, False if there was nothing to render
+    (no TOML file, or no items after any --patch filtering).
+    """
+    if not toml_path.is_file():
+        warn(f"Release notes TOML file not found: {toml_path}")
+        return False
+
+    tex_path.unlink(missing_ok=True)
+
+    from jinja2 import Environment, FileSystemLoader
+
+    with open(toml_path, "rb") as toml_file:
+        content = tomllib.load(toml_file)
+    sections = content.get("sections", {})
+    subsections = content.get("subsections", {})
+    items = content.get("items", [])
+    # if patch, only include fixes
+    if patch:
+        items = [item for item in items if item["section"] == "fixes"]
+        sections = {k: v for k, v in sections.items() if k == "fixes"}
+        subsections = {
+            k: subsections[k] for k in [item["subsection"] for item in items]
+        }
+    # make sure each item has a subsection entry even if empty
+    for item in items:
+        if not item.get("subsection"):
+            item["subsection"] = ""
+    if not any(items):
+        warn("No release notes found, aborting")
+        return False
+
+    loader = FileSystemLoader(notes_dir)
+    env = Environment(
+        loader=loader,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        line_statement_prefix="_",
+        keep_trailing_newline=False,
+        # since latex uses curly brackets,
+        # replace block/var start/end tags
+        block_start_string="([",
+        block_end_string="])",
+        variable_start_string="((",
+        variable_end_string="))",
+    )
+    template = env.get_template(template_name)
+    rendered = template.render(
+        sections=sections,
+        subsections=subsections,
+        items=items,
+        version=version,
+        date=date,
+        archive=archive,
+    )
+    tex_path.write_text(rendered.rstrip() + "\n")
+    return True
+
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--toml", default="develop.toml")
     parser.add_argument("--tex", default="develop.tex")
     parser.add_argument("--patch", default=False, action="store_true")
@@ -65,64 +144,23 @@ if __name__ == "__main__":
         help="Override the date in the --archive header.",
     )
     args = parser.parse_args()
+
     toml_path = Path(args.toml).expanduser().absolute()
     tex_path = Path(args.tex).expanduser().absolute()
-    patch = args.patch
-    archive = args.archive
-    if archive:
+
+    render_version = version
+    render_date = date
+    if args.archive:
         release_version, release_date = latest_release()
-        version = args.version or release_version
-        date = args.date or release_date
-    if not toml_path.is_file():
-        warn(f"Release notes TOML file not found: {toml_path}")
-        sys.exit(0)
+        render_version = args.version or release_version
+        render_date = args.date or release_date
 
-    tex_path.unlink(missing_ok=True)
-
-    import tomli
-    from jinja2 import Environment, FileSystemLoader
-
-    loader = FileSystemLoader(Path(__file__).parent)
-    env = Environment(
-        loader=loader,
-        trim_blocks=True,
-        lstrip_blocks=True,
-        line_statement_prefix="_",
-        keep_trailing_newline=False,
-        # since latex uses curly brackets,
-        # replace block/var start/end tags
-        block_start_string="([",
-        block_end_string="])",
-        variable_start_string="((",
-        variable_end_string="))",
+    render(
+        toml_path,
+        tex_path,
+        template_name=f"{tex_path.name}.jinja",
+        patch=args.patch,
+        archive=args.archive,
+        version=render_version,
+        date=render_date,
     )
-    template = env.get_template(f"{tex_path.name}.jinja")
-    with open(tex_path, "w") as tex_file:
-        with open(toml_path, "rb") as toml_file:
-            content = tomli.load(toml_file)
-            sections = content.get("sections", {})
-            subsections = content.get("subsections", {})
-            items = content.get("items", [])
-            # if patch, only include fixes
-            if patch:
-                items = [item for item in items if item["section"] == "fixes"]
-                sections = {k: v for k, v in sections.items() if k == "fixes"}
-                subsections = {
-                    k: subsections[k] for k in [item["subsection"] for item in items]
-                }
-            # make sure each item has a subsection entry even if empty
-            for item in items:
-                if not item.get("subsection"):
-                    item["subsection"] = ""
-            if not any(items):
-                warn("No release notes found, aborting")
-                sys.exit(0)
-            rendered = template.render(
-                sections=sections,
-                subsections=subsections,
-                items=items,
-                version=version,
-                date=date,
-                archive=archive,
-            )
-            tex_file.write(rendered.rstrip() + "\n")

--- a/doc/ReleaseNotes/mk_releasenotes.py
+++ b/doc/ReleaseNotes/mk_releasenotes.py
@@ -54,8 +54,9 @@ def render(
 ) -> bool:
     """Render a release notes TOML file to a LaTeX file.
 
-    Returns True if a file was written, False if there was nothing to render
-    (no TOML file, or no items after any --patch filtering).
+    Returns True if notes were rendered, False if there was nothing to render
+    (no TOML file, or no items after any --patch filtering). In the latter case
+    an empty LaTeX file is still written so downstream document builds succeed.
     """
     if not toml_path.is_file():
         warn(f"Release notes TOML file not found: {toml_path}")
@@ -83,6 +84,8 @@ def render(
             item["subsection"] = ""
     if not any(items):
         warn("No release notes found, aborting")
+        # still leave an empty file behind
+        tex_path.write_text("")
         return False
 
     loader = FileSystemLoader(notes_dir)

--- a/doc/ReleaseNotes/reset_releasenotes.py
+++ b/doc/ReleaseNotes/reset_releasenotes.py
@@ -1,0 +1,134 @@
+"""Post-release housekeeping for the release notes.
+
+Archives the just-released version's notes to previous/v<version>.tex in the
+compact archive format, registers them in appendixA.tex, and clears the
+archived items from develop.toml so the next development cycle starts empty.
+
+The version is read from version.txt, so run this before bumping the version.
+For a patch release (--patch) only the fix items are archived and cleared; the
+rest carry forward to the next minor release.
+"""
+
+import argparse
+import re
+import sys
+from warnings import warn
+
+from mk_releasenotes import latest_release, notes_dir, render, version
+
+develop_toml_path = notes_dir / "develop.toml"
+appendix_path = notes_dir / "appendixA.tex"
+previous_dir = notes_dir / "previous"
+
+
+def register_archive(version: str):
+    """Add an \\input line for previous/v<version>.tex to appendixA.tex, just
+    above the newest existing entry. No-op if the line is already present."""
+    input_line = f"\\input{{./previous/v{version}.tex}}"
+    lines = appendix_path.read_text().splitlines()
+    if any(input_line in line for line in lines):
+        return
+    for i, line in enumerate(lines):
+        if "\\input{./previous/" in line:
+            indent = line[: len(line) - len(line.lstrip())]
+            lines.insert(i, f"{indent}{input_line}")
+            break
+    else:
+        lines.append(f"        {input_line}")
+    appendix_path.write_text("\n".join(lines) + "\n")
+    print(f"Registered {input_line} in {appendix_path}", file=sys.stderr)
+
+
+def clear_develop_toml(*, patch: bool = False):
+    """Remove release note items from develop.toml for the next cycle.
+
+    The [sections] and [subsections] tables are kept. For a patch release,
+    non-fix items are kept too (they carry forward to the next minor release);
+    otherwise every item is removed.
+    """
+    lines = develop_toml_path.read_text().splitlines()
+    try:
+        first = next(i for i, ln in enumerate(lines) if ln.strip() == "[[items]]")
+    except StopIteration:
+        return  # already empty
+
+    header = lines[:first]
+    while header and not header[-1].strip():
+        header.pop()
+
+    blocks: list[list[str]] = []
+    for ln in lines[first:]:
+        if ln.strip() == "[[items]]":
+            blocks.append([ln])
+        else:
+            blocks[-1].append(ln)
+
+    kept = []
+    if patch:
+        for block in blocks:
+            section = next(
+                (
+                    m.group(1)
+                    for ln in block
+                    if (m := re.match(r'\s*section\s*=\s*"([^"]*)"', ln))
+                ),
+                "",
+            )
+            if section != "fixes":
+                while block and not block[-1].strip():
+                    block.pop()
+                kept.append(block)
+
+    text = "\n".join(header) + "\n"
+    for block in kept:
+        text += "\n" + "\n".join(block) + "\n"
+    develop_toml_path.write_text(text)
+    print(
+        f"Cleared {develop_toml_path}: removed {len(blocks) - len(kept)} item(s), "
+        f"kept {len(kept)}",
+        file=sys.stderr,
+    )
+
+
+def reset_release_notes(*, patch: bool = False):
+    """Archive the just-released version's notes and clear develop.toml."""
+    header_version, header_date = latest_release()
+    if header_version != version:
+        warn(
+            f"version.txt is {version} but the last row of the ReleaseNotes.tex "
+            f"releases table is {header_version}; archiving as {version}. Add the "
+            "release row before releasing (see the release procedure)."
+        )
+
+    if render(
+        develop_toml_path,
+        previous_dir / f"v{version}.tex",
+        patch=patch,
+        archive=True,
+        version=version,
+        date=header_date,
+    ):
+        print(
+            f"Archived release notes to {previous_dir / f'v{version}.tex'}",
+            file=sys.stderr,
+        )
+        register_archive(version)
+    else:
+        warn(f"No {'fix ' if patch else ''}items to archive for v{version}")
+
+    clear_develop_toml(patch=patch)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--patch",
+        default=False,
+        action="store_true",
+        help="Archive and clear only the fix items (patch release).",
+    )
+    args = parser.parse_args()
+    reset_release_notes(patch=args.patch)

--- a/pixi.toml
+++ b/pixi.toml
@@ -113,6 +113,7 @@ update-version = { cmd = "python update_version.py", cwd = "distribution" }
 collect-deprecations = { cmd = "python deprecations.py", cwd = "doc/mf6io/mf6ivar" }
 check-citations = "cffconvert --validate -i CITATION.cff"
 make-release-notes = { cmd = "python mk_releasenotes.py", cwd = "doc/ReleaseNotes" }
+reset-release-notes = { cmd = "python reset_releasenotes.py", cwd = "doc/ReleaseNotes" }
 
 # os-specific default tasks
 [target.linux-64.tasks]


### PR DESCRIPTION
Restore a CI job to automatically open a pull request from `master` into `develop` after a release. (We had this a while ago but it was removed in #1596, I think because we didn't yet have a convention for the `develop` branch version number.) Drop the old manual instructions from the release guide. Tweak `update_version.py`. Add a script and pixi task to reset release notes.